### PR TITLE
fix: clear status message when Ctrl+d returns to Normal mode

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2801,6 +2801,7 @@ pub fn run_tui(
                             );
                         }
                         ui.mode = UiMode::Normal;
+                        ui.status_message = None;
                         shortcut_handled = true;
                     }
                     // Ctrl+t: toggle layout


### PR DESCRIPTION
## Summary

- When `Ctrl+d` exits PaneInput mode and returns to Normal mode, the previous status message (`"PaneInput mode — type to interact, Ctrl+d for dashboard"`) was not cleared
- The status bar renders the stale message instead of the Normal mode navigation hints for up to **15 seconds** (the `STATUS_MESSAGE_TTL`)
- This one-line fix sets `ui.status_message = None` on transition so the hints appear immediately

## Root cause

In `run_tui`, the `Ctrl+d` handler sets `ui.mode = UiMode::Normal` but never cleared `ui.status_message`. The render path checks for a status message first and skips the hint bar if one exists, so the user had no visual feedback that they were back in Normal mode until the TTL expired.

## Test plan

- [ ] Press a number key (e.g. `1`) to focus a pane — status bar shows "PaneInput mode — type to interact, Ctrl+d for dashboard"
- [ ] Press `Ctrl+d` — Normal mode navigation hints should appear **immediately** in the status bar, not after a delay
- [ ] Confirm `?`, `j/k`, `Ctrl+n`, etc. hints are visible right away

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Status messages are now properly cleared when returning to normal mode using the keyboard shortcut.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vfarcic/dot-agent-deck/pull/85)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->