### PR TITLE
fix: update dependencies to resolve cargo audit vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1441,7 +1441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1577,7 +1577,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1626,18 +1626,18 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -1910,9 +1910,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

- Update `rustls-webpki` 0.103.10 → 0.103.13 to fix 3 vulnerabilities
- Update `rand` 0.8.5 → 0.8.6 and 0.9.2 → 0.9.4 to fix unsoundness issue

## Vulnerabilities Fixed

| Crate | Advisory | Title |
|-------|----------|-------|
| rustls-webpki | RUSTSEC-2026-0104 | Reachable panic in certificate revocation list parsing |
| rustls-webpki | RUSTSEC-2026-0098 | Name constraints for URI names were incorrectly accepted |
| rustls-webpki | RUSTSEC-2026-0099 | Name constraints were accepted for certificates asserting a wildcard name |
| rand | RUSTSEC-2026-0097 | Rand is unsound with a custom logger using `rand::rng()` |

## Remaining Warning

The `serial` crate (RUSTSEC-2017-0008, unmaintained) is a transitive dependency from `portable-pty` and cannot be resolved without replacing the upstream crate.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] All tests pass
- [x] `cargo audit` shows no vulnerabilities (only the `serial` unmaintained warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)