### PR TITLE
feat(config-gen): single-step generation, reliable prompt submit, release role

### DIFF
--- a/.dot-agent-deck.toml
+++ b/.dot-agent-deck.toml
@@ -4,15 +4,15 @@ init_command = "devbox shell"
 reactive_panes = 2
 
 [[modes.panes]]
-command = "git diff --stat HEAD"
-name = "Git Diff"
+command = "git status -s"
+name = "Git Status"
 
 [[modes.rules]]
-pattern = "cargo (test|clippy)"
+pattern = "cargo (test|clippy|check|fmt --check|build|audit)"
 watch = false
 
 [[modes.rules]]
-pattern = "git (log|status|show)"
+pattern = "git (log|status|show|diff)"
 watch = false
 
 [[orchestrations]]
@@ -23,42 +23,47 @@ name = "orchestrator"
 command = "devbox run agent-big"
 start = true
 prompt_template = """
-You coordinate the team. You NEVER do work yourself — only delegate to available agents.
+You coordinate the team. You NEVER do implementation, review, or audit work yourself — only delegate to available agents.
 
-Only do enough analysis to understand what needs to be done and provide clear context to \
-the agents who will do the work. Do not deep-dive into source code or implementation details — \
-that is the workers' job.
+You MAY run lightweight coordination slash commands directly (without delegating) when useful: /prd-next to pick the next task, /prd-update-progress to refresh PRD state. Anything that touches source code, runs tests, or reviews/audits a diff must be delegated.
 
-When the user's request relates to a PRD, read only the PRD file from the prds/ directory \
-to understand what needs to be done. Include the PRD file path in your delegation tasks \
-so agents can read it themselves.
+When the user's request relates to a PRD, read only the PRD file from the prds/ directory to understand scope. Do not deep-dive into source code — that is the workers' job.
 
-After the coder finishes, delegate to both the reviewer and auditor in parallel.
+Workflow:
+- Delegate implementation to coder.
+- After coder finishes, delegate to reviewer and auditor in parallel.
+- Resolve any blocking findings (re-delegate to coder) before moving on.
+- Before delegating to release, summarize what to test end-to-end and STOP until the user confirms it works.
+- Then delegate the release flow to release.
 
-After reviewer and auditor both complete with no critical issues, delegate to release to finalize.
+Context handoff (CRITICAL): every worker cold-starts with NO memory of prior conversation, no access to other workers' outputs, and no shared scratchpad. Whatever you write in --task is the entire context the worker has. Therefore:
+- Always include the file paths the worker should read (the PRD path under prds/, the files being modified, etc.).
+- When chaining workers (coder → reviewer/auditor), summarize the prior worker's relevant findings or list the files they changed.
+- When retrying after a failure, paste the exact error message into --task.
+- If context is long, write it to .dot-agent-deck/<task-slug>.md and reference that path in --task instead of pasting inline.
 """
 
 [[orchestrations.roles]]
 name = "coder"
-command = "devbox run oc-coder"
-description = "Implements code changes, fixes bugs, writes features"
-prompt_template = "You are a coding agent. When the task references a PRD file, read it first to understand the full requirements. Implement with clean, minimal code. Run tests before finishing."
+command = "devbox run agent-plan"
+description = "Implements features, fixes bugs, refactors code"
+prompt_template = "Implement the requested change. If the task references a PRD path under prds/, read it first. Before reporting completion, run cargo fmt, cargo clippy -- -D warnings, and cargo test — all must pass. If critical context is missing from the task description, surface it in your work-done summary rather than guessing — the orchestrator will re-delegate with the missing context."
 
 [[orchestrations.roles]]
 name = "reviewer"
 command = "devbox run oc-reviewer"
-description = "Reviews code for correctness, style, and potential issues"
-prompt_template = "Report findings but do not make changes yourself. When the task references a PRD file, read it to verify the implementation matches the documented requirements and acceptance criteria."
+description = "Reviews code changes for correctness, style, and edge cases"
+prompt_template = "Review the change. Report findings only — do not modify code. Focus on correctness, consistency with the rest of the codebase, edge cases, and missed requirements. If the task references a PRD path, verify the implementation matches it. If critical context is missing (e.g. the diff or PRD path), surface it in your work-done summary rather than guessing — the orchestrator will re-delegate with the missing context."
 
 [[orchestrations.roles]]
 name = "auditor"
 command = "devbox run oc-auditor"
-description = "Audits for security vulnerabilities, unsafe code, and OWASP top 10 issues"
-prompt_template = "Audit for security vulnerabilities, unsafe code, and OWASP top 10 issues. When the task references a PRD file, read it to understand the security context and any security-related requirements."
+description = "Audits code for security vulnerabilities and unsafe patterns"
+prompt_template = "Audit the change for security vulnerabilities, unsafe patterns, and OWASP top-10 class issues. Report findings only — do not modify code. If the task references a file or diff, read it before starting. If critical context is missing, surface it in your work-done summary rather than guessing — the orchestrator will re-delegate with the missing context."
 
 [[orchestrations.roles]]
 name = "release"
 command = "devbox run agent-small"
 clear = false
-description = "Runs the release process after all implementation work is reviewed and approved: /prd-done to create PR, merge, and close issue. Delegate here when coder/reviewer/auditor work is complete."
-prompt_template = "You are a release agent. Run /prd-done to complete the PRD workflow (create branch, push, create PR, merge, close issue). Do NOT modify code or fix issues yourself. If any step fails (e.g., failing CI checks, merge conflicts, or reviewer-requested changes), stop and report the issue clearly so the orchestrator can delegate fixes to the coder."
+description = "Runs the project's release flow (/prd-done) after coder/reviewer/auditor work is complete and the user has validated end-to-end behavior. Never modifies source code."
+prompt_template = "Your job is to run /prd-done to complete the PRD workflow (create branch, push, create PR, merge, close issue). Do NOT modify source code. If any step fails (failing CI, merge conflicts, requested changes), report the exact error and stop — do not attempt to diagnose or fix. The orchestrator will re-delegate to coder."

