### PR TITLE
fix: preserve WaitingForInput status when concurrent subagent fires ToolStart

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -286,7 +286,9 @@ impl AppState {
                 session.active_tool = None;
             }
             EventType::ToolStart => {
-                session.status = SessionStatus::Working;
+                if session.status != SessionStatus::WaitingForInput {
+                    session.status = SessionStatus::Working;
+                }
                 session.active_tool = Some(ActiveTool {
                     name: event.tool_name.clone().unwrap_or_default(),
                     detail: event.tool_detail.clone(),
@@ -513,6 +515,38 @@ mod tests {
     }
 
     #[test]
+    fn toolstart_does_not_override_waiting_for_input() {
+        // Regression: a concurrent subagent firing PreToolUse while a permission
+        // prompt is active must not knock the status back to Working.
+        let mut state = AppState::default();
+        state.apply_event(make_event("s1", EventType::SessionStart));
+
+        state.apply_event(make_event("s1", EventType::PermissionRequest));
+        assert_eq!(state.sessions["s1"].status, SessionStatus::WaitingForInput);
+
+        let mut subagent_tool = make_event("s1", EventType::ToolStart);
+        subagent_tool.tool_name = Some("Explore".to_string());
+        state.apply_event(subagent_tool);
+        assert_eq!(
+            state.sessions["s1"].status,
+            SessionStatus::WaitingForInput,
+            "ToolStart must not override WaitingForInput"
+        );
+    }
+
+    #[test]
+    fn toolstart_sets_working_when_not_waiting() {
+        // Normal flow: ToolStart should still set Working when no permission prompt.
+        let mut state = AppState::default();
+        state.apply_event(make_event("s1", EventType::SessionStart));
+
+        let mut tool_start = make_event("s1", EventType::ToolStart);
+        tool_start.tool_name = Some("Bash".to_string());
+        state.apply_event(tool_start);
+        assert_eq!(state.sessions["s1"].status, SessionStatus::Working);
+    }
+
+    #[test]
     fn tool_end_preserves_working_status() {
         let mut state = AppState::default();
         state.apply_event(make_event("s1", EventType::SessionStart));
@@ -714,7 +748,7 @@ mod tests {
     }
 
     #[test]
-    fn tool_start_clears_waiting_for_input() {
+    fn tool_start_preserves_waiting_for_input() {
         let mut state = AppState::default();
         state.apply_event(make_event("s1", EventType::SessionStart));
         state.apply_event(make_event("s1", EventType::WaitingForInput));
@@ -723,7 +757,7 @@ mod tests {
         let mut tool_start = make_event("s1", EventType::ToolStart);
         tool_start.tool_name = Some("Bash".into());
         state.apply_event(tool_start);
-        assert_eq!(state.sessions["s1"].status, SessionStatus::Working);
+        assert_eq!(state.sessions["s1"].status, SessionStatus::WaitingForInput);
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -532,6 +532,11 @@ mod tests {
             SessionStatus::WaitingForInput,
             "ToolStart must not override WaitingForInput"
         );
+        assert_eq!(
+            state.sessions["s1"].active_tool.as_ref().map(|t| t.name.as_str()),
+            Some("Explore"),
+            "active_tool must still be updated even when status is preserved"
+        );
     }
 
     #[test]
@@ -544,6 +549,11 @@ mod tests {
         tool_start.tool_name = Some("Bash".to_string());
         state.apply_event(tool_start);
         assert_eq!(state.sessions["s1"].status, SessionStatus::Working);
+        assert_eq!(
+            state.sessions["s1"].active_tool.as_ref().map(|t| t.name.as_str()),
+            Some("Bash"),
+            "active_tool must be set on normal ToolStart"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #43

## Root cause

`ToolStart` (fired by `PreToolUse`) unconditionally set `session.status = Working`, so whenever a subagent ran a tool concurrently with a permission prompt, the dashboard card would flip from **Needs Input** back to **Working** — hiding the prompt from the user.

## Fix

Added a single guard in the `ToolStart` handler in `src/state.rs`:

```rust
if session.status != SessionStatus::WaitingForInput {
    session.status = SessionStatus::Working;
}
```

`active_tool` is still updated regardless, so the tool name display is unaffected.

## Tests

- Updated `tool_start_clears_waiting_for_input` → `tool_start_preserves_waiting_for_input` (was asserting the buggy behaviour)
- Added `toolstart_does_not_override_waiting_for_input` — fires `PermissionRequest` then `ToolStart`, asserts status stays `WaitingForInput`
- Added `toolstart_sets_working_when_not_waiting` — confirms normal `ToolStart → Working` flow is unchanged

## Test results

411 passing (same as main). The `embedded_pane` failures are pre-existing and require real PTY processes to spawn — they also fail on unmodified main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool start events no longer override a session’s "waiting for input" state; sessions preserve waiting status when appropriate while still updating the active tool.
* **Tests**
  * Added regression tests and renamed an existing test to verify preservation of "waiting for input" during permission prompts and correct transition to "working" otherwise.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vfarcic/dot-agent-deck/pull/86)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->