### PR TITLE
fix: close agent pane PTY when mode tab is closed

### DIFF
--- a/changelog.d/fix-agent-pane-leak.md
+++ b/changelog.d/fix-agent-pane-leak.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- **Mode tab agent pane leak on close**
+  Closing a mode tab (Ctrl+W) now properly closes the agent pane's embedded PTY. Previously, `close_tab()` only closed persistent and reactive panes via `deactivate_mode()`, leaving the agent pane orphaned in the embedded pane controller. These orphaned panes accumulated on the dashboard's right-side terminal pane list each time a mode tab was closed and reopened.

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -270,10 +270,17 @@ impl TabManager {
         let tab = self.tabs.remove(index);
         let pane_ids = match tab {
             Tab::Mode {
-                mut mode_manager, ..
+                mut mode_manager,
+                agent_pane_id,
+                ..
             } => {
-                let ids = mode_manager.managed_pane_ids();
+                let mut ids = mode_manager.managed_pane_ids();
                 let _ = mode_manager.deactivate_mode();
+                // Close the agent pane PTY so it doesn't linger on the dashboard.
+                let _ = self.pane_controller.close_pane(&agent_pane_id);
+                if !agent_pane_id.is_empty() {
+                    ids.push(agent_pane_id);
+                }
                 ids
             }
             Tab::Orchestration { role_pane_ids, .. } => {
@@ -596,18 +603,45 @@ mod tests {
     fn close_mode_tab() {
         let mock = Arc::new(MockPaneController::new());
         let mut tm = TabManager::new(mock.clone());
-        let (_, ids) = tm
-            .open_mode_tab(&test_config("k8s"), "/tmp", String::new())
+        let agent_id = mock.create_pane(None, None).unwrap();
+        let (_, side_ids) = tm
+            .open_mode_tab(&test_config("k8s"), "/tmp", agent_id.clone())
             .unwrap();
         assert_eq!(tm.tab_count(), 2);
 
         let closed_ids = tm.close_tab(1).unwrap();
-        assert_eq!(closed_ids, ids);
+        // Should include both side pane IDs AND the agent pane ID.
+        assert!(closed_ids.contains(&agent_id));
+        for id in &side_ids {
+            assert!(closed_ids.contains(id));
+        }
         assert_eq!(tm.tab_count(), 1);
         assert_eq!(tm.active_index(), 0);
-        // Verify panes were closed via the mock.
+        // Verify the agent pane was closed via the mock.
         let closed = mock.closed.lock().unwrap();
-        assert!(!closed.is_empty());
+        assert!(closed.contains(&agent_id));
+    }
+
+    #[test]
+    fn close_all_mode_tabs_closes_agent_panes() {
+        let mock = Arc::new(MockPaneController::new());
+        let mut tm = TabManager::new(mock.clone());
+        let agent1 = mock.create_pane(None, None).unwrap();
+        let agent2 = mock.create_pane(None, None).unwrap();
+        tm.open_mode_tab(&test_config("a"), "/tmp/a", agent1.clone())
+            .unwrap();
+        tm.open_mode_tab(&test_config("b"), "/tmp/b", agent2.clone())
+            .unwrap();
+
+        // Simulate exit cleanup: close tabs in reverse order.
+        for i in (1..tm.tab_count()).rev() {
+            let _ = tm.close_tab(i).unwrap();
+        }
+
+        let closed = mock.closed.lock().unwrap();
+        assert!(closed.contains(&agent1));
+        assert!(closed.contains(&agent2));
+        assert_eq!(tm.tab_count(), 1);
     }
 
     #[test]

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -277,8 +277,8 @@ impl TabManager {
                 let mut ids = mode_manager.managed_pane_ids();
                 let _ = mode_manager.deactivate_mode();
                 // Close the agent pane PTY so it doesn't linger on the dashboard.
-                let _ = self.pane_controller.close_pane(&agent_pane_id);
                 if !agent_pane_id.is_empty() {
+                    let _ = self.pane_controller.close_pane(&agent_pane_id);
                     ids.push(agent_pane_id);
                 }
                 ids


### PR DESCRIPTION
## Summary

- Fix orphaned agent panes accumulating on the dashboard when mode tabs are closed
- `TabManager::close_tab()` now closes the agent pane's embedded PTY and includes its ID in the returned Vec

## Problem

When closing a mode tab (Ctrl+W), `close_tab()` called `deactivate_mode()` which properly closed persistent and reactive panes, but **never closed the agent pane's embedded PTY**. The orphaned pane remained in `EmbeddedPaneController.panes` and appeared on the dashboard's right-side terminal pane list because it wasn't in any tab's `managed_pane_ids()`.

This affected two code paths:
1. **Ctrl+W close** — state was cleaned up but the PTY survived
2. **Exit cleanup** — agent pane ID not returned by `close_tab`, so never unregistered

## Changes

**`src/tab.rs`** — `close_tab()` `Tab::Mode` arm now:
1. Destructures `agent_pane_id` (was previously ignored via `..`)
2. Calls `self.pane_controller.close_pane(&agent_pane_id)` to kill the PTY
3. Includes `agent_pane_id` in the returned Vec so callers unregister it

**Tests updated:**
- `close_mode_tab` — now uses a real agent pane ID and verifies it's closed
- `close_all_mode_tabs_closes_agent_panes` — new test simulating exit cleanup

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All 382 unit tests pass
- [x] All 7 integration tests pass
- [x] All 11 mode integration tests pass
- [ ] Manual: open a mode tab, close with Ctrl+W, verify agent pane disappears from dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed an issue where closing a mode tab (Ctrl+W) failed to properly clean up the associated agent pane and its embedded terminal. Previously, these orphaned panes would accumulate in the dashboard's terminal pane list each time mode tabs were reopened, cluttering the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->