--- a/assets/config_gen_prompt.md
+++ b/assets/config_gen_prompt.md
@@ -1,0 +1,222 @@
+Analyze this project and create a `.dot-agent-deck.toml` configuration file in the project root.
+
+## What is .dot-agent-deck.toml?
+
+This file configures "workspace modes" for the dot-agent-deck TUI dashboard. Each mode defines a tab-based workspace that pairs you (the AI agent) with live command output in side panes. When a user activates a mode, a new tab opens with the agent on the left and side panes stacked on the right.
+
+## Config Format
+
+The file is TOML. You can define one or more modes. Each mode has a name, optional persistent panes, and optional reactive rules.
+
+```toml
+[[modes]]
+name = "mode-name"   # Display name shown in the tab bar
+init_command = "devbox shell"  # Optional: runs once in every pane before its command
+reactive_panes = 2             # Optional: number of reactive pane slots (default: 2)
+
+# Persistent panes: run when the mode activates, stay alive for the tab lifetime.
+# By default, commands are re-executed every 10 seconds automatically (watch = true).
+# Set watch = false for commands that stream/follow on their own (e.g., --watch, -f, tail -f).
+[[modes.panes]]
+command = "some-command"           # Shell command to run (plain, no watch/follow flags needed)
+name = "Display Name"              # Optional label (defaults to command)
+# watch = true                     # Default: system re-runs command every 10s automatically
+                                   # Set to false for commands with built-in streaming
+
+# Reactive rules: regex patterns matched against your bash commands.
+# When you execute a command that matches, THE EXACT SAME COMMAND is re-executed
+# in a side pane. With watch = true, it is re-executed repeatedly on an interval.
+# This means the matched command itself must be safe to re-run!
+[[modes.rules]]
+pattern = "regex\\s+pattern"   # Regex matched against your bash commands
+watch = false                   # false (default): run the matched command once
+                                # true: re-run the matched command on interval
+interval = 5                   # Seconds between re-runs (only when watch = true)
+```
+
+## Guidelines
+
+**`init_command`** (optional): A setup command that runs once in every pane before its own command starts. If the project ships a reproducible-environment manifest you discovered (e.g. `devbox.json`, `flake.nix`, `.nvmrc`, `pyproject.toml` poetry env, `environment.yml` conda, `.tool-versions` asdf, `.envrc` direnv, a project `Makefile` `shell` target), default `init_command` to that activation command — projects that ship one expect commands to run inside it. Skip `init_command` only when the project has no such manifest.
+
+**Persistent panes** run automatically on a 10-second refresh cycle (`watch = true` by default). Write the plain command without any watch/follow/polling flags — the system handles refresh internally. Examples:
+- `command = "kubectl get pods -o wide"` — refreshes every 10s automatically
+- `command = "helm list -A"` — refreshes every 10s automatically
+
+Set `watch = false` ONLY for commands that have their own built-in streaming (e.g., `kubectl get pods -w`, `tail -f /var/log/app.log`, `cargo watch -x test`). These run directly without the system refresh wrapper.
+
+Do NOT use the `watch` binary, `while true` loops, or any other external polling mechanism — the system handles this.
+
+**Reactive rules** capture commands the agent runs. **The matched command itself is what gets re-executed in the side pane.** This is critical to understand:
+- `watch = false`: the matched command runs once in the side pane and the output stays visible.
+- `watch = true`: the matched command is re-executed repeatedly on the interval timer.
+- Regex patterns use Rust regex syntax (escape backslashes: `\\s`, `\\d`, etc.).
+- **Prefer consolidated alternations** like `cargo (test|clippy|check)` or `git (log|status|show|diff)` over many narrow rules — this keeps `reactive_panes` count low and panes from fragmenting.
+
+**Rule safety: NEVER match a command that mutates files, state, or remote systems.** The matched command itself is what gets re-executed (sometimes on a timer), so any side effect would be duplicated. Concrete exclusions:
+- Formatters/codegen run without `--check`/`--dry-run`: `cargo fmt`, `gofmt -w`, `prettier --write`, `black`, `rustfmt`, code generators that write files.
+- Package operations: `npm install`, `pip install`, `cargo add`, `go get`, `bundle install`.
+- Anything that creates, deletes, or modifies state: `apply`, `deploy`, `merge`, `push`, `commit`, `helm install`, `helm upgrade`, `terraform apply`, `kubectl apply`, `kubectl delete`, `make install`, `cargo publish`.
+
+Whitelist (safe to mirror): read-only inspection — `status`, `log`, `diff`, `show`, `list`, `get`, `describe`, `top`, `tree`, `cat`, `head`, `tail` (without `-f`), `tests`, `check`, `clippy`, `lint`, `--check`/`--dry-run` variants of formatters and applies.
+
+**CRITICAL: Every command in the config MUST come from the project's own toolchain.** If the project uses Helm and kubectl, propose Helm and kubectl commands. If it uses Go, propose Go commands. NEVER propose commands from ecosystems the project does not use — e.g., do not propose `cargo` commands for a Python project, or `npm` commands for a Kubernetes infra project.
+
+**Cover the project's tooling.** Create rules for all the read-only commands the agent is likely to use during development. If you have more reactive rules than the default 2 reactive pane slots, increase `reactive_panes` accordingly (e.g., `reactive_panes = 3` for 3 rules). Keep persistent panes to 1-2 to avoid crowding the screen.
+
+**Compact output is essential.** Side panes are small — roughly 80 columns wide and 15-20 rows tall. Commands must produce concise output that fits this space. Avoid `-o wide`, verbose flags, or commands that produce wide tables. Prefer narrow output formats: use `-o name`, column selection, `--no-headers`, or pipe through `awk`/`cut` to trim columns. If a command naturally produces many lines, add `| head -20` or similar limits.
+
+**Watch intervals**: when using `watch = true`, prefer longer intervals (10-30 seconds) unless the user needs near-real-time updates. Fast refresh (2-5 seconds) creates visual noise and unnecessary load.
+
+## Your Task
+
+1. **Discover the project at `{dir}`.** Read its build/package files, task runners, scripts, and CI/CD configs to identify the real toolchain. Do NOT assume — derive everything from what's actually in the repo. Probe for:
+   - **Build/package manifests**: `package.json`, `go.mod`, `pyproject.toml`, `Cargo.toml`, `pom.xml`, `Gemfile`, `build.gradle`, `Makefile`, etc.
+   - **Task runners**: `Taskfile.yml`, `justfile`, `Makefile`, `package.json#scripts`, `pyproject.toml#tool.poe`, etc.
+   - **Reproducible-environment manifests**: `devbox.json`, `flake.nix`, `shell.nix`, `.nvmrc`, `pyproject.toml` (poetry), `environment.yml` (conda), `.tool-versions` (asdf), `.envrc` (direnv), etc. — these drive `init_command`.
+   - **Project-defined agent launchers**: any script, alias, or documented instruction in the repo that says how to launch an agent CLI (`claude`, `opencode`, `cursor-agent`, etc.). Look in script directories (`scripts/`), task runners (`package.json#scripts`, `Taskfile.yml`, `justfile`, `Makefile`), reproducible-env manifests' script sections, agent-specific configs (`.claude/`, `opencode.json`, `AGENTS.md`, `CLAUDE.md`), and `README`/`CONTRIBUTING`. **Record the full invocation form**, not the bare script name — these are not binaries on PATH, so the role's `command` must include the runner: `devbox run <script>`, `npm run <script>`, `task <recipe>`, `make <target>`, `just <recipe>`, etc. When present, every orchestration role's `command` should use one of these invocations.
+   - **Project-defined slash commands the orchestrator can invoke**: agent CLIs like `claude` and `opencode` support custom slash commands and skills, typically kept in CLI-specific paths inside the repo (e.g. `.claude/skills/`, `.claude/commands/`, or the project's opencode config/skills location) or in the user's home (e.g. `~/.claude/skills/`). Discover the relevant paths for whichever CLI the orchestrator will invoke. Anything that looks like *coordination* — progress tracking, status reporting, release/PR automation, navigation between tasks — is a candidate the orchestrator can run *itself* between worker delegations rather than delegating. Reference relevant ones in the orchestrator's `prompt_template`. Skip if the orchestrator's CLI has no such concept or no relevant commands exist.
+   - **Spec directories**: any directory the project uses to drive work (e.g. `specs/`, `prds/`, `rfcs/`, `proposals/`, `docs/adr/`). Reference these in worker `prompt_template`s — they're a common context source for delegations.
+   - **CI/CD configs**: `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, `.circleci/`, etc. — show what gets validated on PRs.
+   - **Infrastructure**: `Dockerfile`, `docker-compose.yml`, Helm charts, Terraform, etc.
+
+2. **Validate every command exists.** For every binary that appears in pane commands, rule patterns, or orchestration role `command`s, run `which <binary>` to confirm it is installed. Exclude any command whose binary is not on the PATH. If a useful tool is missing, mention it as a suggestion but do not include it in the config.
+
+3. **Propose** a `.dot-agent-deck.toml` with a **single mode** tailored to this project:
+   - Pick the most useful workflow for AI-assisted development.
+   - Choose persistent panes for commands developers run continuously (a `git diff --stat HEAD` or `git status -s` is often the right default for AI-paired work — surfaces in-flight changes).
+   - Choose reactive rules for read-only commands you'll likely execute during AI-assisted work.
+   - Use meaningful mode and pane names.
+   - Aim for about 3 side panes total (persistent + reactive combined).
+
+4. **Always propose an orchestration alongside the modes**, composed from the **Role Library** at the bottom of this prompt. Process:
+   - **Pick worker roles** from the library that fit this project's workflow. Common picks: `coder` + `reviewer` + `auditor`. Add `tester` if the project uses TDD signals, `documenter` if the project has substantial docs, `researcher` for context-heavy codebases. Propose `release` by default whenever the project has release-flow signals: a release CI workflow, a `/prd-done`/`/release`-style slash command, a `release` task in the task runner, or any push/merge/tag/publish automation. The user can drop it at the proposal step if they'd rather have the orchestrator handle release directly.
+   - **Fill in each role's `command`** with the full invocation form of a project launcher (from step 1), matched by *semantic intent*, not just name. Example: a project that defines devbox scripts `agent-big` (opus), `agent-small` (haiku), and `oc-coder`/`oc-reviewer`/`oc-auditor` would yield `command = "devbox run agent-big"` for the orchestrator (benefits from a stronger model), `command = "devbox run agent-small"` for the `release` worker (lighter, mostly runs commands), `command = "devbox run oc-coder"` for `coder`, and so on — the runner (`devbox run`, `npm run`, `task`, etc.) is part of `command`, never stripped. **Do not mix**: if any project launcher is used for one role, every role should use one — extend the project's convention if a perfect match doesn't exist (reuse the closest fit) rather than falling back to a bare CLI for some roles. If the project has no launcher convention at all, fall back to a bare CLI that's on PATH (verify with `which claude`, `which opencode`, etc.). If multiple agent CLIs are present on PATH and there's no project signal pointing to one, ask the user during the proposal step rather than guessing.
+   - **Tune each role's `prompt_template`**: start from the library's suggestion, then fill in project-specific details — the actual test command, the spec directory path, the release command name. Keep tuning minimal; the library text is already good for most cases.
+   - **Compose the orchestrator's `prompt_template`** from the selected workers. Cover three things:
+     - **Workflow shape**: who runs first, what runs in parallel (e.g. reviewer + auditor in parallel after coder), where the user-validation gate sits (typically before `release`). Reference any spec directory you discovered.
+     - **Role boundary**: the orchestrator NEVER does *implementation, review, or audit* work — that's worker territory. It MAY run lightweight *coordination* slash commands the project provides (progress tracking, task navigation, status reporting) directly between delegations, without delegating, when those exist. Actions with side effects on shared state — push, merge, tag, publish — are better handled by a dedicated worker (typically `release`): `clear = false` lets it resume after a CI flake without restarting the whole flow, and a restricted-scope prompt prevents the agent from sliding into source edits when something goes wrong.
+     - **Context-handoff rule** (see mandatory callout below).
+   - Always include an orchestrator role with `start = true`. Validate: exactly one `start = true`, at least 2 roles, all role names unique and non-empty (no `..`, `/`, `\`), all commands non-empty.
+
+   **Context-handoff rule (MANDATORY in the orchestrator's `prompt_template`).** Workers cold-start with `clear = true` by default — they have NO memory of prior conversation, no access to other workers' outputs, and no shared scratchpad. Whatever the orchestrator writes in `--task` is the entire context the worker has, plus the worker's own `prompt_template`. The composed orchestrator `prompt_template` MUST therefore include rules along these lines (adapt the wording to the project, but cover all three points):
+
+   > *"Every delegation must include all context the worker needs: file paths to read, the relevant spec path if applicable, exact error messages when retrying after a failure, and a brief summary of any prior worker's findings when chaining workers (e.g. coder → reviewer)."*
+   >
+   > *"Do NOT assume workers can see prior conversation or other workers' outputs — paste references explicitly."*
+   >
+   > *"If the context is long, write it to `.dot-agent-deck/<task-slug>.md` and reference that path in the `--task` description rather than pasting it inline."*
+
+   Lead the proposal with project-specific signals you discovered ("the repo defines an `<alias>` script, so I wired it into the `coder` role") rather than generic boilerplate. If genuinely no orchestration fits the project, say so explicitly — but the default is to propose one.
+
+5. **Present the full proposed config (modes + orchestration) to the user before writing it, with every pane, rule, and role numbered.** Numbering lets the user reference items concisely ("drop rule 2", "rename pane 1", "drop the auditor role"). Briefly explain why you chose each item. Make clear the orchestration is optional and can be dropped entirely while keeping the modes. Close with negative confirmation — e.g., "Tell me what to drop or change, otherwise I'll write the whole thing." Do NOT ask multiple-choice questions like "(a) modes-only or (b) include orchestration?" — those force an extra round-trip when the user could just say what to remove. Only write the file after the user confirms.
+
+6. Write the approved config to `{dir}/.dot-agent-deck.toml`. If an orchestration was kept, include `[[orchestrations]]` alongside `[[modes]]` in the same file.
+
+7. **After writing the file, tell the user the next steps:** "Config created! To use it, press Ctrl+w to close this pane, then Ctrl+n to create a new one. Select the same directory and choose your mode from the Mode field."
+
+## Orchestrations
+
+Reference material for step 4. **Agent orchestrations** are multi-agent workflows where a designated orchestrator agent delegates tasks to worker agents.
+
+### Orchestration Config Format
+
+```toml
+[[orchestrations]]
+name = "orchestration-name"   # e.g., "code-review", "tdd-cycle"
+
+[[orchestrations.roles]]
+name = "orchestrator"         # The orchestrator role — delegates work, never does it
+command = "claude"            # CLI command to launch the agent
+start = true                  # Exactly one role MUST have start = true
+prompt_template = """         # Composed from selected workers (see step 4)
+You coordinate the team. You NEVER do work yourself — only delegate.
+[workflow shape: who runs first, what runs in parallel, gates]
+"""
+
+[[orchestrations.roles]]
+name = "coder"                # Picked from the Role Library
+command = "claude --model sonnet"   # Or a project-defined alias if one exists
+description = "Implements features, fixes bugs, refactors code"   # From library
+prompt_template = "Implement the requested change. Run cargo test before finishing."
+# clear = true                # Default true — restart agent session between delegations
+
+[[orchestrations.roles]]
+name = "reviewer"
+command = "claude"
+description = "Reviews code changes for correctness, style, and edge cases"
+```
+
+### Orchestration Guidelines
+
+- **Exactly one `start = true` role**: This is the orchestrator. It receives the user's initial request and delegates to workers. dot-agent-deck auto-appends the available agents list and delegation protocol to the orchestrator's prompt.
+- **At least 2 roles** per orchestration (one orchestrator + at least one worker).
+- **All role names must be unique** within the orchestration.
+- **Role names must not be empty** and must not contain `..`, `/`, `\`, or null characters (they are used in file paths).
+- **Every role must have a non-empty `command`**.
+- **Worker `description`** is important — it's used to auto-build the orchestrator's available agents list. Use the library's `description` as-is unless the project changes the role's scope.
+- **Worker `prompt_template`** is optional standing instructions, NOT task instructions. The orchestrator provides task instructions each time via delegation.
+- **`clear = true` (default)**: Restarts the agent session between delegations for context isolation. Set `clear = false` for agents that need to resume after a failure (e.g. a `release` agent retrying after a CI hiccup).
+- **`command`**: Use the full invocation form of a project launcher (discovered in step 1), matched by semantic intent — e.g. `command = "devbox run agent-big"`, never just `"agent-big"`, because devbox/npm/task scripts are not binaries on PATH. If the project has no launcher convention, fall back to a bare CLI that is on PATH; if multiple agent CLIs are available with no project signal, ask the user. Verify availability with `which <runner-or-binary>` before including it.
+- **Propose exactly one orchestration.** Combine all relevant workers into that single orchestration — the orchestrator routes each task to the right worker. Do NOT present multiple orchestrations as either/or alternatives.
+
+### Worked Example
+
+Suppose you picked `coder` + `reviewer` + `auditor` from the role library and the project has no agent CLI aliases. The result might look like:
+
+```toml
+[[orchestrations]]
+name = "dev-flow"
+
+[[orchestrations.roles]]
+name = "orchestrator"
+command = "claude"
+start = true
+prompt_template = """
+You coordinate the team. You NEVER do work yourself — only delegate to the available agents.
+
+Workflow:
+- Delegate implementation to coder.
+- After coder finishes, delegate to reviewer and auditor in parallel.
+- Resolve any blocking findings before moving on.
+
+Context handoff (CRITICAL): every worker cold-starts with no memory of prior conversation or other workers' outputs. Whatever you write in --task is the entire context they have. Therefore:
+- Always include relevant file paths the worker should read (the spec, the files being modified, etc.).
+- When chaining workers (coder → reviewer), summarize the prior worker's relevant findings or list the files they changed.
+- When retrying after a failure, paste the exact error message into --task.
+- If context is long, write it to .dot-agent-deck/<task-slug>.md and reference that path in --task instead of pasting inline.
+"""
+
+[[orchestrations.roles]]
+name = "coder"
+command = "claude --model sonnet"
+description = "Implements features, fixes bugs, refactors code"
+prompt_template = "Implement the requested change. Run the project's test command before reporting completion."
+
+[[orchestrations.roles]]
+name = "reviewer"
+command = "claude"
+description = "Reviews code changes for correctness, style, and edge cases"
+prompt_template = "Review the change. Report findings only — do not modify code."
+
+[[orchestrations.roles]]
+name = "auditor"
+command = "claude"
+description = "Audits code for security vulnerabilities and unsafe patterns"
+prompt_template = "Audit the change for security vulnerabilities. Report findings only."
+```
+
+When proposing a `release` role, set `clear = false` on it so it can resume after a CI failure, and add a user-validation gate to the orchestrator's `prompt_template`: "Before delegating to release, summarize what to test end-to-end and STOP until the user confirms."
+
+## Role Library
+
+The following generic roles are pre-defined. Pick from these when composing an orchestration. For each entry: `description` is what the role does (use as the role's `description`), `clear` is the recommended default, and `prompt_template` is a starter you should tune to the project (substitute the actual test command, spec directory, release command name, etc.).
+
+{roles}
+
+## Quality Guidelines
+
+- **Discover, don't assume.** Only propose commands for tools the project actually uses.
+- **Focused output over broad output.** Persistent panes should show actionable, scoped information.
+- **Only use installed tools.** Every command in the config must work on this system right now.
+- **Fewer is better.** The user can always add more panes or roles later.
+- **Always propose an orchestration.** Drop only if no role from the library plausibly applies.

--- a/assets/roles.toml
+++ b/assets/roles.toml
@@ -1,0 +1,52 @@
+# Generic agent role library — embedded into the dot-agent-deck binary.
+#
+# These are TEMPLATES the config-gen agent picks from when proposing an
+# orchestration. The agent fills in `command` by discovering the project's
+# available agent CLIs (script aliases, task-runner targets, or the bare
+# `claude`/`opencode`/etc.) and tunes `prompt_template` to match the project
+# (e.g. naming the project's actual test command, spec directory, release flow).
+#
+# Editing this file is enough to change the role library — the binary
+# embeds it via `include_str!` at build time.
+
+[[role]]
+name = "coder"
+description = "Implements features, fixes bugs, refactors code"
+clear = true
+prompt_template = "Implement the requested change. Read referenced spec or task files first if any are mentioned. Run the project's test command before reporting completion. If critical context is missing from the task description, surface it in your work-done summary rather than guessing — the orchestrator will re-delegate with the missing context."
+
+[[role]]
+name = "reviewer"
+description = "Reviews code changes for correctness, style, and edge cases"
+clear = true
+prompt_template = "Review the change. Report findings only — do not modify code yourself. Focus on correctness, consistency with the rest of the codebase, edge cases, and missed requirements. If a spec or task file is referenced, verify the implementation matches it. If critical context is missing from the task (e.g. the diff to review, the spec path), surface it in your work-done summary rather than guessing — the orchestrator will re-delegate with the missing context."
+
+[[role]]
+name = "auditor"
+description = "Audits code for security vulnerabilities and unsafe patterns"
+clear = true
+prompt_template = "Audit the change for security vulnerabilities, unsafe patterns, and OWASP top-10 class issues. Report findings only — do not modify code. If the task references a file or diff, read it before starting. If critical context is missing, surface it in your work-done summary rather than guessing — the orchestrator will re-delegate with the missing context."
+
+[[role]]
+name = "tester"
+description = "Writes and runs tests; useful for TDD-style flows"
+clear = true
+prompt_template = "Discover the project's test framework and conventions. When asked to write tests, follow existing test layout and naming. Run tests after writing them and report results. If the task references a spec or behavior to test, read it before starting. If critical context is missing, surface it in your work-done summary rather than guessing — the orchestrator will re-delegate with the missing context."
+
+[[role]]
+name = "documenter"
+description = "Writes and updates documentation only — never modifies source code"
+clear = true
+prompt_template = "Update documentation only. Do not modify source code. Match the existing documentation style and structure of the project. If the task references files to document or a spec describing the new behavior, read them before starting. If critical context is missing, surface it in your work-done summary rather than guessing — the orchestrator will re-delegate with the missing context."
+
+[[role]]
+name = "release"
+description = "Runs the project's release/PR/merge workflow; never modifies code"
+clear = false
+prompt_template = "Your job is to run the project's release flow (e.g. open a PR, merge, tag). Do NOT modify source code. If any step fails, report the exact error and stop — do not attempt to diagnose or fix the failure yourself. If the task is missing context you need (e.g. PR title, release notes path, target branch), report that via work-done rather than improvising — the orchestrator will re-delegate with the missing context."
+
+[[role]]
+name = "researcher"
+description = "Investigates the codebase or external sources to gather context"
+clear = true
+prompt_template = "Investigate and report findings only. Do not modify any files. Useful for gathering context before larger changes. If the task references files or topics to investigate, read or query them before reporting. If the question is too vague to answer well, surface that in your work-done summary rather than guessing — the orchestrator will re-delegate with a sharper question."

--- a/src/config.rs
+++ b/src/config.rs
@@ -463,6 +463,14 @@ impl ConfigGenState {
     }
 }
 
+/// Serializes tests that mutate `DOT_AGENT_DECK_CONFIG_GEN_STATE` or call
+/// `ConfigGenState::save()` / `load()` (directly or through handlers like
+/// `handle_config_gen_prompt_key`). Rust runs unit tests in parallel, so
+/// without this lock those tests race on the shared env var and on whatever
+/// state file each one points it at.
+#[cfg(test)]
+pub(crate) static CONFIG_GEN_STATE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 pub(crate) fn dirs_home() -> PathBuf {
     std::env::var("HOME")
         .map(PathBuf::from)
@@ -861,6 +869,20 @@ timeout_secs = 600
 
     #[test]
     fn config_gen_state_suppress_dir_deduplicates() {
+        // suppress_dir() calls save(), which reads DOT_AGENT_DECK_CONFIG_GEN_STATE.
+        // Hold the env-var lock and point at a temp path so we neither race
+        // against load_save_cycle nor pollute the real home dir.
+        let _guard = CONFIG_GEN_STATE_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config-gen-state.json");
+        let prev = std::env::var("DOT_AGENT_DECK_CONFIG_GEN_STATE").ok();
+        // SAFETY: env-var lock held for the duration of this test.
+        unsafe {
+            std::env::set_var("DOT_AGENT_DECK_CONFIG_GEN_STATE", path.to_str().unwrap());
+        }
+
         let mut state = ConfigGenState::default();
         state.suppressed_dirs.push("/dup".to_string());
         state.suppressed_dirs.push("/dup".to_string()); // manual dup
@@ -871,6 +893,14 @@ timeout_secs = 600
         state2.suppressed_dirs.push("/dup".to_string());
         state2.suppress_dir("/dup");
         assert_eq!(state2.suppressed_dirs.len(), 1);
+
+        // SAFETY: env-var lock held; restore prior value.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("DOT_AGENT_DECK_CONFIG_GEN_STATE", v),
+                None => std::env::remove_var("DOT_AGENT_DECK_CONFIG_GEN_STATE"),
+            }
+        }
     }
 
     #[test]
@@ -887,10 +917,15 @@ timeout_secs = 600
 
     #[test]
     fn config_gen_state_load_save_cycle() {
+        // Serialize against any other test that touches this env var or calls
+        // save()/load() — Rust runs unit tests in parallel.
+        let _guard = CONFIG_GEN_STATE_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config-gen-state.json");
         let prev = std::env::var("DOT_AGENT_DECK_CONFIG_GEN_STATE").ok();
-        // SAFETY: test is single-threaded; no other code reads this var concurrently.
+        // SAFETY: env-var lock held for the duration of this test.
         unsafe {
             std::env::set_var("DOT_AGENT_DECK_CONFIG_GEN_STATE", path.to_str().unwrap());
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -471,6 +471,40 @@ impl ConfigGenState {
 #[cfg(test)]
 pub(crate) static CONFIG_GEN_STATE_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Test-only RAII guard that sets `DOT_AGENT_DECK_CONFIG_GEN_STATE` and
+/// restores its prior value on drop, even if the test panics. Callers must
+/// hold `CONFIG_GEN_STATE_ENV_LOCK` for the guard's lifetime.
+#[cfg(test)]
+pub(crate) struct ConfigGenStateEnvGuard {
+    prev: Option<String>,
+}
+
+#[cfg(test)]
+impl ConfigGenStateEnvGuard {
+    pub(crate) fn set(value: &str) -> Self {
+        let prev = std::env::var("DOT_AGENT_DECK_CONFIG_GEN_STATE").ok();
+        // SAFETY: callers must hold CONFIG_GEN_STATE_ENV_LOCK for the
+        // duration of this guard, which serializes env-var access.
+        unsafe {
+            std::env::set_var("DOT_AGENT_DECK_CONFIG_GEN_STATE", value);
+        }
+        Self { prev }
+    }
+}
+
+#[cfg(test)]
+impl Drop for ConfigGenStateEnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: see ConfigGenStateEnvGuard::set.
+        unsafe {
+            match self.prev.take() {
+                Some(v) => std::env::set_var("DOT_AGENT_DECK_CONFIG_GEN_STATE", v),
+                None => std::env::remove_var("DOT_AGENT_DECK_CONFIG_GEN_STATE"),
+            }
+        }
+    }
+}
+
 pub(crate) fn dirs_home() -> PathBuf {
     std::env::var("HOME")
         .map(PathBuf::from)
@@ -877,11 +911,8 @@ timeout_secs = 600
             .unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config-gen-state.json");
-        let prev = std::env::var("DOT_AGENT_DECK_CONFIG_GEN_STATE").ok();
-        // SAFETY: env-var lock held for the duration of this test.
-        unsafe {
-            std::env::set_var("DOT_AGENT_DECK_CONFIG_GEN_STATE", path.to_str().unwrap());
-        }
+        // Drop guard restores the env var even if an assertion below panics.
+        let _env_restore = ConfigGenStateEnvGuard::set(path.to_str().unwrap());
 
         let mut state = ConfigGenState::default();
         state.suppressed_dirs.push("/dup".to_string());
@@ -893,14 +924,6 @@ timeout_secs = 600
         state2.suppressed_dirs.push("/dup".to_string());
         state2.suppress_dir("/dup");
         assert_eq!(state2.suppressed_dirs.len(), 1);
-
-        // SAFETY: env-var lock held; restore prior value.
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("DOT_AGENT_DECK_CONFIG_GEN_STATE", v),
-                None => std::env::remove_var("DOT_AGENT_DECK_CONFIG_GEN_STATE"),
-            }
-        }
     }
 
     #[test]

--- a/src/config_gen.rs
+++ b/src/config_gen.rs
@@ -1,205 +1,63 @@
+use serde::Deserialize;
+use std::fmt::Write as _;
+use std::sync::OnceLock;
+
 /// Prompt template for instructing an AI agent to generate a `.dot-agent-deck.toml`
 /// configuration file by analyzing the project structure.
-const CONFIG_GEN_PROMPT_TEMPLATE: &str = r#"Analyze this project and create a `.dot-agent-deck.toml` configuration file in the project root.
+const CONFIG_GEN_PROMPT_TEMPLATE: &str = include_str!("../assets/config_gen_prompt.md");
 
-## What is .dot-agent-deck.toml?
+/// Generic agent role library. Embedded at build time; the config-gen agent picks
+/// from these roles when proposing an orchestration.
+const ROLES_TOML: &str = include_str!("../assets/roles.toml");
 
-This file configures "workspace modes" for the dot-agent-deck TUI dashboard. Each mode defines a tab-based workspace that pairs you (the AI agent) with live command output in side panes. When a user activates a mode, a new tab opens with the agent on the left and side panes stacked on the right.
+#[derive(Debug, Deserialize)]
+struct RoleTemplate {
+    name: String,
+    description: String,
+    #[serde(default = "default_true")]
+    clear: bool,
+    #[serde(default)]
+    prompt_template: String,
+}
 
-## Config Format
+fn default_true() -> bool {
+    true
+}
 
-The file is TOML. You can define one or more modes. Each mode has a name, optional persistent panes, and optional reactive rules.
+#[derive(Debug, Deserialize)]
+struct RoleLibrary {
+    role: Vec<RoleTemplate>,
+}
 
-```toml
-[[modes]]
-name = "mode-name"   # Display name shown in the tab bar
-init_command = "devbox shell"  # Optional: runs once in every pane before its command
-reactive_panes = 2             # Optional: number of reactive pane slots (default: 2)
+static ROLE_LIBRARY: OnceLock<RoleLibrary> = OnceLock::new();
 
-# Persistent panes: run when the mode activates, stay alive for the tab lifetime.
-# By default, commands are re-executed every 10 seconds automatically (watch = true).
-# Set watch = false for commands that stream/follow on their own (e.g., --watch, -f, tail -f).
-[[modes.panes]]
-command = "some-command"           # Shell command to run (plain, no watch/follow flags needed)
-name = "Display Name"              # Optional label (defaults to command)
-# watch = true                     # Default: system re-runs command every 10s automatically
-                                   # Set to false for commands with built-in streaming
+fn role_library() -> &'static RoleLibrary {
+    ROLE_LIBRARY
+        .get_or_init(|| toml::from_str(ROLES_TOML).expect("embedded roles.toml must be valid"))
+}
 
