### PR TITLE
fix(prd-13): force black background for light terminal compat

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -920,6 +920,12 @@ fn render_frame(
 ) {
     let area = frame.area();
 
+    // Force black background so dark-optimised colors are always readable
+    frame.render_widget(
+        ratatui::widgets::Block::default().style(Style::default().bg(Color::Black)),
+        area,
+    );
+
     if state.sessions.is_empty() {
         let bar_height = if has_pane_control { 2 } else { 1 };
         let vertical = Layout::vertical([


### PR DESCRIPTION
## Summary
- Forces a black background on the dashboard pane so dark-optimized colors remain readable regardless of terminal theme
- Resolves the core readability issue from PRD #13 without losing visual hierarchy
- A follow-up PRD (#27) tracks adding an explicit light theme with white background and adjusted colors

## Test plan
- [ ] Verify dashboard looks unchanged on dark terminal themes
- [ ] Switch terminal to a light theme and confirm the dashboard pane is readable with black background
- [ ] Run `cargo test` — all 126 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Application now displays a black background across the entire frame.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->