### PR TITLE
feat: add clickable hyperlinks via OSC 8 support

### DIFF
--- a/src/embedded_pane.rs
+++ b/src/embedded_pane.rs
@@ -7,6 +7,7 @@ use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 
 use std::any::Any;
 
+use crate::hyperlink::{HyperlinkMap, Osc8Filter, Osc8Segment};
 use crate::pane::{PaneController, PaneDirection, PaneError, PaneInfo};
 
 /// State for a single embedded terminal pane.
@@ -27,6 +28,8 @@ struct Pane {
     command: Option<String>,
     /// Whether the child app has enabled mouse reporting (e.g., TUI apps like opencode).
     mouse_mode: Arc<AtomicBool>,
+    /// Hyperlink URLs extracted from OSC 8 escape sequences, keyed by screen row.
+    hyperlinks: Arc<Mutex<HyperlinkMap>>,
 }
 
 /// Thread-safe pane registry.
@@ -59,6 +62,12 @@ impl EmbeddedPaneController {
     pub fn get_screen(&self, pane_id: &str) -> Option<Arc<Mutex<vt100::Parser>>> {
         let panes = self.panes.lock().unwrap();
         panes.get(pane_id).map(|p| Arc::clone(&p.screen))
+    }
+
+    /// Access the hyperlink map for a pane (used for click-to-open).
+    pub fn get_hyperlinks(&self, pane_id: &str) -> Option<Arc<Mutex<HyperlinkMap>>> {
+        let panes = self.panes.lock().unwrap();
+        panes.get(pane_id).map(|p| Arc::clone(&p.hyperlinks))
     }
 
     /// Return all pane IDs in insertion order (by numeric ID).
@@ -278,22 +287,68 @@ impl PaneController for EmbeddedPaneController {
 
         let parser = Arc::new(Mutex::new(vt100::Parser::new(24, 80, 10_000)));
         let mouse_mode = Arc::new(AtomicBool::new(false));
+        let hyperlinks = Arc::new(Mutex::new(HyperlinkMap::new()));
 
         // Spawn a background thread to read PTY output and feed it to the vt100 parser.
-        // Also scan for mouse-enable/disable escape sequences to track mouse mode.
+        // Strips OSC 8 hyperlink sequences and records row → URL associations.
         let parser_clone = Arc::clone(&parser);
         let mouse_mode_clone = Arc::clone(&mouse_mode);
+        let hyperlinks_clone = Arc::clone(&hyperlinks);
         std::thread::spawn(move || {
             let mut buf = [0u8; 4096];
+            let mut osc8 = Osc8Filter::new();
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) => break,
                     Ok(n) => {
                         let data = &buf[..n];
-                        // Scan for mouse mode enable/disable sequences.
                         scan_mouse_mode(data, &mouse_mode_clone);
+
+                        let segments = osc8.process(data);
+                        let mut new_links: Vec<(u16, String)> = Vec::new();
+                        let mut scroll_amount: u16 = 0;
+
                         if let Ok(mut p) = parser_clone.lock() {
-                            p.process(data);
+                            let max_row = p.screen().size().0.saturating_sub(1);
+                            for segment in &segments {
+                                match segment {
+                                    Osc8Segment::Text(bytes) => {
+                                        let rb = p.screen().cursor_position().0;
+                                        p.process(bytes);
+                                        let ra = p.screen().cursor_position().0;
+                                        if rb >= max_row && ra >= max_row {
+                                            let nl = bytes.iter().filter(|&&b| b == b'\n').count()
+                                                as u16;
+                                            scroll_amount += nl;
+                                        }
+                                    }
+                                    Osc8Segment::LinkedText { url, bytes } => {
+                                        // cursor_before is the row where link text starts
+                                        let row = p.screen().cursor_position().0;
+                                        let rb = row;
+                                        p.process(bytes);
+                                        let ra = p.screen().cursor_position().0;
+                                        new_links.push((row, url.clone()));
+                                        if rb >= max_row && ra >= max_row {
+                                            let nl = bytes.iter().filter(|&&b| b == b'\n').count()
+                                                as u16;
+                                            scroll_amount += nl;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        // parser lock released
+
+                        if (!new_links.is_empty() || scroll_amount > 0)
+                            && let Ok(mut hmap) = hyperlinks_clone.lock()
+                        {
+                            if scroll_amount > 0 {
+                                hmap.shift_up(scroll_amount);
+                            }
+                            for (row, url) in &new_links {
+                                hmap.set_row(*row, url);
+                            }
                         }
                     }
                     Err(_) => break,
@@ -310,6 +365,7 @@ impl PaneController for EmbeddedPaneController {
             is_focused: false,
             command: command.map(|c| c.to_string()),
             mouse_mode,
+            hyperlinks,
         };
 
         self.panes.lock().unwrap().insert(pane_id.clone(), pane);

--- a/src/hyperlink.rs
+++ b/src/hyperlink.rs
@@ -1,0 +1,428 @@
+//! OSC 8 hyperlink parsing and row-based URL tracking.
+//!
+//! Terminal applications emit OSC 8 escape sequences to create clickable
+//! hyperlinks.  The vt100 crate does not support OSC 8, so this module
+//! intercepts the raw PTY byte stream, strips OSC 8 sequences, and records
+//! which screen rows have hyperlink URLs.
+
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Osc8Filter — strips OSC 8 sequences from a byte stream
+// ---------------------------------------------------------------------------
+
+/// A segment produced by [`Osc8Filter::process`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum Osc8Segment {
+    /// Plain bytes (no active hyperlink). Feed directly to vt100.
+    Text(Vec<u8>),
+    /// Bytes that are part of an active hyperlink. Feed to vt100 and
+    /// record the cursor row → URL association.
+    LinkedText { url: String, bytes: Vec<u8> },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum FilterState {
+    Normal,
+    Esc,
+    OscDigits,
+    Osc8Params,
+    Osc8Uri,
+    Osc8UriEsc,
+    OscOther,
+    OscOtherEsc,
+}
+
+/// State machine that strips OSC 8 hyperlink escape sequences from a byte
+/// stream and emits [`Osc8Segment`]s.
+///
+/// Maintains state across calls so it correctly handles sequences that span
+/// multiple read chunks.
+#[derive(Debug)]
+pub struct Osc8Filter {
+    state: FilterState,
+    current_url: Option<String>,
+    text_buf: Vec<u8>,
+    osc_num: Vec<u8>,
+    osc_params: Vec<u8>,
+    osc_uri: Vec<u8>,
+    osc_other_buf: Vec<u8>,
+}
+
+impl Default for Osc8Filter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Osc8Filter {
+    pub fn new() -> Self {
+        Self {
+            state: FilterState::Normal,
+            current_url: None,
+            text_buf: Vec::new(),
+            osc_num: Vec::new(),
+            osc_params: Vec::new(),
+            osc_uri: Vec::new(),
+            osc_other_buf: Vec::new(),
+        }
+    }
+
+    pub fn process(&mut self, input: &[u8]) -> Vec<Osc8Segment> {
+        let mut segments = Vec::new();
+
+        for &byte in input {
+            match self.state {
+                FilterState::Normal => {
+                    if byte == 0x1b {
+                        self.state = FilterState::Esc;
+                    } else {
+                        self.text_buf.push(byte);
+                    }
+                }
+                FilterState::Esc => {
+                    if byte == b']' {
+                        self.osc_num.clear();
+                        self.state = FilterState::OscDigits;
+                    } else {
+                        self.text_buf.push(0x1b);
+                        self.text_buf.push(byte);
+                        self.state = FilterState::Normal;
+                    }
+                }
+                FilterState::OscDigits => {
+                    if byte.is_ascii_digit() {
+                        self.osc_num.push(byte);
+                    } else if byte == b';' && self.osc_num == b"8" {
+                        self.flush_text(&mut segments);
+                        self.osc_params.clear();
+                        self.state = FilterState::Osc8Params;
+                    } else {
+                        self.osc_other_buf.clear();
+                        self.osc_other_buf.push(0x1b);
+                        self.osc_other_buf.push(b']');
+                        self.osc_other_buf.extend_from_slice(&self.osc_num);
+                        self.osc_other_buf.push(byte);
+                        self.osc_num.clear();
+                        if byte == 0x07 {
+                            self.text_buf
+                                .extend_from_slice(&std::mem::take(&mut self.osc_other_buf));
+                            self.state = FilterState::Normal;
+                        } else {
+                            self.state = FilterState::OscOther;
+                        }
+                    }
+                }
+                FilterState::Osc8Params => {
+                    if byte == b';' {
+                        self.osc_uri.clear();
+                        self.state = FilterState::Osc8Uri;
+                    } else if byte == 0x07 {
+                        self.complete_osc8();
+                    } else if byte == 0x1b {
+                        self.state = FilterState::Osc8UriEsc;
+                    } else {
+                        self.osc_params.push(byte);
+                    }
+                }
+                FilterState::Osc8Uri => {
+                    if byte == 0x07 {
+                        self.complete_osc8();
+                    } else if byte == 0x1b {
+                        self.state = FilterState::Osc8UriEsc;
+                    } else {
+                        self.osc_uri.push(byte);
+                    }
+                }
+                FilterState::Osc8UriEsc => {
+                    if byte == b'\\' {
+                        self.complete_osc8();
+                    } else {
+                        self.osc_uri.push(0x1b);
+                        self.osc_uri.push(byte);
+                        self.state = FilterState::Osc8Uri;
+                    }
+                }
+                FilterState::OscOther => {
+                    if byte == 0x07 {
+                        self.osc_other_buf.push(byte);
+                        self.text_buf
+                            .extend_from_slice(&std::mem::take(&mut self.osc_other_buf));
+                        self.state = FilterState::Normal;
+                    } else if byte == 0x1b {
+                        self.state = FilterState::OscOtherEsc;
+                    } else {
+                        self.osc_other_buf.push(byte);
+                    }
+                }
+                FilterState::OscOtherEsc => {
+                    if byte == b'\\' {
+                        self.osc_other_buf.push(0x1b);
+                        self.osc_other_buf.push(b'\\');
+                        self.text_buf
+                            .extend_from_slice(&std::mem::take(&mut self.osc_other_buf));
+                        self.state = FilterState::Normal;
+                    } else {
+                        self.osc_other_buf.push(0x1b);
+                        self.osc_other_buf.push(byte);
+                        self.state = FilterState::OscOther;
+                    }
+                }
+            }
+        }
+
+        self.flush_text(&mut segments);
+        segments
+    }
+
+    fn flush_text(&mut self, segments: &mut Vec<Osc8Segment>) {
+        if self.text_buf.is_empty() {
+            return;
+        }
+        let bytes = std::mem::take(&mut self.text_buf);
+        match &self.current_url {
+            Some(url) => segments.push(Osc8Segment::LinkedText {
+                url: url.clone(),
+                bytes,
+            }),
+            None => segments.push(Osc8Segment::Text(bytes)),
+        }
+    }
+
+    fn complete_osc8(&mut self) {
+        let uri = std::mem::take(&mut self.osc_uri);
+        self.osc_params.clear();
+        if uri.is_empty() {
+            self.current_url = None;
+        } else if let Ok(url) = String::from_utf8(uri) {
+            self.current_url = Some(url);
+        }
+        self.state = FilterState::Normal;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HyperlinkMap — maps screen rows to URLs
+// ---------------------------------------------------------------------------
+
+/// Maps terminal screen rows to hyperlink URLs.
+///
+/// Stores `row → URL`. On click, look up the clicked row.
+/// When the terminal scrolls, call [`shift_up`] to adjust entries.
+#[derive(Debug, Default)]
+pub struct HyperlinkMap {
+    rows: HashMap<u16, String>,
+}
+
+impl HyperlinkMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a hyperlink URL for the given screen row.
+    pub fn set_row(&mut self, row: u16, url: &str) {
+        self.rows.insert(row, url.to_string());
+    }
+
+    /// Look up the URL for a row, if any.
+    pub fn get_row(&self, row: u16) -> Option<&str> {
+        self.rows.get(&row).map(|s| s.as_str())
+    }
+
+    /// Shift all entries up by `n` rows (called when the terminal scrolls).
+    pub fn shift_up(&mut self, n: u16) {
+        let mut updated = HashMap::with_capacity(self.rows.len());
+        for (row, url) in self.rows.drain() {
+            if row >= n {
+                updated.insert(row - n, url);
+            }
+        }
+        self.rows = updated;
+    }
+
+    /// Remove all entries.
+    pub fn clear(&mut self) {
+        self.rows.clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Osc8Filter tests --
+
+    #[test]
+    fn plain_text_passes_through() {
+        let mut f = Osc8Filter::new();
+        let segs = f.process(b"Hello, world!");
+        assert_eq!(segs, vec![Osc8Segment::Text(b"Hello, world!".to_vec())]);
+    }
+
+    #[test]
+    fn single_link_bel() {
+        let mut f = Osc8Filter::new();
+        let segs = f.process(b"\x1b]8;;https://example.com\x07Click\x1b]8;;\x07");
+        assert_eq!(
+            segs,
+            vec![Osc8Segment::LinkedText {
+                url: "https://example.com".into(),
+                bytes: b"Click".to_vec(),
+            }]
+        );
+    }
+
+    #[test]
+    fn single_link_st() {
+        let mut f = Osc8Filter::new();
+        let segs = f.process(b"\x1b]8;;https://x.com\x1b\\Click\x1b]8;;\x1b\\");
+        assert_eq!(
+            segs,
+            vec![Osc8Segment::LinkedText {
+                url: "https://x.com".into(),
+                bytes: b"Click".to_vec(),
+            }]
+        );
+    }
+
+    #[test]
+    fn link_with_id_param() {
+        let mut f = Osc8Filter::new();
+        let segs = f.process(b"\x1b]8;id=foo;https://example.com\x07text\x1b]8;;\x07");
+        assert_eq!(
+            segs,
+            vec![Osc8Segment::LinkedText {
+                url: "https://example.com".into(),
+                bytes: b"text".to_vec(),
+            }]
+        );
+    }
+
+    #[test]
+    fn link_with_surrounding_text() {
+        let mut f = Osc8Filter::new();
+        let segs = f.process(b"before \x1b]8;;http://u\x07link\x1b]8;;\x07 after");
+        assert_eq!(
+            segs,
+            vec![
+                Osc8Segment::Text(b"before ".to_vec()),
+                Osc8Segment::LinkedText {
+                    url: "http://u".into(),
+                    bytes: b"link".to_vec(),
+                },
+                Osc8Segment::Text(b" after".to_vec()),
+            ]
+        );
+    }
+
+    #[test]
+    fn ansi_inside_link() {
+        let mut f = Osc8Filter::new();
+        let segs =
+            f.process(b"\x1b]8;;http://u\x07\x1b[34m\x1b[1mblue bold\x1b[22m\x1b[39m\x1b]8;;\x07");
+        assert_eq!(
+            segs,
+            vec![Osc8Segment::LinkedText {
+                url: "http://u".into(),
+                bytes: b"\x1b[34m\x1b[1mblue bold\x1b[22m\x1b[39m".to_vec(),
+            }]
+        );
+    }
+
+    #[test]
+    fn non_osc8_passes_through() {
+        let mut f = Osc8Filter::new();
+        let segs = f.process(b"\x1b]0;title\x07hello");
+        assert_eq!(
+            segs,
+            vec![Osc8Segment::Text(b"\x1b]0;title\x07hello".to_vec())]
+        );
+    }
+
+    #[test]
+    fn split_across_chunks() {
+        let mut f = Osc8Filter::new();
+        let s1 = f.process(b"\x1b]8;;https://exam");
+        assert_eq!(s1, vec![]);
+        let s2 = f.process(b"ple.com\x07link\x1b]8;;\x07");
+        assert_eq!(
+            s2,
+            vec![Osc8Segment::LinkedText {
+                url: "https://example.com".into(),
+                bytes: b"link".to_vec(),
+            }]
+        );
+    }
+
+    #[test]
+    fn regular_csi_passes_through() {
+        let mut f = Osc8Filter::new();
+        let segs = f.process(b"\x1b[31mred\x1b[0m");
+        assert_eq!(
+            segs,
+            vec![Osc8Segment::Text(b"\x1b[31mred\x1b[0m".to_vec())]
+        );
+    }
+
+    // -- HyperlinkMap tests --
+
+    #[test]
+    fn row_set_get() {
+        let mut m = HyperlinkMap::new();
+        m.set_row(5, "http://a");
+        assert_eq!(m.get_row(5), Some("http://a"));
+        assert_eq!(m.get_row(6), None);
+    }
+
+    #[test]
+    fn row_shift_up() {
+        let mut m = HyperlinkMap::new();
+        m.set_row(0, "http://gone");
+        m.set_row(3, "http://kept");
+        m.shift_up(2);
+        assert_eq!(m.get_row(0), None);
+        assert_eq!(m.get_row(1), Some("http://kept"));
+    }
+
+    #[test]
+    fn row_clear() {
+        let mut m = HyperlinkMap::new();
+        m.set_row(0, "http://a");
+        m.clear();
+        assert_eq!(m.get_row(0), None);
+    }
+
+    // -- Full pipeline integration test --
+
+    #[test]
+    fn full_pipeline() {
+        let mut filter = Osc8Filter::new();
+        let mut parser = vt100::Parser::new(24, 80, 0);
+        let mut hmap = HyperlinkMap::new();
+
+        let pty = b"Hello \x1b]8;;https://example.com\x07Click here\x1b]8;;\x07 world\r\n";
+        let segments = filter.process(pty);
+
+        for segment in &segments {
+            match segment {
+                Osc8Segment::Text(bytes) => {
+                    parser.process(bytes);
+                }
+                Osc8Segment::LinkedText { url, bytes } => {
+                    let row = parser.screen().cursor_position().0;
+                    parser.process(bytes);
+                    hmap.set_row(row, url);
+                }
+            }
+        }
+
+        let contents = parser.screen().contents();
+        assert!(contents.contains("Hello Click here world"));
+        assert_eq!(hmap.get_row(0), Some("https://example.com"));
+        assert_eq!(hmap.get_row(1), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod error;
 pub mod event;
 pub mod hook;
 pub mod hooks_manage;
+pub mod hyperlink;
 pub mod init;
 pub mod llm;
 pub mod mode_manager;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1194,11 +1194,14 @@ fn keyevent_to_bytes(key: &KeyEvent) -> Option<Vec<u8>> {
 }
 
 /// Compute the row offset between widget-relative coordinates and vt100 screen
-/// coordinates. The widget shows the bottom `inner_h` rows of the screen.
+/// coordinates. Must match the viewport calculation in `terminal_widget.rs`.
 fn screen_row_offset(screen: &vt100::Screen, pane_rect: Rect) -> u16 {
-    let inner_h = pane_rect.height.saturating_sub(2);
-    let screen_rows = screen.size().0;
-    screen_rows.saturating_sub(inner_h)
+    let inner_h = pane_rect.height.saturating_sub(2) as usize;
+    let screen_rows = screen.size().0 as usize;
+    let cursor_row = screen.cursor_position().0 as usize;
+    let anchor = (cursor_row + 1).min(screen_rows);
+    let effective_rows = anchor.max(inner_h);
+    effective_rows.saturating_sub(inner_h) as u16
 }
 
 /// Extract text from a vt100 screen for the given selection region.
@@ -2428,7 +2431,49 @@ pub fn run_tui(
                         crossterm::event::MouseEventKind::Down(
                             crossterm::event::MouseButton::Left,
                         ) => {
-                            if let Some(rect) = ui.focused_pane_rect {
+                            // Ctrl+click opens hyperlinks.
+                            let has_modifier = mouse
+                                .modifiers
+                                .contains(crossterm::event::KeyModifiers::CONTROL);
+                            if has_modifier {
+                                if let Some(rect) = ui.focused_pane_rect {
+                                    let inner_x = rect.x + 1;
+                                    let inner_y = rect.y + 1;
+                                    let inner_w = rect.width.saturating_sub(2);
+                                    let inner_h = rect.height.saturating_sub(2);
+                                    if mouse.column >= inner_x
+                                        && mouse.column < inner_x + inner_w
+                                        && mouse.row >= inner_y
+                                        && mouse.row < inner_y + inner_h
+                                    {
+                                        let row = mouse.row - inner_y;
+                                        if let Some(hmap_arc) = embedded.get_hyperlinks(&pane_id)
+                                            && let Ok(hmap) = hmap_arc.lock()
+                                            && let Some(screen_arc) = embedded.get_screen(&pane_id)
+                                            && let Ok(parser) = screen_arc.lock()
+                                        {
+                                            let offset = screen_row_offset(parser.screen(), rect);
+                                            let screen_row = row + offset;
+                                            if let Some(url) = hmap.get_row(screen_row) {
+                                                let url = url.to_string();
+                                                drop(parser);
+                                                drop(hmap);
+                                                if open::that(&url).is_ok() {
+                                                    let display = if url.len() > 60 {
+                                                        format!("{}...", &url[..57])
+                                                    } else {
+                                                        url
+                                                    };
+                                                    ui.status_message = Some((
+                                                        format!("Opened: {display}"),
+                                                        std::time::Instant::now(),
+                                                    ));
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            } else if let Some(rect) = ui.focused_pane_rect {
                                 let inner_x = rect.x + 1;
                                 let inner_y = rect.y + 1;
                                 let inner_w = rect.width.saturating_sub(2);
@@ -4431,6 +4476,7 @@ fn render_help_overlay(frame: &mut Frame, active_mode_name: Option<&str>, palett
         Line::from("  Enter           Enter PaneInput on selected"),
         Line::from("  Esc             Deselect side pane"),
         Line::from("  Mouse click     Focus pane"),
+        Line::from("  Ctrl+click      Open hyperlink"),
         Line::from(format!("  {MOD_KEY}+d            Return to Normal mode")),
         Line::from(""),
         Line::styled("  New Agent Form", cyan),


### PR DESCRIPTION
## Summary

- Strip OSC 8 hyperlink escape sequences from embedded PTY output and track row-to-URL associations
- Open hyperlinks in the default browser on Ctrl+click
- Add help screen entry for the new keybinding

## How it works

Tools like Claude Code emit [OSC 8 hyperlink sequences](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) to make text clickable. The vt100 crate doesn't support OSC 8, so:

1. **`src/hyperlink.rs`** — `Osc8Filter` state machine strips OSC 8 from the PTY byte stream (handles BEL/ST terminators, params, cross-chunk splits). `HyperlinkMap` stores row → URL associations.
2. **`src/embedded_pane.rs`** — Wires the filter into the PTY reader thread. Before processing each `LinkedText` segment, records `cursor_row → URL`.
3. **`src/ui.rs`** — On Ctrl+click, looks up the clicked row in the hyperlink map and opens the URL via `open::that()`. Shows "Opened: ..." in the status bar.

No changes to `terminal_widget.rs` — link text is already styled (bold+blue) by ANSI codes from the source app.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] All 395 unit tests pass
- [x] All integration tests pass
- [x] Manual test: Ctrl+click on Claude Code hyperlinks opens URL in browser
- [ ] Verify Ctrl+click on file path links (e.g., `src/ui.rs`) opens correctly
- [ ] Verify non-link rows don't trigger on Ctrl+click

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hyperlink extraction and recognition in embedded terminal panes.
  * Implemented Ctrl+click functionality to open hyperlinks in terminal output.
  * Updated help documentation to document the hyperlink opening shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->