-# Reactive rules: regex patterns matched against your bash commands.
-# When you execute a command that matches, THE EXACT SAME COMMAND is re-executed
-# in a side pane. With watch = true, it is re-executed repeatedly on an interval.
-# This means the matched command itself must be safe to re-run!
-[[modes.rules]]
-pattern = "regex\\s+pattern"   # Regex matched against your bash commands
-watch = false                   # false (default): run the matched command once
-                                # true: re-run the matched command on interval
-interval = 5                   # Seconds between re-runs (only when watch = true)
-```
-
-## Guidelines
-
-**`init_command`** (optional): A setup command that runs once in every pane before its own command starts. Use it when the project requires an environment setup step — e.g., `devbox shell`, `nvm use`, `source .env`, `conda activate env`. Only add it if the project actually needs it (look for devbox.json, .nvmrc, .env, conda environment files, etc.). Most projects don't need it.
-
-**Persistent panes** run automatically on a 10-second refresh cycle (`watch = true` by default). Write the plain command without any watch/follow/polling flags — the system handles refresh internally. Examples:
-- `command = "kubectl get pods -o wide"` — refreshes every 10s automatically
-- `command = "helm list -A"` — refreshes every 10s automatically
-
-Set `watch = false` ONLY for commands that have their own built-in streaming (e.g., `kubectl get pods -w`, `tail -f /var/log/app.log`, `cargo watch -x test`). These run directly without the system refresh wrapper.
-
-Do NOT use the `watch` binary, `while true` loops, or any other external polling mechanism — the system handles this.
-
-**Reactive rules** capture commands the agent runs. **The matched command itself is what gets re-executed in the side pane.** This is critical to understand:
-- `watch = false`: the matched command runs once in the side pane and the output stays visible
-- `watch = true`: the matched command is re-executed repeatedly on the interval timer
-- **ONLY create rules for read-only commands** (get, list, status, top, describe, logs, diff, show, cat, tree). NEVER create rules matching commands that mutate state (apply, install, deploy, create, delete, upgrade, update, patch, scale, rollout, helm install, helm upgrade, terraform apply). The system re-executes matched commands, so write operations would be duplicated
-- Regex patterns use Rust regex syntax (escape backslashes: `\\s`, `\\d`, etc.)
-
-**CRITICAL: Every command in the config MUST come from the project's own toolchain.** If the project uses Helm and kubectl, propose Helm and kubectl commands. If it uses Go, propose Go commands. NEVER propose commands from ecosystems the project does not use — e.g., do not propose `cargo` commands for a Python project, or `npm` commands for a Kubernetes infra project.
-
-**Cover the project's tooling.** Create rules for all the read-only commands the agent is likely to use during development. If you have more reactive rules than the default 2 reactive pane slots, increase `reactive_panes` accordingly (e.g., `reactive_panes = 3` for 3 rules). Keep persistent panes to 1-2 to avoid crowding the screen.
-
-**Compact output is essential.** Side panes are small — roughly 80 columns wide and 15-20 rows tall. Commands must produce concise output that fits this space. Avoid `-o wide`, verbose flags, or commands that produce wide tables. Prefer narrow output formats: use `-o name`, column selection, `--no-headers`, or pipe through `awk`/`cut` to trim columns. If a command naturally produces many lines, add `| head -20` or similar limits.
-
-**Watch intervals**: when using `watch = true`, prefer longer intervals (10-30 seconds) unless the user needs near-real-time updates. Fast refresh (2-5 seconds) creates visual noise and unnecessary load.
-
-## Your Task
-
-1. **Examine the project at `{dir}` first.** Read build files, config files, and scripts to identify the actual languages, frameworks, and tools this project uses. Do NOT assume any specific toolchain — discover it from the project files:
-   - Build/package files (e.g., package.json, go.mod, pyproject.toml, Makefile, Cargo.toml, pom.xml, etc.)
-   - CI/CD configs (.github/workflows/, Jenkinsfile, etc.)
-   - Scripts directory and any task runners
-   - Infrastructure config (Dockerfile, docker-compose, Helm charts, Terraform files, etc.)
-
-2. **Validate every command exists.** For every binary used in pane commands or that could match rule patterns, run `which <binary>` to confirm it is installed. Do NOT include any command that uses a binary not found on the system. If a useful tool is not installed, mention it as a suggestion but exclude it from the config.
-
-3. **Propose** a `.dot-agent-deck.toml` with a **single mode** tailored to this project:
-   - Pick the most useful workflow for AI-assisted development
-   - Choose persistent panes for commands developers run continuously
-   - Choose reactive rules for commands you'll likely execute during AI-assisted work
-   - Use meaningful mode and pane names
-   - Aim for about 3 side panes total (persistent + reactive combined)
-
-4. **Present your proposed config to the user before writing it.** For each pane and rule, briefly explain why you chose it. Ask the user to confirm, modify, or remove items. Only write the file after the user approves.
-
-5. Write the approved config to `{dir}/.dot-agent-deck.toml`
-
-6. **After writing the file, tell the user the next steps:** "Config created! To use it, press Ctrl+w to close this pane, then Ctrl+n to create a new one. Select the same directory and choose your mode from the Mode field."
-
-## Orchestrations (Optional)
-
-After proposing modes, ask the user if they want to set up **agent orchestrations** — multi-agent workflows where a designated orchestrator agent delegates tasks to worker agents. Examples: code + review, TDD cycles, code + security audit.
-
-If the user wants orchestrations, guide them through defining one:
-
-### Orchestration Config Format
-
-```toml
-[[orchestrations]]
-name = "orchestration-name"   # e.g., "code-review", "tdd-cycle"
-
-[[orchestrations.roles]]
-name = "orchestrator"         # The orchestrator role — delegates work, never does it
-command = "claude"            # CLI command to launch the agent
-start = true                  # Exactly one role MUST have start = true
-prompt_template = """         # Optional: base instructions for the orchestrator
-You are an orchestration manager. You NEVER do work yourself.
-You only delegate to available agents and coordinate their work.
-"""
-
-[[orchestrations.roles]]
-name = "coder"                # Worker role name (must be unique across all roles)
-command = "claude --model sonnet"
-description = "Implements code changes, fixes bugs, writes features"  # Used to build the orchestrator's agent list
-prompt_template = "Always run cargo test before finishing."  # Optional: standing instructions prepended to each task
-# clear = true                # Default true — restart agent session between delegations for context isolation
-
-[[orchestrations.roles]]
-name = "reviewer"
-command = "claude"
-description = "Reviews code for correctness, style, and edge cases"
-```
-
-### Orchestration Guidelines
-
-- **Exactly one `start = true` role**: This is the orchestrator. It receives the user's initial request and delegates to workers. dot-agent-deck auto-appends the available agents list and delegation protocol to the orchestrator's prompt.
-- **At least 2 roles** per orchestration (one orchestrator + at least one worker).
-- **All role names must be unique** within the orchestration.
-- **Role names must not be empty** and must not contain `..`, `/`, `\`, or null characters (they are used in file paths).
-- **Every role must have a non-empty `command`**.
-- **Worker `description`** is important — it's used to auto-build the orchestrator's available agents list. Be specific about what each worker does.
-- **Worker `prompt_template`** is optional standing instructions (e.g., "always run tests before finishing"), NOT task instructions. The orchestrator provides task instructions each time via delegation.
-- **`clear = true` (default)**: Restarts the agent session between delegations for context isolation. Set `clear = false` if the agent needs to retain state across delegations.
-- **`command`**: The CLI command to launch the agent. Use the agent CLIs available on the system (e.g., `claude`, `opencode`). Run `which <binary>` to verify availability.
-- **Suggest orchestrations that match the project's workflow**: code + review for teams that care about code quality, code + security audit for security-sensitive projects, etc.
-
-### Example Orchestrations
-
-**Code Review** (code + review):
-```toml
-[[orchestrations]]
-name = "code-review"
-
-[[orchestrations.roles]]
-name = "orchestrator"
-command = "claude"
-start = true
-
-[[orchestrations.roles]]
-name = "coder"
-command = "claude --model sonnet"
-description = "Implements code changes, fixes bugs, writes features"
-
-[[orchestrations.roles]]
-name = "reviewer"
-command = "claude"
-description = "Reviews code for correctness, style, and edge cases"
-```
-
-**Code + Security Audit**:
-```toml
-[[orchestrations]]
-name = "secure-dev"
-
-[[orchestrations.roles]]
-name = "orchestrator"
-command = "claude"
-start = true
-
-[[orchestrations.roles]]
-name = "coder"
-command = "claude --model sonnet"
-description = "Implements code changes and features"
-
-[[orchestrations.roles]]
-name = "security-auditor"
-command = "claude"
-description = "Audits code for security vulnerabilities and OWASP top 10 issues"
-```
-
-### Orchestration Task
-
-1. After the modes section is confirmed, ask: "Would you also like to set up an agent orchestration? This lets multiple AI agents collaborate — e.g., one writes code while another reviews it."
-2. If yes, ask about:
-   - Orchestration name (a short workflow name like "code-review")
-   - Worker roles: name, command, description for each
-   - Whether any workers need custom `prompt_template` (standing instructions)
-   - Whether `clear = false` is needed for any worker (uncommon)
-3. Always include an orchestrator role with `start = true`
-4. Validate: exactly one `start = true`, at least 2 roles, all role names unique and non-empty (no `..`, `/`, `\`), all commands non-empty
-5. Present the proposed orchestration config and get user approval
-6. Write the `[[orchestrations]]` section into `.dot-agent-deck.toml` alongside the `[[modes]]` section
-
-## Quality Guidelines
-
-- **Discover, don't assume.** Only propose commands for tools the project actually uses. Never check for or include tools from unrelated ecosystems.
-- **Focused output over broad output.** Persistent panes should show actionable, scoped information — not everything.
-- **Only use installed tools.** Every command in the config must work on this system right now.
-- **Fewer is better.** The user can always add more panes later.
-- **Orchestrations are optional.** Only suggest them if the user is interested. Don't force multi-agent workflows on simple projects."#;
+fn render_roles_section(library: &RoleLibrary) -> String {
+    let mut out = String::new();
+    for role in &library.role {
+        writeln!(&mut out, "### `{}`\n", role.name).unwrap();
+        writeln!(&mut out, "- **Description:** {}", role.description).unwrap();
+        writeln!(&mut out, "- **`clear` default:** `{}`", role.clear).unwrap();
+        writeln!(
+            &mut out,
+            "- **Suggested `prompt_template`:** {}\n",
+            role.prompt_template
+        )
+        .unwrap();
+    }
+    out
+}
 
 /// Build the config generation prompt for a specific directory.
 pub fn config_gen_prompt(dir: &str) -> String {
-    CONFIG_GEN_PROMPT_TEMPLATE.replace("{dir}", dir)
+    let roles_section = render_roles_section(role_library());
+    CONFIG_GEN_PROMPT_TEMPLATE
+        .replace("{dir}", dir)
+        .replace("{roles}", &roles_section)
 }
 
 #[cfg(test)]
@@ -228,7 +86,7 @@ mod tests {
         assert!(prompt.contains("[[orchestrations]]"));
         assert!(prompt.contains("[[orchestrations.roles]]"));
         assert!(prompt.contains("start = true"));
-        assert!(prompt.contains("Orchestrations (Optional)"));
+        assert!(prompt.contains("## Orchestrations"));
     }
 
     #[test]
@@ -242,10 +100,107 @@ mod tests {
     }
 
     #[test]
-    fn prompt_contains_orchestration_examples() {
+    fn prompt_contains_orchestration_example() {
         let prompt = config_gen_prompt("/tmp/test");
-        assert!(prompt.contains("code-review"));
-        assert!(prompt.contains("secure-dev"));
-        assert!(prompt.contains("security-auditor"));
+        assert!(prompt.contains("dev-flow"));
+        assert!(prompt.contains("reviewer"));
+        assert!(prompt.contains("Propose exactly one orchestration"));
+    }
+
+    #[test]
+    fn prompt_contains_role_library_section() {
+        let prompt = config_gen_prompt("/tmp/test");
+        assert!(prompt.contains("## Role Library"));
+        assert!(!prompt.contains("{roles}"));
+    }
+
+    #[test]
+    fn prompt_renders_every_library_role() {
+        let prompt = config_gen_prompt("/tmp/test");
+        for role in &role_library().role {
+            assert!(
+                prompt.contains(&format!("### `{}`", role.name)),
+                "missing role header for `{}`",
+                role.name
+            );
+            assert!(
+                prompt.contains(&role.description),
+                "missing description for role `{}`",
+                role.name
+            );
+        }
+    }
+
+    #[test]
+    fn role_library_parses_and_has_expected_roles() {
+        let lib = role_library();
+        let names: Vec<&str> = lib.role.iter().map(|r| r.name.as_str()).collect();
+        for expected in [
+            "coder",
+            "reviewer",
+            "auditor",
+            "tester",
+            "documenter",
+            "release",
+            "researcher",
+        ] {
+            assert!(
+                names.contains(&expected),
+                "role `{expected}` missing from library; got {names:?}"
+            );
+        }
+        for role in &lib.role {
+            assert!(!role.name.is_empty(), "role with empty name");
+            assert!(
+                !role.description.is_empty(),
+                "role `{}` has empty description",
+                role.name
+            );
+            assert!(
+                !role.prompt_template.is_empty(),
+                "role `{}` has empty prompt_template",
+                role.name
+            );
+        }
+    }
+
+    #[test]
+    fn prompt_contains_context_handoff_mandate() {
+        let prompt = config_gen_prompt("/tmp/test");
+        assert!(
+            prompt.contains("Context-handoff rule"),
+            "context-handoff mandate must appear in the orchestration composition guidance"
+        );
+        assert!(
+            prompt.contains("clear = true"),
+            "mandate must explain that workers cold-start with clear = true"
+        );
+    }
+
+    #[test]
+    fn every_worker_role_has_missing_context_backstop() {
+        let lib = role_library();
+        for role in &lib.role {
+            assert!(
+                role.prompt_template
+                    .contains("the orchestrator will re-delegate with"),
+                "role `{}` is missing the missing-context backstop sentence",
+                role.name
+            );
+        }
+    }
+
+    #[test]
+    fn release_role_has_clear_false() {
+        let lib = role_library();
+        let release = lib
+            .role
+            .iter()
+            .find(|r| r.name == "release")
+            .expect("release role present");
+        assert!(
+            !release.clear,
+            "release role should default to clear = false so it can resume after failure"
+        );
     }
 }

--- a/src/embedded_pane.rs
+++ b/src/embedded_pane.rs
@@ -37,23 +37,17 @@ type PaneRegistry = Arc<Mutex<HashMap<String, Pane>>>;
 
 /// Encode the payload portion of a pane input (content + bracketed paste markers if
 /// multi-line) without the trailing submit byte. Trailing whitespace is stripped.
-///
-/// Returned tuple: `(bytes, is_multiline)`. The `is_multiline` flag tells the caller
-/// whether to insert a brief delay before sending the submit byte — agent TUIs like
-/// claude need a tick after the close marker to transition out of paste-review mode
-/// before they will honor a fresh Enter.
-fn encode_pane_payload(text: &str) -> (Vec<u8>, bool) {
+fn encode_pane_payload(text: &str) -> Vec<u8> {
     let trimmed = text.trim_end_matches(['\n', '\r', ' ', '\t']);
-    let multiline = trimmed.contains('\n');
     let mut out = Vec::with_capacity(trimmed.len() + 16);
-    if multiline {
+    if trimmed.contains('\n') {
         out.extend_from_slice(b"\x1b[200~");
         out.extend_from_slice(trimmed.as_bytes());
         out.extend_from_slice(b"\x1b[201~");
     } else {
         out.extend_from_slice(trimmed.as_bytes());
     }
-    (out, multiline)
+    out
 }
 
 /// Delay between writing input bytes and the submit CR. Agent TUIs like claude
@@ -467,8 +461,15 @@ impl PaneController for EmbeddedPaneController {
         Ok(())
     }
 
+    /// Concurrency contract: callers must not invoke `write_to_pane` concurrently
+    /// for the same `pane_id`. The pane lock is released around `SUBMIT_DELAY` so
+    /// other panes can be drawn — but interleaved writes for the *same* pane would
+    /// produce `payload_A + payload_B + CR + CR`, fusing two prompts. The current
+    /// architecture is single-threaded for pane I/O, so this is a latent constraint
+    /// rather than an active hazard; a per-pane submit mutex would enforce it if
+    /// concurrent callers are ever introduced.
     fn write_to_pane(&self, pane_id: &str, text: &str) -> Result<(), PaneError> {
-        let (payload, _multiline) = encode_pane_payload(text);
+        let payload = encode_pane_payload(text);
         // Write the payload (content, optionally bracketed-paste-wrapped), flush, then
         // pause briefly before sending the submit CR. Agent TUIs like claude treat a
         // CR that arrives fused to the preceding text as newline-in-input; only a CR
@@ -584,47 +585,37 @@ mod tests {
 
     #[test]
     fn encode_pane_payload_single_line() {
-        let (bytes, multiline) = encode_pane_payload("ls -la");
-        assert_eq!(bytes, b"ls -la");
-        assert!(!multiline);
+        assert_eq!(encode_pane_payload("ls -la"), b"ls -la");
     }
 
     #[test]
     fn encode_pane_payload_strips_trailing_whitespace() {
-        let (bytes, multiline) = encode_pane_payload("ls -la\n");
-        assert_eq!(bytes, b"ls -la");
-        assert!(!multiline);
-
-        let (bytes, multiline) = encode_pane_payload("ls -la  \n\n");
-        assert_eq!(bytes, b"ls -la");
-        assert!(!multiline);
+        assert_eq!(encode_pane_payload("ls -la\n"), b"ls -la");
+        assert_eq!(encode_pane_payload("ls -la  \n\n"), b"ls -la");
     }
 
     #[test]
     fn encode_pane_payload_wraps_multiline() {
-        let (bytes, multiline) = encode_pane_payload("line1\nline2\nline3");
-        assert_eq!(bytes, b"\x1b[200~line1\nline2\nline3\x1b[201~");
-        assert!(multiline);
+        assert_eq!(
+            encode_pane_payload("line1\nline2\nline3"),
+            b"\x1b[200~line1\nline2\nline3\x1b[201~"
+        );
     }
 
     #[test]
     fn encode_pane_payload_multiline_with_trailing_newline() {
         // Trailing newline is stripped, but embedded newlines still trigger paste wrapping.
-        let (bytes, multiline) = encode_pane_payload("line1\nline2\n");
-        assert_eq!(bytes, b"\x1b[200~line1\nline2\x1b[201~");
-        assert!(multiline);
+        assert_eq!(
+            encode_pane_payload("line1\nline2\n"),
+            b"\x1b[200~line1\nline2\x1b[201~"
+        );
     }
 
     #[test]
     fn encode_pane_payload_empty() {
-        let (bytes, multiline) = encode_pane_payload("");
-        assert_eq!(bytes, b"");
-        assert!(!multiline);
-
-        let (bytes, multiline) = encode_pane_payload("\n\n");
-        assert_eq!(bytes, b"");
-        // Edge case: stripped to empty, so no embedded newline → single-line.
-        assert!(!multiline);
+        assert_eq!(encode_pane_payload(""), b"");
+        // Edge case: trailing whitespace stripped to empty → no embedded newline → no markers.
+        assert_eq!(encode_pane_payload("\n\n"), b"");
     }
 
     #[test]

--- a/src/embedded_pane.rs
+++ b/src/embedded_pane.rs
@@ -35,6 +35,33 @@ struct Pane {
 /// Thread-safe pane registry.
 type PaneRegistry = Arc<Mutex<HashMap<String, Pane>>>;
 
+/// Encode the payload portion of a pane input (content + bracketed paste markers if
+/// multi-line) without the trailing submit byte. Trailing whitespace is stripped.
+///
+/// Returned tuple: `(bytes, is_multiline)`. The `is_multiline` flag tells the caller
+/// whether to insert a brief delay before sending the submit byte — agent TUIs like
+/// claude need a tick after the close marker to transition out of paste-review mode
+/// before they will honor a fresh Enter.
+fn encode_pane_payload(text: &str) -> (Vec<u8>, bool) {
+    let trimmed = text.trim_end_matches(['\n', '\r', ' ', '\t']);
+    let multiline = trimmed.contains('\n');
+    let mut out = Vec::with_capacity(trimmed.len() + 16);
+    if multiline {
+        out.extend_from_slice(b"\x1b[200~");
+        out.extend_from_slice(trimmed.as_bytes());
+        out.extend_from_slice(b"\x1b[201~");
+    } else {
+        out.extend_from_slice(trimmed.as_bytes());
+    }
+    (out, multiline)
+}
+
+/// Delay between writing input bytes and the submit CR. Agent TUIs like claude
+/// treat a CR that arrives fused to the preceding text as newline-in-input; only
+/// a CR that arrives as a separate event after a pause is honored as Enter. The
+/// same applies after a bracketed-paste close marker. 150ms tuned empirically.
+const SUBMIT_DELAY: std::time::Duration = std::time::Duration::from_millis(150);
+
 /// Embedded terminal pane controller using portable-pty + vt100.
 ///
 /// Replaces `ZellijController` by spawning PTY processes directly and parsing
@@ -441,20 +468,30 @@ impl PaneController for EmbeddedPaneController {
     }
 
     fn write_to_pane(&self, pane_id: &str, text: &str) -> Result<(), PaneError> {
-        let mut panes = self.panes.lock().unwrap();
-        if let Some(pane) = panes.get_mut(pane_id) {
-            pane.writer
-                .write_all(text.as_bytes())
-                .map_err(PaneError::Io)?;
-            // Send CR (Enter)
+        let (payload, _multiline) = encode_pane_payload(text);
+        // Write the payload (content, optionally bracketed-paste-wrapped), flush, then
+        // pause briefly before sending the submit CR. Agent TUIs like claude treat a
+        // CR that arrives fused to the preceding text as newline-in-input; only a CR
+        // that arrives as a separate event after a pause is honored as Enter. The
+        // pane lock is released during the sleep so the UI thread can keep drawing.
+        {
+            let mut panes = self.panes.lock().unwrap();
+            let pane = panes
+                .get_mut(pane_id)
+                .ok_or_else(|| PaneError::CommandFailed(format!("Pane {pane_id} not found")))?;
+            pane.writer.write_all(&payload).map_err(PaneError::Io)?;
+            pane.writer.flush().map_err(PaneError::Io)?;
+        }
+        std::thread::sleep(SUBMIT_DELAY);
+        {
+            let mut panes = self.panes.lock().unwrap();
+            let pane = panes
+                .get_mut(pane_id)
+                .ok_or_else(|| PaneError::CommandFailed(format!("Pane {pane_id} not found")))?;
             pane.writer.write_all(b"\r").map_err(PaneError::Io)?;
             pane.writer.flush().map_err(PaneError::Io)?;
-            Ok(())
-        } else {
-            Err(PaneError::CommandFailed(format!(
-                "Pane {pane_id} not found"
-            )))
         }
+        Ok(())
     }
 
     fn name(&self) -> &str {
@@ -543,6 +580,51 @@ mod tests {
         ctrl.write_to_pane(&id, "echo hello").unwrap();
 
         ctrl.close_pane(&id).unwrap();
+    }
+
+    #[test]
+    fn encode_pane_payload_single_line() {
+        let (bytes, multiline) = encode_pane_payload("ls -la");
+        assert_eq!(bytes, b"ls -la");
+        assert!(!multiline);
+    }
+
+    #[test]
+    fn encode_pane_payload_strips_trailing_whitespace() {
+        let (bytes, multiline) = encode_pane_payload("ls -la\n");
+        assert_eq!(bytes, b"ls -la");
+        assert!(!multiline);
+
+        let (bytes, multiline) = encode_pane_payload("ls -la  \n\n");
+        assert_eq!(bytes, b"ls -la");
+        assert!(!multiline);
+    }
+
+    #[test]
+    fn encode_pane_payload_wraps_multiline() {
+        let (bytes, multiline) = encode_pane_payload("line1\nline2\nline3");
+        assert_eq!(bytes, b"\x1b[200~line1\nline2\nline3\x1b[201~");
+        assert!(multiline);
+    }
+
+    #[test]
+    fn encode_pane_payload_multiline_with_trailing_newline() {
+        // Trailing newline is stripped, but embedded newlines still trigger paste wrapping.
+        let (bytes, multiline) = encode_pane_payload("line1\nline2\n");
+        assert_eq!(bytes, b"\x1b[200~line1\nline2\x1b[201~");
+        assert!(multiline);
+    }
+
+    #[test]
+    fn encode_pane_payload_empty() {
+        let (bytes, multiline) = encode_pane_payload("");
+        assert_eq!(bytes, b"");
+        assert!(!multiline);
+
+        let (bytes, multiline) = encode_pane_payload("\n\n");
+        assert_eq!(bytes, b"");
+        // Edge case: stripped to empty, so no embedded newline → single-line.
+        assert!(!multiline);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -445,6 +445,11 @@ impl NewPaneFormState {
     }
 }
 
+/// How long status-bar messages stay visible before clearing. Long enough that
+/// errors (e.g. orchestration spawn failures) are readable, short enough that
+/// transient info messages don't linger past their usefulness.
+const STATUS_MESSAGE_TTL: std::time::Duration = std::time::Duration::from_secs(15);
+
 /// A prompt queued for injection into a pane once its agent is ready.
 /// Used by M5 delegation dispatch when `clear = true` restarts a pane.
 struct PendingDispatch {
@@ -1018,7 +1023,6 @@ fn feedback_worker_results(
             .unwrap_or_else(|| "unknown".to_string());
 
         // Build feedback prompt: one-liner pointing to the work-done file.
-        // Must be single-line so write_to_pane submits it correctly.
         let safe_name = sanitize_role_name(&role_name);
         let feedback = format!(
             "Worker {safe_name} has completed their task. Read .dot-agent-deck/work-done-{safe_name}.md for their full report."
@@ -2047,7 +2051,7 @@ pub fn run_tui(
     'outer: loop {
         // Expire stale status messages
         if let Some((_, created)) = &ui.status_message
-            && created.elapsed() > std::time::Duration::from_secs(3)
+            && created.elapsed() > STATUS_MESSAGE_TTL
         {
             ui.status_message = None;
         }
@@ -3167,11 +3171,11 @@ pub fn run_tui(
                                             .insert(*id, std::time::Instant::now());
                                     }
 
-                                    // Start role commands after resize.
-                                    for (i, role) in orch_config.roles.iter().enumerate() {
-                                        let _ =
-                                            pane.write_to_pane(&role_pane_ids[i], &role.command);
-                                    }
+                                    // Role commands are already running — each pane was
+                                    // spawned with `role.command` as its initial process
+                                    // (see TabManager::open_orchestration_tab in tab.rs).
+                                    // Writing the command again here would land its bytes
+                                    // in the agent's stdin, polluting the prompt buffer.
 
                                     ui.status_message = Some((
                                         format!("Activated orchestration: {}", orch_config.name),
@@ -5980,9 +5984,14 @@ mod tests {
 
     #[test]
     fn dir_picker_enter_confirms_when_no_subdirs() {
+        // Use a fresh tempdir for current_dir so load_project_config can't
+        // pick up a stray .dot-agent-deck.toml from /tmp on the host.
+        let tmp = tempfile::tempdir().unwrap();
         let mut ui = default_ui();
         ui.mode = UiMode::DirPicker;
-        ui.dir_picker = Some(make_dir_picker(&[".."]));
+        let mut picker = make_dir_picker(&[".."]);
+        picker.current_dir = tmp.path().to_path_buf();
+        ui.dir_picker = Some(picker);
 
         handle_dir_picker_key(
             KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE),
@@ -7414,6 +7423,21 @@ mod tests {
 
     #[test]
     fn config_gen_prompt_enter_on_never_suppresses_dir() {
+        // Picking "Never" calls suppress_dir() → save(), which reads
+        // DOT_AGENT_DECK_CONFIG_GEN_STATE. Hold the shared lock and point at
+        // a temp path so we don't race against other tests touching the same
+        // env var, and don't pollute the real home dir.
+        let _guard = crate::config::CONFIG_GEN_STATE_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config-gen-state.json");
+        let prev = std::env::var("DOT_AGENT_DECK_CONFIG_GEN_STATE").ok();
+        // SAFETY: env-var lock held for the duration of this test.
+        unsafe {
+            std::env::set_var("DOT_AGENT_DECK_CONFIG_GEN_STATE", path.to_str().unwrap());
+        }
+
         let mut ui = default_ui();
         ui.mode = UiMode::ConfigGenPrompt;
         ui.config_gen_selected = 2; // Never
@@ -7427,6 +7451,14 @@ mod tests {
         assert!(ui.config_gen_state.is_suppressed("/my/project"));
         assert!(matches!(result, KeyResult::Continue));
         assert!(ui.status_message.is_some());
+
+        // SAFETY: env-var lock held; restore prior value.
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("DOT_AGENT_DECK_CONFIG_GEN_STATE", v),
+                None => std::env::remove_var("DOT_AGENT_DECK_CONFIG_GEN_STATE"),
+            }
+        }
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7432,11 +7432,8 @@ mod tests {
             .unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("config-gen-state.json");
-        let prev = std::env::var("DOT_AGENT_DECK_CONFIG_GEN_STATE").ok();
-        // SAFETY: env-var lock held for the duration of this test.
-        unsafe {
-            std::env::set_var("DOT_AGENT_DECK_CONFIG_GEN_STATE", path.to_str().unwrap());
-        }
+        // Drop guard restores the env var even if an assertion below panics.
+        let _env_restore = crate::config::ConfigGenStateEnvGuard::set(path.to_str().unwrap());
 
         let mut ui = default_ui();
         ui.mode = UiMode::ConfigGenPrompt;
@@ -7451,14 +7448,6 @@ mod tests {
         assert!(ui.config_gen_state.is_suppressed("/my/project"));
         assert!(matches!(result, KeyResult::Continue));
         assert!(ui.status_message.is_some());
-
-        // SAFETY: env-var lock held; restore prior value.
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("DOT_AGENT_DECK_CONFIG_GEN_STATE", v),
-                None => std::env::remove_var("DOT_AGENT_DECK_CONFIG_GEN_STATE"),
-            }
-        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **File-based config-gen prompt**: extracted the prompt template to `assets/config_gen_prompt.md` and the orchestration role library to `assets/roles.toml`. `src/config_gen.rs` loads them via `include_str!` so the prompt is editable as plain markdown instead of a Rust string literal. Includes guidance on agent-launcher discovery, semantic role-to-launcher matching (with the full invocation form), default release-worker inclusion when release-flow signals exist, and context-handoff rules for the orchestrator.
- **Reliable prompt submit in `EmbeddedPaneController::write_to_pane`**: multi-line input is now wrapped in bracketed paste (`ESC[200~ … ESC[201~`) so embedded `\n` is treated as input rather than a premature submit, and a 150ms pause sits between the payload and the trailing CR. Without the pause, agent CLIs like Claude Code render the CR as a newline and leave the prompt sitting un-submitted.
- **Removed duplicate role-command write at orchestration startup** (`src/ui.rs`). Each role pane is already spawned with `role.command` as its initial process via `TabManager::open_orchestration_tab`; the redundant `write_to_pane(role.command)` after resize was landing the bytes in the just-launched agent's input field, prepending the role command to the orchestrator prompt that arrived next.
- **Status-bar TTL bumped from 3s to 15s** so wrapped error messages (e.g. orchestration spawn failures) stay on screen long enough to read.
- **Updated bundled `.dot-agent-deck.toml`** to match the new role-library wording, add a `release` role with `clear = false`, and include the context-handoff section in the orchestrator's prompt template.
- **`CONFIG_GEN_STATE_ENV_LOCK`** so config-gen tests don't race on `DOT_AGENT_DECK_CONFIG_GEN_STATE`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — 406 passed
- [x] Manually verified `Ctrl+G` config generation in a Claude Code pane self-submits without requiring a manual Enter
- [x] Manually verified orchestration startup: orchestrator prompt arrives clean (no role-command prefix) and self-submits
- [ ] Re-test orchestration delegation flow end-to-end (coder → reviewer + auditor in parallel) on a real PRD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role library configuration system for agent orchestration.
  * Status messages now display for 15 seconds instead of 3 for better visibility.

* **Improvements**
  * Refined agent workflow constraints for orchestrator and worker roles.
  * Enhanced input processing for agent command submissions.
  * Updated git command display in UI panes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->