### PR TITLE
chore: prepare release v0.24.4

### DIFF
--- a/changelog.d/fix-docs-port-leak.bugfix.md
+++ b/changelog.d/fix-docs-port-leak.bugfix.md
@@ -1,0 +1,3 @@
+## Docs site port leak in directory redirects
+
+Clicking links like `/docs/installation` (no trailing slash) on the public docs site no longer bounces users to a non-routable `http://agent-deck.devopstoolkit.ai:8080/...` URL. The docs container now ships a custom nginx config that disables `absolute_redirect` and `port_in_redirect`, so directory 301 redirects emit relative `Location` headers and the upstream Gateway's host, scheme, and port are preserved.

--- a/changelog.d/fix-docs-port-leak.fix.md
+++ b/changelog.d/fix-docs-port-leak.fix.md
@@ -1,4 +1,0 @@
-### Fixed
-
-- **Docs site port leak in directory redirects**
-  Clicking links like `/docs/installation` (no trailing slash) on the public docs site no longer bounces users to a non-routable `http://agent-deck.devopstoolkit.ai:8080/...` URL. The docs container now ships a custom nginx config that disables `absolute_redirect` and `port_in_redirect`, so directory 301 redirects emit relative `Location` headers and the upstream Gateway's host, scheme, and port are preserved.

--- a/changelog.d/fix-opencode-plugin-xdg-path.bugfix.md
+++ b/changelog.d/fix-opencode-plugin-xdg-path.bugfix.md
@@ -1,0 +1,3 @@
+## OpenCode worker status updates not appearing on dashboard cards
+
+On systems where OpenCode 1.x is installed under the XDG layout (`~/.config/opencode/` instead of legacy `~/.opencode/`), the dashboard's auto-installer never wrote its plugin, so `session.*` and `tool.execute.*` events from OpenCode workers never reached the daemon and card statuses stayed frozen on their initial state. The installer now resolves the active OpenCode root by checking XDG first (`$XDG_CONFIG_HOME/opencode`, defaulting to `~/.config/opencode`) and falling back to `~/.opencode`. Explicit `dot-agent-deck hooks install --agent opencode` targets the detected root or the XDG default; uninstall sweeps both layouts.

--- a/changelog.d/fix-opencode-plugin-xdg-path.fix.md
+++ b/changelog.d/fix-opencode-plugin-xdg-path.fix.md
@@ -1,4 +1,0 @@
-### Fixed
-
-- **OpenCode worker status updates not appearing on dashboard cards**
-  On systems where OpenCode 1.x is installed under the XDG layout (`~/.config/opencode/` instead of legacy `~/.opencode/`), the dashboard's auto-installer never wrote its plugin, so `session.*` and `tool.execute.*` events from OpenCode workers never reached the daemon and card statuses stayed frozen on their initial state. The installer now resolves the active OpenCode root by checking XDG first (`$XDG_CONFIG_HOME/opencode`, defaulting to `~/.config/opencode`) and falling back to `~/.opencode`. Explicit `dot-agent-deck hooks install --agent opencode` targets the detected root or the XDG default; uninstall sweeps both layouts.

--- a/scripts/assemble-changelog.sh
+++ b/scripts/assemble-changelog.sh
@@ -24,6 +24,32 @@ declare -A TYPE_HEADERS=(
 # Ordered list of types to scan — earlier entries appear first in the changelog.
 TYPES=(breaking added feature changed fixed bugfix removed doc misc)
 
+# Fail loudly if changelog.d/ contains fragments with unrecognized suffixes,
+# rather than silently skipping them. (v0.24.3 shipped with `*.fix.md` fragments
+# that were ignored because only `*.bugfix.md`/`*.fixed.md` are recognized,
+# leaving the GitHub release body and CHANGELOG.md empty for that version.)
+if [ -d "$CHANGELOG_DIR" ]; then
+  unknown_fragments=()
+  while IFS= read -r -d '' f; do
+    name="$(basename "$f")"
+    [[ "$name" == ".gitkeep" ]] && continue
+    matched=false
+    for type in "${TYPES[@]}"; do
+      [[ "$name" == *.${type}.md ]] && { matched=true; break; }
+    done
+    $matched || unknown_fragments+=("$name")
+  done < <(find "$CHANGELOG_DIR" -maxdepth 1 -name '*.md' -print0 2>/dev/null)
+
+  if [ ${#unknown_fragments[@]} -gt 0 ]; then
+    echo "ERROR: changelog.d/ contains fragments with unrecognized type suffix:" >&2
+    printf '  %s\n' "${unknown_fragments[@]}" >&2
+    echo >&2
+    echo "Recognized types: ${TYPES[*]}" >&2
+    echo "Rename each fragment so its suffix matches one of the recognized types (e.g. '.bugfix.md', '.feature.md')." >&2
+    exit 1
+  fi
+fi
+
 section=""
 processed_files=()
 seen_headers=()


### PR DESCRIPTION
## Summary

Prep work for cutting release v0.24.4. Two changes:

1. **Rename + reformat changelog fragments** (`changelog.d/`):
   - `fix-docs-port-leak.fix.md` → `fix-docs-port-leak.bugfix.md`
   - `fix-opencode-plugin-xdg-path.fix.md` → `fix-opencode-plugin-xdg-path.bugfix.md`
   - Both rewritten from `### Fixed` + `- **Title**` bullet form to the canonical `## Title` + body form expected by `scripts/assemble-changelog.sh`.

2. **Harden `scripts/assemble-changelog.sh`** to fail fast on unrecognized fragment suffixes instead of silently skipping them.

## Why

The v0.24.3 release shipped with an empty GitHub release body and no `CHANGELOG.md` entry. Root cause: `fix-docs-port-leak.fix.md` used the unrecognized `.fix` suffix, and the assembler globbed only for known suffixes (`*.bugfix.md`, `*.fixed.md`, etc.), so the fragment was silently dropped — `git diff --cached --quiet` then saw nothing to commit and the workflow's `$CHANGELOG` output was empty.

The renamed `fix-docs-port-leak.bugfix.md` will be picked up when v0.24.4 is tagged, so the missed fix gets release notes one release late.

The new guard in `assemble-changelog.sh` scans `changelog.d/*.md` up front and exits with an error listing any unrecognized files. If this had been in place when v0.24.3 was released, the workflow would have failed loudly instead of producing an empty release.

## Test plan

- [ ] CI green (build, security, label, CodeRabbit)
- [ ] After merge: tag `v0.24.4`, verify release workflow assembles a non-empty CHANGELOG entry covering both fragments and removes them from `changelog.d/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)