### PR TITLE
docs(prds): create PRDs #99 and #100

### DIFF
--- a/prds/100-fix-orchestrator-enter-key-newline.md
+++ b/prds/100-fix-orchestrator-enter-key-newline.md
@@ -1,0 +1,102 @@
+# PRD #100: Fix Enter-Key Intermittently Inserting Newline Instead of Submitting to Orchestrator
+
+**Status**: Planning
+**Priority**: High
+**Created**: 2026-05-21
+**GitHub Issue**: [#100](https://github.com/vfarcic/dot-agent-deck/issues/100)
+**Related**: PRD #24 (Send Prompt to Agent — uses `zellij action write 10` for newline), PRD #58 / #82 (orchestrator role), PRD #93 (always-external daemon — will collapse the local/remote split that may be hiding the bug)
+
+## Problem Statement
+
+When a user sends a message to the orchestrator agent via the deck's send-prompt path, **pressing Enter sometimes inserts a newline into the orchestrator's input box instead of submitting the message**. The user observes:
+
+- The text content lands in the orchestrator's input correctly — the write path is not dropping characters.
+- The trailing Enter does not always trigger submission. When it fails, the user sees the cursor drop to a new line inside the same input box, with the text still un-submitted.
+- The failure is **intermittent**. There is no known reproducer; sometimes the same flow works, sometimes it does not. The user has not yet identified a pattern (e.g. message length, timing, orchestrator state).
+- The bug has been observed **only with the orchestrator role**, not with other agents (Claude Code, OpenCode) in the dashboard.
+- The bug has only been tested **while running through the daemon**. Whether it reproduces in the in-process / local path is unknown (and PRD #93 is on track to eliminate that split, so this distinction may become moot — but it is data worth collecting now).
+
+The practical consequence: orchestration runs are the longest, most expensive interactions the user has with the deck, and the kickoff step — pressing Enter to dispatch the prompt — silently fails some fraction of the time. The user discovers it only by glancing at the orchestrator pane, deleting the stray newline, and pressing Enter again. This is the worst point in the workflow for an intermittent input failure.
+
+## Solution Overview
+
+This is a bug PRD, not a feature PRD. The solution shape depends on what the investigation finds. The PRD is structured around **investigation first, fix second** — explicitly, because guessing at causes for an intermittent bug wastes time.
+
+Three leading hypotheses, listed in rough order of likelihood:
+
+1. **Bracketed-paste framing eats the trailing Enter.** Many modern terminals support bracketed-paste mode (`\e[200~ ... \e[201~`). When an agent's input box is in bracketed-paste mode and the deck sends the prompt as a paste, an Enter inside the paste is treated as a literal newline, not a submit. If the daemon's pane-write path emits the prompt with bracketed-paste sequences (or if it does so under some conditions and not others), this matches the symptom precisely — including the intermittent character.
+2. **`\n` vs `\r` framing inconsistency on the daemon write path.** PRD #24 documents using `zellij action write 10` to send a newline. Most TTY apps treat `\r` (CR, 13) as "submit" and `\n` (LF, 10) as "newline". If the daemon path sometimes emits 10 and sometimes 13 (or sometimes both, sometimes neither), Claude Code and OpenCode may be lenient about it while the orchestrator's input mode is strict.
+3. **Orchestrator-UI input-mode race.** The orchestrator may have a multi-line input mode it toggles into transiently. If the Enter arrives during a window where the UI is in multi-line mode, the keystroke is interpreted as a newline. This would explain why only the orchestrator is affected (other agents have simpler single-line submit semantics).
+
+These are hypotheses, not conclusions. Investigation in Phase 1 nails down which (if any) is the actual cause, and the fix is sized accordingly.
+
+## Scope
+
+### In Scope
+
+- **Reproduce the bug deterministically.** Build a reproducer that fails reliably enough to bisect. May involve instrumenting the daemon write path to log every byte sent, and the orchestrator pane to log every byte received.
+- **Identify root cause.** Confirm one of the three hypotheses (or surface a new one) with evidence.
+- **Fix at the lowest correct layer.** If it is bracketed-paste, fix the daemon write path. If it is `\n` vs `\r`, normalize. If it is the orchestrator UI, fix the input-mode logic.
+- **Regression test.** Add a test that fails before the fix and passes after, exercising the path through the daemon — not just an in-process unit test, since the bug is daemon-specific so far.
+- **Investigate whether the bug exists in the local (in-process) path.** If yes, document; if no, note that PRD #93's unification will need to keep the daemon-only fix in place.
+
+### Out of Scope
+
+- **Broad refactor of the orchestrator UI** beyond what is needed to fix this bug. PRD #82 covers orchestrator role-reinforcement work; this PRD only touches input handling.
+- **Adding new keybindings or customization** of submit vs newline. PRD #40 (customizable keybindings) and the broader chat-UI customization conversation handle that.
+- **Fixing the same class of bug for non-orchestrator agents.** They have not been reported as broken. If the investigation reveals the same underlying mechanism could affect them, that goes in a follow-up.
+- **Pre-emptively switching the entire write path to `expect`-style explicit framing.** If a small targeted fix works, ship it; do not gold-plate.
+
+## Success Criteria
+
+- A reproducer exists and is documented (steps or test) that triggered the bug reliably **before** the fix.
+- After the fix, the same reproducer no longer triggers the bug — verified across N runs (N to be set in M2; rough target: 100 consecutive sends with zero newline-instead-of-submit).
+- The fix is covered by an automated test in the daemon-path test suite. The test fails on `main` without the fix and passes with the fix applied.
+- The root cause is documented in the PRD's "Root cause" section (added during Phase 2) so future investigators have an audit trail.
+- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass. `cargo test` passes.
+- Manual smoke: a long-form orchestrator prompt sent through the daemon submits on first Enter, 10 consecutive times.
+
+## Milestones
+
+### Phase 1: Investigation and reproducer
+
+- [ ] **M1.1** — Instrument the daemon's pane-write path to log every byte sent to a pane, with a feature flag or `RUST_LOG=trace` gate so the instrumentation can stay in tree. Confirm whether bracketed-paste sequences (`\e[200~ ... \e[201~`) are present and whether the trailing byte is `\n` (10), `\r` (13), or both.
+- [ ] **M1.2** — Build a deterministic reproducer. Try the obvious axes first: very long messages, messages with embedded newlines, rapid back-to-back sends, sends immediately after the orchestrator pane mounts, sends while another role pane is animating. Document what triggers the bug.
+- [ ] **M1.3** — Determine whether the bug exists in the local (in-process) path or only the daemon path. This is one data point that helps localize the cause and informs PRD #93's regression surface.
+
+### Phase 2: Root cause and fix
+
+- [ ] **M2.1** — Document the root cause in this PRD (add a "Root cause" section). Cite the evidence from M1.
+- [ ] **M2.2** — Implement the fix at the smallest layer that resolves it. Likely one of: daemon write path normalization, orchestrator UI input-mode guard, or removing bracketed-paste framing on the send-prompt path.
+- [ ] **M2.3** — Decide and document the fix's scope: orchestrator-only, all-agents, or a layer that incidentally fixes both.
+
+### Phase 3: Tests and validation
+
+- [ ] **M3.1** — Add an automated regression test that exercises the daemon write path and asserts the submit actually fires (i.e. the orchestrator processed the message, not just that bytes were written). Test must fail before the fix.
+- [ ] **M3.2** — Run the M1.2 reproducer 100 consecutive times against the fixed build; confirm zero failures.
+- [ ] **M3.3** — Verify no regression for other agents (Claude Code, OpenCode) — run the existing send-prompt tests and a manual smoke through each agent type.
+
+### Phase 4: Docs and release
+
+- [ ] **M4.1** — Changelog fragment via `dot-ai-changelog-fragment`. Frame as a bug fix — "fix Enter sometimes inserting newline instead of submitting in the orchestrator pane".
+- [ ] **M4.2** — Note in the PRD #93 dependency graph if any of this work should be folded into the unification, or if the fix lands on both paths cleanly.
+- [ ] **M4.3** — PR, review, audit, merge, close.
+
+## Key Files (preliminary — confirm during M1)
+
+- `src/embedded_pane.rs` — pane write path, framing.
+- `src/daemon.rs` — daemon-side handling of write commands.
+- `src/orchestrator/` (per PRD #58 / #82) — orchestrator UI input handling, if the bug turns out to live there.
+- `src/pane.rs` / send-prompt write path from PRD #24.
+- `tests/` — wherever daemon-path send tests live (or a new test module if none).
+
+## Risks and Mitigations
+
+- **Risk**: The bug is genuinely non-deterministic (true race) and the reproducer never gets to 100%. Then the success criterion of "100 consecutive runs without failure" is the wrong bar.
+  - *Mitigation*: If M1.2 cannot get above ~90% repro rate, escalate: pair the byte-level instrumentation with the actual fix attempt and verify by inspection of the byte stream rather than by statistical pass count. Update success criteria with reasoning.
+- **Risk**: The fix on the daemon path conflicts with PRD #93's restructure.
+  - *Mitigation*: Coordinate with PRD #93 — if the structural fix is small, land here first and PRD #93 carries it forward; if it's invasive, fold this PRD's fix into PRD #93's branch.
+- **Risk**: Fix turns out to be in the orchestrator agent's *own* input handling (i.e. upstream code we don't own).
+  - *Mitigation*: If that is the case, M2.2 becomes "send the byte sequence the upstream agent expects" rather than "patch the upstream". Document the dependency and the workaround.
+- **Risk**: Investigation reveals other agents have the same latent bug and just haven't been reported.
+  - *Mitigation*: Document and open a follow-up issue; do not expand this PRD's scope unilaterally.

--- a/prds/99-orchestrator-completion-notifications.md
+++ b/prds/99-orchestrator-completion-notifications.md
@@ -1,0 +1,110 @@
+# PRD #99: Orchestrator Completion Notifications (Pluggable Channels)
+
+**Status**: Planning
+**Priority**: Medium
+**Created**: 2026-05-21
+**GitHub Issue**: [#99](https://github.com/vfarcic/dot-agent-deck/issues/99)
+**Related**: PRD #8 (terminal bell — local, per-session), PRD #58 / #82 (multi-role orchestration), PRD #78 (tab-level status indicators)
+
+## Problem Statement
+
+Orchestrator runs in `dot-agent-deck` can be long — a single orchestration may delegate work to several roles, each running for minutes to hours, before the orchestrator finalizes. During that time the user is typically not staring at the TUI. The deck has a terminal bell (PRD #8) that fires on per-session state transitions, but it has two limitations that make it the wrong tool for "orchestrator done":
+
+1. **It is local to the terminal.** The bell only reaches a user whose terminal window is focused (or whose terminal is configured to bounce the dock / flash the taskbar). A user on a different machine, in another tab, or away from the keyboard gets nothing.
+2. **It fires per-session, not per-orchestration.** When an orchestrator delegates to three roles, the user gets bell events for each role's idle/waiting transitions. There is no single "the whole orchestration is finished" signal — the user has to infer it.
+
+The result: users start a long orchestrator run, walk away, and either come back too early (and waste a context switch) or too late (and stall the next iteration). There is no out-of-band signal that closes the loop.
+
+## Solution Overview
+
+Introduce a **notification layer** with three pieces:
+
+1. **A completion event source** in the orchestrator. The orchestrator already knows when a run starts and when it ends (PRD #58 establishes the lifecycle). This PRD adds an explicit "orchestrator run completed" event with metadata: which orchestration, success/failure, duration, summary text.
+2. **A pluggable `Notifier` trait** that takes a completion event and dispatches it. The trait surface is small: `fn notify(&self, event: &CompletionEvent) -> Result<()>`. Each channel (desktop, email, Slack, webhook, ...) is one implementation.
+3. **Per-user config** in `config.toml` that selects which channels are enabled and which events trigger them. Opt-in by default — no channel fires until the user configures it.
+
+The PRD ships **one channel first** to validate the layer end-to-end (recommended: desktop notification via the existing OS notification command, since it has no external dependencies and works for the common single-user-at-a-laptop case). Additional channels (webhook, Slack, email) are subsequent milestones — each is a self-contained `Notifier` implementation plus a config block, and can land independently.
+
+## Scope
+
+### In Scope
+
+- **`CompletionEvent` type** with fields: orchestration ID, started-at, ended-at, outcome (`Success | Failure { reason }`), role count, optional summary text.
+- **Emission point** in the orchestrator: a single hook that fires exactly once per orchestrator run, on terminal state (success, failure, user-cancelled).
+- **`Notifier` trait** and a dispatcher that fans the event out to all enabled notifiers. Errors from one notifier do not block the others; they are logged.
+- **Desktop notification channel** as the first concrete implementation. Uses `notify-rust` or a shelled-out OS command (`osascript` / `notify-send`) — final choice during M1.
+- **`config.toml` block** under `[notifications]` with `enabled = false` default and per-channel subtables. Reuses the existing config loading path.
+- **Tests**: unit tests for the dispatcher and the event-emission predicate; an integration test with a mock notifier verifying it fires exactly once per run.
+- **Docs**: a `docs/notifications.md` (or extension to an existing config doc) covering how to enable each channel and what the config looks like.
+
+### Out of Scope (this PRD)
+
+- **Per-role completion notifications.** This PRD is about the orchestrator as a whole. Per-role bells are already covered by PRD #8 in-terminal; per-role external notifications can be a follow-up if there is demand.
+- **Notifications for non-orchestrator events** (single-agent runs, hook events, status transitions). The trait is reusable, but wiring other event sources is future work.
+- **Bidirectional channels** (e.g. a Slack bot that can be replied to). One-way notification only.
+- **Per-orchestration channel routing** (e.g. "this run should notify Slack but not email"). Config is global; per-run overrides can come later.
+- **Cryptographic signing of webhooks** or other production-grade webhook hardening. We will document the basic shape; hardening is follow-up.
+
+## Success Criteria
+
+- A user with `[notifications.desktop] enabled = true` in `config.toml` receives an OS desktop notification within ~1 second of an orchestrator run reaching a terminal state.
+- The notification fires **exactly once** per orchestrator run, regardless of how many roles the orchestrator delegated to or how many state transitions occurred internally.
+- Disabling notifications (`[notifications] enabled = false`, or the channel-specific toggle) suppresses the notification with zero side effects on the orchestrator path.
+- A failing notifier (e.g. Slack webhook returns 500) does not crash the deck, does not block the orchestrator, and surfaces the error in the daemon log.
+- Adding a new channel requires adding one file (the `Notifier` impl) and one config sub-block — no changes to the orchestrator or dispatcher.
+- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass. `cargo test` passes including the new tests.
+
+## Open Questions (resolve during M1)
+
+1. **Which crate / mechanism for desktop notifications?** `notify-rust` is cross-platform but adds a dep; shelling out to `osascript` / `notify-send` is dep-free but platform-specific. Default recommendation: try `notify-rust` first; fall back to shell-out if it pulls in heavy transitive deps.
+2. **Where does the emission point live?** Probably in the orchestrator coordinator that already tracks role lifecycles (PRD #58). M1.1 includes locating the exact site.
+3. **Is "summary text" something the orchestrator can produce, or does it come from the user's prompt?** For v1, a generic "Orchestration <id> completed (<duration>)" is sufficient. Richer summaries can use the existing role-done content but are not required.
+4. **Order of channel rollout after desktop**: webhook (most flexible, easiest to test) → Slack (high user value but needs webhook URL story) → email (most setup overhead).
+
+## Milestones
+
+### Phase 1: Core layer + desktop channel
+
+- [ ] **M1.1** — Define `CompletionEvent` and locate the emission point in the orchestrator (PRD #58 / #82 coordinator). Confirm the event fires exactly once per terminal state.
+- [ ] **M1.2** — Implement the `Notifier` trait and a dispatcher that loads enabled notifiers from config and fans events out.
+- [ ] **M1.3** — Implement the desktop-notification `Notifier`. Decide between `notify-rust` and shell-out based on dep weight. Wire it to the dispatcher.
+- [ ] **M1.4** — Add the `[notifications]` block to `config.toml` schema with `enabled = false` default and a `[notifications.desktop]` subtable.
+
+### Phase 2: Additional channels
+
+- [ ] **M2.1** — Webhook channel: POSTs the `CompletionEvent` as JSON to a user-configured URL. Config: URL, optional bearer token header.
+- [ ] **M2.2** — Slack channel: sends a formatted message via incoming webhook URL. Config: webhook URL, optional channel override.
+- [ ] **M2.3** — Email channel: sends via SMTP. Config: SMTP host, port, credentials, from/to addresses. (Lowest priority — may defer if demand is low.)
+
+### Phase 3: Tests and validation
+
+- [ ] **M3.1** — Unit tests for the dispatcher: empty-config no-op, single-channel fan-out, multi-channel fan-out, failing-channel does-not-block-others.
+- [ ] **M3.2** — Integration test with a mock `Notifier` that asserts exactly-once delivery per orchestrator run.
+- [ ] **M3.3** — Manual validation: run a real orchestration with `[notifications.desktop] enabled = true` and confirm the desktop notification appears at the expected moment.
+
+### Phase 4: Docs and release
+
+- [ ] **M4.1** — Write `docs/notifications.md` (or extend an existing config doc) with per-channel setup instructions and config examples.
+- [ ] **M4.2** — Note in `docs/getting-started.mdx` that orchestrator completion notifications exist and link to the new doc.
+- [ ] **M4.3** — Changelog fragment via `dot-ai-changelog-fragment`. Frame as "you can now get notified when long orchestrator runs finish".
+- [ ] **M4.4** — PR, review, audit, merge, release.
+
+## Key Files
+
+- `src/orchestrator/` (per PRD #58 / #82) — emission point for the completion event.
+- `src/notifications/mod.rs` — new module: `CompletionEvent`, `Notifier` trait, dispatcher.
+- `src/notifications/desktop.rs` (M1.3), `src/notifications/webhook.rs` (M2.1), `src/notifications/slack.rs` (M2.2), `src/notifications/email.rs` (M2.3) — one file per channel.
+- `src/config.rs` — extend with `[notifications]` block.
+- `tests/notifications.rs` — dispatcher and exactly-once tests.
+- `docs/notifications.md` — new user-facing doc.
+
+## Risks and Mitigations
+
+- **Risk**: Cross-platform desktop notifications are fiddly (macOS Notification Center permissions, Linux daemon variations).
+  - *Mitigation*: Start with `notify-rust` (handles platform branching); document fallback if a user's OS blocks notifications.
+- **Risk**: A misconfigured webhook URL or unreachable SMTP server stalls the orchestrator shutdown.
+  - *Mitigation*: Dispatcher runs notifiers on a separate task with a short timeout; errors are logged but never propagate.
+- **Risk**: Scope creep — users will ask for per-role notifications, per-event channel routing, two-way Slack, etc.
+  - *Mitigation*: This PRD is explicit about the v1 surface (single completion event, global channel selection). Follow-ups get their own PRDs.
+- **Risk**: Notification spam if "completion" is defined too loosely (e.g. firing on every role's "done").
+  - *Mitigation*: M1.1 nails down the predicate: exactly one event per orchestrator run, on terminal state only.


### PR DESCRIPTION
## Summary

- PRD #99: Orchestrator completion notifications (pluggable channels) — adds an out-of-band signal when long orchestrator runs finish, behind a pluggable `Notifier` trait so channels (desktop, webhook, Slack, email) can ship incrementally.
- PRD #100: Fix Enter-key intermittently inserting newline instead of submitting to orchestrator — bug PRD scoping the investigation + fix for the daemon-path orchestrator submit failure.

Both PRDs are Planning-stage docs only; no code changes. PRD #100 is High priority (active bug), PRD #99 is Medium.

## Test plan

- [ ] No code changes — `[skip ci]` applied.
- [ ] PRD files render correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added product requirements for resolving intermittent Enter key submission issues in the orchestrator input interface
  * Added product requirements for new orchestrator completion notifications feature with desktop notification support as the initial implementation channel

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vfarcic/dot-agent-deck/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->