### PR TITLE
fix: prevent Needs Input status getting stuck during active tool

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -123,8 +123,13 @@ impl AppState {
                 session.tool_count += 1;
             }
             EventType::WaitingForInput => {
-                session.status = SessionStatus::WaitingForInput;
-                session.active_tool = None;
+                // Only transition if no tool is actively running.
+                // Permission prompts always arrive before PreToolUse, so a
+                // Notification that arrives while a tool is executing is
+                // informational and must not override the Working status.
+                if session.active_tool.is_none() {
+                    session.status = SessionStatus::WaitingForInput;
+                }
             }
             EventType::Idle => {
                 session.status = SessionStatus::Idle;
@@ -245,6 +250,23 @@ mod tests {
         state.apply_event(make_event("s1", EventType::WaitingForInput));
         assert_eq!(state.sessions["s1"].status, SessionStatus::WaitingForInput);
         assert!(state.sessions["s1"].active_tool.is_none());
+    }
+
+    #[test]
+    fn notification_during_active_tool_stays_working() {
+        let mut state = AppState::default();
+        state.apply_event(make_event("s1", EventType::SessionStart));
+
+        let mut tool_start = make_event("s1", EventType::ToolStart);
+        tool_start.tool_name = Some("Bash".to_string());
+        state.apply_event(tool_start);
+        assert_eq!(state.sessions["s1"].status, SessionStatus::Working);
+
+        // A Notification arriving while the tool is running must NOT
+        // override Working → WaitingForInput (the screenshot bug).
+        state.apply_event(make_event("s1", EventType::WaitingForInput));
+        assert_eq!(state.sessions["s1"].status, SessionStatus::Working);
+        assert!(state.sessions["s1"].active_tool.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **Bug**: Sidebar showed "Needs Input" even after the user provided input and the session was actively working (running tools)
- **Cause**: `Notification` hook events unconditionally overrode `Working` status to `WaitingForInput`, even when a tool was mid-execution
- **Fix**: Only transition to `WaitingForInput` when no tool is active (`active_tool.is_none()`), since permission prompts always fire before `PreToolUse`

## Test plan
- [x] New unit test `notification_during_active_tool_stays_working` verifies the fix
- [x] Existing test `waiting_for_input_status` confirms normal flow still works
- [x] All 112 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where the application would incorrectly change its status when receiving input requests during active tool execution. The session now maintains its working state and preserves the active operation until completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->