### PR TITLE
feat(prd-103): build-version handshake + daemon stop/restart

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -126,17 +126,28 @@ fn git_is_dirty() -> bool {
     !output.stdout.is_empty()
 }
 
-/// Parse `.git/HEAD` to extract the symbolic ref path (e.g. `refs/heads/main`).
-/// Returns `None` on detached HEAD (where HEAD contains a raw SHA — the
-/// existing `.git/HEAD` watch already covers that case) or when `.git/HEAD`
-/// is unreadable.
+/// Resolve the symbolic ref path HEAD points at (e.g. `refs/heads/main`)
+/// via `git symbolic-ref -q HEAD`. Returns `None` on detached HEAD (the
+/// existing HEAD watch already covers that case) or when git isn't
+/// available.
+///
+/// We can't read `.git/HEAD` directly: in a worktree, `.git` is a *file*
+/// containing `gitdir: ...`, not a directory, so the literal path
+/// points at nothing. `git symbolic-ref` handles both layouts uniformly
+/// and prints just the ref path (or fails silently with a non-zero exit
+/// when HEAD is detached).
 fn parse_head_ref_path() -> Option<String> {
-    let contents = std::fs::read_to_string(".git/HEAD").ok()?;
-    let trimmed = contents.trim();
-    let ref_path = trimmed.strip_prefix("ref:")?.trim();
+    let output = Command::new("git")
+        .args(["symbolic-ref", "-q", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let ref_path = String::from_utf8(output.stdout).ok()?.trim().to_string();
     if ref_path.is_empty() {
         None
     } else {
-        Some(ref_path.to_string())
+        Some(ref_path)
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -6,8 +6,61 @@ fn main() {
     let version = git_version().unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
     println!("cargo:rustc-env=DAD_VERSION={version}");
 
-    // Re-run if HEAD changes (new commit, new tag, checkout, etc.)
-    println!("cargo:rerun-if-changed=.git/HEAD");
+    // PRD #103 M1.0: emit a finer-grained build identifier alongside DAD_VERSION.
+    // Shape: `<DAD_VERSION>-g<short-sha>[-dirty]`, falling back to
+    // `<DAD_VERSION>-unknown` when git metadata is unavailable.
+    let build_id = compose_build_id(&version);
+    println!("cargo:rustc-env=DAD_BUILD_ID={build_id}");
+
+    // Re-run if HEAD changes (new commit, branch switch, detached-HEAD move).
+    // `.git/HEAD` alone is necessary but not sufficient on a normal branch —
+    // the file contents `ref: refs/heads/<branch>` don't change when commits
+    // land on that branch. PRD #103 M1.0 prescribes also watching the
+    // resolved ref file, the index (dirty/clean transitions), and
+    // packed-refs (post-`git gc` fallback).
+    //
+    // In a git worktree, `.git` is a *file* containing
+    // `gitdir: <main-repo>/.git/worktrees/<name>`, not a directory. The
+    // literal `.git/HEAD` / `.git/index` paths then point at nothing and
+    // `cargo:rerun-if-changed` silently no-ops, which means cached
+    // `DAD_BUILD_ID` doesn't invalidate on commit (violates PRD invariant
+    // 6). Resolve each path through `git rev-parse --git-path <name>` so
+    // we watch the real file under `.git/worktrees/<name>/...` (or the
+    // shared `commondir` for packed-refs). Fall back to the literal path
+    // only if `git rev-parse` fails — matches the existing degrade-to-
+    // unknown discipline elsewhere in this file.
+    emit_rerun_if_changed_git_path("HEAD");
+    emit_rerun_if_changed_git_path("index");
+    emit_rerun_if_changed_git_path("packed-refs");
+    if let Some(ref_path) = parse_head_ref_path() {
+        emit_rerun_if_changed_git_path(&ref_path);
+    }
+}
+
+/// Emit `cargo:rerun-if-changed` for a git-internal path resolved via
+/// `git rev-parse --git-path <relative>`. In a worktree this returns the
+/// real path under `.git/worktrees/<name>/...` (for HEAD/index) or the
+/// shared `commondir` for `packed-refs` and `refs/heads/<branch>`.
+///
+/// Falls back to the literal `.git/<relative>` path if `git rev-parse`
+/// fails (no git, shallow tarball, ...). Cargo's `rerun-if-changed`
+/// silently tolerates non-existent paths, so the fallback is harmless
+/// outside a real repo.
+fn emit_rerun_if_changed_git_path(relative: &str) {
+    let resolved = Command::new("git")
+        .args(["rev-parse", "--git-path", relative])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| format!(".git/{relative}"));
+    println!("cargo:rerun-if-changed={resolved}");
 }
 
 fn git_version() -> Option<String> {
@@ -35,5 +88,55 @@ fn git_version() -> Option<String> {
         Some(stripped.to_string())
     } else {
         None
+    }
+}
+
+/// Compose `<version>-g<short-sha>[-dirty]`, or `<version>-unknown` when
+/// git is not available. Mirrors the fallback discipline of `git_version`:
+/// any git failure degrades to the `-unknown` sentinel rather than aborting
+/// the build, so tarball / shallow-clone builds still produce a usable
+/// `DAD_BUILD_ID`.
+fn compose_build_id(version: &str) -> String {
+    let Some(short_sha) = git_short_sha() else {
+        return format!("{version}-unknown");
+    };
+    let dirty_suffix = if git_is_dirty() { "-dirty" } else { "" };
+    format!("{version}-g{short_sha}{dirty_suffix}")
+}
+
+fn git_short_sha() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    if sha.is_empty() { None } else { Some(sha) }
+}
+
+fn git_is_dirty() -> bool {
+    let Ok(output) = Command::new("git").args(["status", "--porcelain"]).output() else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    !output.stdout.is_empty()
+}
+
+/// Parse `.git/HEAD` to extract the symbolic ref path (e.g. `refs/heads/main`).
+/// Returns `None` on detached HEAD (where HEAD contains a raw SHA — the
+/// existing `.git/HEAD` watch already covers that case) or when `.git/HEAD`
+/// is unreadable.
+fn parse_head_ref_path() -> Option<String> {
+    let contents = std::fs::read_to_string(".git/HEAD").ok()?;
+    let trimmed = contents.trim();
+    let ref_path = trimmed.strip_prefix("ref:")?.trim();
+    if ref_path.is_empty() {
+        None
+    } else {
+        Some(ref_path.to_string())
     }
 }

--- a/changelog.d/103.bugfix.md
+++ b/changelog.d/103.bugfix.md
@@ -1,0 +1,9 @@
+## Stale-Daemon Version Skew Detection and `daemon stop`/`restart` Commands
+
+The local TUI now detects when it is connecting to a daemon built from a different commit and exits with a clear error message instead of silently misfiring. Previously, upgrading the `dot-agent-deck` binary while a daemon from the previous build was still running could cause delegate prompts to appear queued in the TUI but never progress — the stale daemon's handler code predated internal role-map schema changes, so orchestration silently no-op'd with no error visible to the user.
+
+A new `DAD_BUILD_ID` build variable (`<version>-g<short-sha>[-dirty]`, e.g. `0.25.0-g243b049`) is compiled into every binary. On startup, the TUI performs a build-version handshake with the local daemon and, on mismatch, prints a message naming both build IDs and exits non-zero — prompting the user to run `dot-agent-deck daemon stop` before relaunching. The same field is compared on remote connections (`probe_remote_protocol`), where a mismatch points at `remote upgrade` instead.
+
+Two new CLI subcommands make daemon lifecycle management safe and documented: `dot-agent-deck daemon stop` gracefully shuts down the local daemon (via `SIGTERM`, falling back to `SIGKILL` after 5 s with `--force`), refusing if managed agents are still alive unless `--force` is passed. `dot-agent-deck daemon restart` stops the daemon and lets the next TUI launch re-spawn it. Both commands discover the daemon PID via socket peer credentials (`SO_PEERCRED` on Linux, `LOCAL_PEERPID` on macOS) — an OS-level facility that works against any daemon version, including pre-handshake binaries.
+
+See the updated [Installation](https://devopstoolkit.ai/docs/ui/installation) and [Troubleshooting](https://devopstoolkit.ai/docs/ui/troubleshooting) docs for the recommended upgrade flow and recovery steps.

--- a/devbox.json
+++ b/devbox.json
@@ -23,8 +23,8 @@
       "agent-big":          ["claude --model opus"],
       "agent-orchestrator": ["claude --model opus"],
       "agent-coder":        ["claude --model opus"],
-      "agent-reviewer":     ["opencode --model openrouter/openai/gpt-5.5"],
-      "agent-auditor":      ["opencode --model openrouter/openai/gpt-5.5"],
+      "agent-reviewer":     ["claude --model opus"],
+      "agent-auditor":      ["claude --model opus"],
       "agent-release":      ["claude --model sonnet"],
       "oc-release":         ["opencode --model openai/gpt-5.4-mini"],
       "oc-kimi":            ["opencode --model openrouter/moonshotai/kimi-k2.6"]

--- a/devbox.json
+++ b/devbox.json
@@ -3,7 +3,6 @@
   "packages": [
     "vals@0.43.7",
     "go-task@3.48.0",
-    "nodejs@20",
     "kubernetes-helm@3.19.1",
     "git@2.53.0",
     "upcloud-cli@3.29.0",

--- a/devbox.lock
+++ b/devbox.lock
@@ -221,55 +221,6 @@
         }
       }
     },
-    "nodejs@20": {
-      "last_modified": "2026-03-27T11:17:38Z",
-      "plugin_version": "0.0.2",
-      "resolved": "github:NixOS/nixpkgs/832efc09b4caf6b4569fbf9dc01bec3082a00611#nodejs_20",
-      "source": "devbox-search",
-      "version": "20.20.2",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/vamh3ysrfc0qz2mdhh6klyi5ngaffl0q-nodejs-20.20.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/vamh3ysrfc0qz2mdhh6klyi5ngaffl0q-nodejs-20.20.2"
-        },
-        "aarch64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/b1i1izsybrhzifbrr84nbmw62fl07ia2-nodejs-20.20.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/b1i1izsybrhzifbrr84nbmw62fl07ia2-nodejs-20.20.2"
-        },
-        "x86_64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/yg5qivw8g8gxpc536kwc0fg73nviiv9l-nodejs-20.20.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/yg5qivw8g8gxpc536kwc0fg73nviiv9l-nodejs-20.20.2"
-        },
-        "x86_64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/1gw2r0h59vr5dzcilhg1xvzjqgn84f8b-nodejs-20.20.2",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/1gw2r0h59vr5dzcilhg1xvzjqgn84f8b-nodejs-20.20.2"
-        }
-      }
-    },
     "upcloud-cli@3.29.0": {
       "last_modified": "2026-04-23T13:07:47Z",
       "resolved": "github:NixOS/nixpkgs/01fbdeef22b76df85ea168fbfe1bfd9e63681b30#upcloud-cli",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,3 +46,42 @@ dot-agent-deck --help
 The first time you run `dot-agent-deck`, the binary auto-spawns a small per-user background daemon and connects to it over a Unix socket (under `$XDG_RUNTIME_DIR` when available, otherwise a per-uid path in `/tmp`). The same daemon is used for both local and remote (`dot-agent-deck connect`) sessions; there is no separate "local mode".
 
 The daemon outlives the TUI: detach the deck, your agents keep running, reattach later and they're still there. About 30 seconds after the TUI has detached *and* every managed agent is gone, the daemon exits on its own. Set `DOT_AGENT_DECK_IDLE_SHUTDOWN_SECS` to override the window (`0` keeps it up indefinitely).
+
+## Upgrading
+
+After upgrading the `dot-agent-deck` binary, just relaunch it:
+
+```bash
+dot-agent-deck
+```
+
+On every launch, the TUI performs a build-version handshake with the running daemon. If a daemon spawned by the previous version is still alive, the TUI detects the mismatch and prompts you in your terminal (the prompt itself names both build IDs and, when managed agents are running, lists them before you confirm). Press **S** to stop the stale daemon and continue — the TUI lazy-spawns a fresh one at the new version and continues into the dashboard. No separate command needed.
+
+If the TUI is not attached to a terminal (CI, scripts, piped stdout), it cannot prompt, so it prints a recovery hint to stderr and exits non-zero. In that case, run `dot-agent-deck daemon stop` explicitly before relaunching — see [Recycling the local daemon](#recycling-the-local-daemon) below.
+
+See [Troubleshooting › Delegate prompts silently no-op after an upgrade](troubleshooting.md#delegate-prompts-silently-no-op-after-an-upgrade) for the symptom you'll see if you ever connect to a stale daemon without seeing the prompt first.
+
+## Recycling the local daemon
+
+`dot-agent-deck daemon stop` shuts down the running daemon gracefully. Use it after a binary upgrade or any time you want to start a fresh daemon process.
+
+```bash
+dot-agent-deck daemon stop
+```
+
+- **Idempotent.** If no daemon is running, the command prints `no daemon running` and exits 0.
+- **Data-loss guard.** If managed agents are still alive, the command refuses with a list of agent IDs and exits non-zero — terminating the daemon would kill their PTYs. Detach the agents first (close their panes, or quit the TUI to detach the deck while keeping the agents running), or pass `--force`.
+- **Grace window.** Sends `SIGTERM` and polls for the socket to disappear for up to 5 seconds. With `--force`, escalates to `SIGKILL` after that window. A `SIGTERM` timeout without `--force` exits non-zero so you can re-run with `--force` consciously.
+
+```bash
+# Force shutdown even when managed agents are running. This kills the agents.
+dot-agent-deck daemon stop --force
+```
+
+`dot-agent-deck daemon restart` is a thin wrapper: it runs `daemon stop`, then returns. The next `dot-agent-deck` invocation lazy-spawns a fresh daemon (see [How it runs](#how-it-runs) above). `--force` works the same way.
+
+```bash
+dot-agent-deck daemon restart
+```
+
+> Stopping a *remote* daemon works differently — each remote attach has its own per-host daemon, governed by the lifecycle in [Remote Environments](remote-environments.md). The local `daemon stop` only touches the daemon on this machine.

--- a/docs/remote-environments.md
+++ b/docs/remote-environments.md
@@ -162,3 +162,4 @@ Agents emit hook events (delegate, work-done, etc.) by piping JSON to `dot-agent
 
 - [Remote Environment Requirements](remote-requirements.md) — what a host must provide before you can register it.
 - [Remote Recipes](remote-recipes.md) — provisioning snippets for common cloud and local-VM hosts.
+- [Installation › Recycling the local daemon](installation.md#recycling-the-local-daemon) — `dot-agent-deck daemon stop` is the local counterpart for recycling the daemon on your laptop after a binary upgrade. The remote lifecycle described above (per-attach daemon, ssh session governs cleanup) is independent.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -73,6 +73,45 @@ dot-agent-deck hooks uninstall --agent opencode   # OpenCode
 
 > **Note:** If you uninstall hooks manually, the next dashboard launch will re-install them automatically.
 
+## Delegate prompts silently no-op after an upgrade
+
+After upgrading the `dot-agent-deck` binary, the new TUI may attach to a daemon that was spawned by the *previous* version. The wire format stays compatible, but newer features (delegate role maps, orchestration tab fields, and similar internal refactors) silently no-op because the stale daemon doesn't know about the newer shape.
+
+### Symptom
+
+You upgrade `dot-agent-deck`, relaunch it, and delegate prompts arrive in the TUI as if they were queued — but the orchestration pipeline never moves. Other recently-added features may also fail to take effect without an obvious error.
+
+If you see this, you connected to the stale daemon without going through the version-mismatch prompt — either because an earlier `dot-agent-deck` version (pre-handshake) attached silently, or because the relaunch happened in a non-interactive context. Newer builds prompt you at launch (see *Why this happens* below).
+
+### Fix
+
+Relaunch `dot-agent-deck` from an interactive terminal:
+
+```bash
+dot-agent-deck
+```
+
+You'll see the mismatch prompt — press **S** to stop the stale daemon and continue. The TUI lazy-spawns a fresh daemon at the new binary's version on its way into the dashboard.
+
+If the relaunch is happening from a script, CI job, or piped context (no TTY), the TUI cannot prompt. Run `daemon stop` explicitly first:
+
+```bash
+dot-agent-deck daemon stop
+dot-agent-deck
+```
+
+If managed agents are still running and you cannot detach them first, pass `--force` to terminate them along with the daemon:
+
+```bash
+dot-agent-deck daemon stop --force
+```
+
+See [Installation › Recycling the local daemon](installation.md#recycling-the-local-daemon) for the full command reference, including the data-loss guard and exit codes.
+
+### Why this happens
+
+On every launch, the TUI performs a build-version handshake with the daemon. When it detects a mismatch *and* your terminal is interactive, it prompts you with both build IDs and a single-keystroke choice — press **S** to recycle the daemon and continue, or **Q** to abort. (If managed agents are running, the prompt itself lists them and warns before you confirm.) When the TUI is not attached to a terminal (CI, pipes), it prints the recovery hint to stderr and exits non-zero instead of prompting.
+
 ## Enabling Debug Logs
 
 When something goes wrong and the dashboard's status messages aren't enough to diagnose it, set the `DOT_AGENT_DECK_LOG` environment variable to capture tracing output to a file:

--- a/src/agent_pty.rs
+++ b/src/agent_pty.rs
@@ -2375,7 +2375,7 @@ mod tests {
         let registry = Arc::new(AgentPtyRegistry::new());
         let id1 = registry
             .spawn_agent(SpawnOptions {
-                command: Some("/bin/true"),
+                command: Some("/usr/bin/true"),
                 env: vec![(
                     DOT_AGENT_DECK_PANE_ID.to_string(),
                     "pane-recycle".to_string(),
@@ -2395,7 +2395,7 @@ mod tests {
         assert_eq!(
             registry.live_count(),
             0,
-            "test prerequisite: /bin/true must have exited"
+            "test prerequisite: /usr/bin/true must have exited"
         );
         assert_eq!(registry.len(), 1, "exited entry must still be in registry");
 
@@ -2425,11 +2425,11 @@ mod tests {
         let registry = Arc::new(AgentPtyRegistry::new());
         let _id = registry
             .spawn_agent(SpawnOptions {
-                command: Some("/bin/true"),
+                command: Some("/usr/bin/true"),
                 env: vec![(DOT_AGENT_DECK_PANE_ID.to_string(), "ghost".to_string())],
                 ..SpawnOptions::default()
             })
-            .expect("spawn /bin/true");
+            .expect("spawn /usr/bin/true");
 
         // Wait for `exited` to flip.
         let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
@@ -2463,7 +2463,7 @@ mod tests {
         let registry = Arc::new(AgentPtyRegistry::new());
         let _dead = registry
             .spawn_agent(SpawnOptions {
-                command: Some("/bin/true"),
+                command: Some("/usr/bin/true"),
                 env: vec![(DOT_AGENT_DECK_PANE_ID.to_string(), "reuse-me".to_string())],
                 ..SpawnOptions::default()
             })
@@ -2848,14 +2848,14 @@ mod tests {
         let registry = Arc::new(AgentPtyRegistry::new());
         let id = registry
             .spawn_agent(SpawnOptions {
-                command: Some("/bin/true"),
+                command: Some("/usr/bin/true"),
                 ..SpawnOptions::default()
             })
             .expect("spawn should succeed");
         assert_eq!(registry.len(), 1);
 
         // Wait up to a few seconds for the reader thread to drain to EOF
-        // and set `exited`. /bin/true exits quickly, but the PTY drain +
+        // and set `exited`. /usr/bin/true exits quickly, but the PTY drain +
         // OS scheduling can take a couple of hundred ms on a loaded box.
         let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
         while tokio::time::Instant::now() < deadline {
@@ -2911,7 +2911,7 @@ mod tests {
         // pump_reader on EOF.
         let _id2 = registry
             .spawn_agent(SpawnOptions {
-                command: Some("/bin/true"),
+                command: Some("/usr/bin/true"),
                 ..SpawnOptions::default()
             })
             .expect("spawn should succeed");

--- a/src/agent_pty.rs
+++ b/src/agent_pty.rs
@@ -2609,20 +2609,45 @@ mod tests {
     #[tokio::test]
     async fn write_to_pane_notice_bytes_precede_next_submit_with_only_lf_between() {
         let registry = AgentPtyRegistry::new();
+        // The shell prints `RAW-READY` *after* stty applies and *before* exec
+        // into cat, so the test can poll the scrollback for that marker and
+        // know the slave's termios is in raw mode before issuing the notice /
+        // submit writes. On slow Linux CI runners a fixed sleep is not enough
+        // — if `\n` lands while OPOST/ONLCR is still active, the kernel
+        // translates it to `\r\n` in the master scrollback and the no-`\r`
+        // assertion below trips on the ONLCR artifact even though the daemon
+        // never emitted a CR.
         let _id = registry
             .spawn_agent(SpawnOptions {
-                command: Some("stty -echo -icanon -icrnl -opost min 1 time 0 && exec cat -u"),
+                command: Some(
+                    "stty -echo -icanon -icrnl -opost min 1 time 0 && \
+                     printf RAW-READY && exec cat -u",
+                ),
                 env: vec![(DOT_AGENT_DECK_PANE_ID.to_string(), "accumulate".to_string())],
                 ..SpawnOptions::default()
             })
             .expect("spawn raw-mode cat shell");
         let agent_id = registry.agent_ids()[0].clone();
 
-        // Give the shell time to apply `stty` and `exec` into cat
-        // before writes hit the slave — otherwise the first bytes
-        // would traverse the default termios (ICANON + ICRNL + OPOST)
-        // and the order/contents of the scrollback would be ambiguous.
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        // Wait for the shell to apply `stty` and print the readiness marker.
+        // `printf` is a builtin in both bash and dash so no fork is needed
+        // between stty completing and the marker landing, and the marker is
+        // pure alphanumeric+hyphen so OPOST translation does not affect its
+        // appearance even on the off chance stty hadn't applied yet.
+        let ready_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        let mut raw_ready = false;
+        while tokio::time::Instant::now() < ready_deadline {
+            let snap = registry.snapshot(&agent_id).unwrap_or_default();
+            if snap.windows(b"RAW-READY".len()).any(|w| w == b"RAW-READY") {
+                raw_ready = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(30)).await;
+        }
+        assert!(
+            raw_ready,
+            "shell never printed RAW-READY — stty/exec cat -u didn't apply in time"
+        );
 
         registry
             .write_to_pane_notice("accumulate", "NOTICE-MARKER")

--- a/src/build_id.rs
+++ b/src/build_id.rs
@@ -1,0 +1,41 @@
+//! Effective build ID used for the local-attach build-version handshake.
+//!
+//! Production callers read the compile-time `env!("DAD_BUILD_ID")` baked
+//! in by `build.rs` (PRD #103 M1.0). This helper layers a **test-only**
+//! runtime override on top: when `DOT_AGENT_DECK_BUILD_ID_OVERRIDE` is
+//! set in the process's environment, [`local_build_id`] returns that
+//! value instead.
+//!
+//! The override exists exclusively so the M4.2 integration tests
+//! (`tests/build_version_handshake.rs`) can simulate same-tag /
+//! different-commit skew between the TUI and the daemon subprocess
+//! without rebuilding the binary at a synthetic `DAD_BUILD_ID`. Both
+//! sides honour the same variable so each subprocess can be pinned to
+//! its own build_id independently:
+//!
+//! - [`crate::daemon_protocol::AttachResponse::hello`] uses it to
+//!   advertise the daemon's `build_version` on the wire.
+//! - [`crate::build_version_handshake::ensure_compatible_daemon_or_die`]
+//!   uses it for the laptop's own comparison value and for the
+//!   `client_build_version` it sends on `Hello`.
+//!
+//! Production code must never set this env var — there is no scenario
+//! in which honest builds need to lie about their `DAD_BUILD_ID`. The
+//! variable is grep-ably named so a future audit can confirm nothing
+//! outside tests sets it.
+
+/// Return the effective build_id for the local handshake.
+///
+/// `env!("DAD_BUILD_ID")` in production; the value of
+/// `DOT_AGENT_DECK_BUILD_ID_OVERRIDE` when set under
+/// `cfg(any(test, debug_assertions))`. Release builds (which set
+/// `debug_assertions = false`) compile the override branch out entirely,
+/// so the test hook cannot be reached from a shipped binary even if the
+/// env var happens to be set in the operator's environment.
+pub fn local_build_id() -> String {
+    #[cfg(any(test, debug_assertions))]
+    if let Ok(v) = std::env::var("DOT_AGENT_DECK_BUILD_ID_OVERRIDE") {
+        return v;
+    }
+    env!("DAD_BUILD_ID").to_string()
+}

--- a/src/build_version_handshake.rs
+++ b/src/build_version_handshake.rs
@@ -200,12 +200,32 @@ pub async fn ensure_compatible_daemon_or_die(
     match decision {
         InteractiveDecision::Quit => Err(HandshakeError::MismatchAborted),
         InteractiveDecision::Stop => {
+            // PRD #103 PID-reuse mitigation: re-resolve `peer_pid()` on
+            // the SAME `UnixStream` we kept open across the interactive
+            // prompt. Holding the stream open prevents the kernel from
+            // tearing down the socket pairing in the window where the
+            // user was deciding S/Q. If `peer_pid()` now fails the
+            // daemon has already exited on its own — there's nothing to
+            // terminate, so short-circuit to success rather than
+            // signalling an arbitrary same-UID PID.
+            let resolved_pid = match peer_pid(&probe.stream) {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::debug!(
+                        target: "build_version_handshake",
+                        error = %e,
+                        original_pid = probe.peer_pid,
+                        "re-resolved peer_pid failed after prompt; treating daemon as already gone"
+                    );
+                    return Ok(HandshakeOutcome::Recovered);
+                }
+            };
             // Phase 2 doesn't escalate to SIGKILL — the user can re-run
             // `dot-agent-deck daemon stop --force` for that. The
             // graceful-SIGTERM outcome is the only success variant we
             // care about here; treat both Stopped and Killed (the
             // latter is unreachable with `None`) as Recovered.
-            terminate_daemon_graceful(probe.peer_pid, attach_path, TERMINATE_POLL_TIMEOUT, None)
+            terminate_daemon_graceful(resolved_pid, attach_path, TERMINATE_POLL_TIMEOUT, None)
                 .await?;
             Ok(HandshakeOutcome::Recovered)
         }
@@ -215,28 +235,41 @@ pub async fn ensure_compatible_daemon_or_die(
 struct ProbeOutcome {
     response: AttachResponse,
     peer_pid: u32,
+    /// The original connected `UnixStream` is held alive across the
+    /// interactive prompt so the kernel can't recycle the daemon's PID
+    /// while the user is deciding S/Q (PRD #103 PID-reuse mitigation —
+    /// see [`ensure_compatible_daemon_or_die`]). Used for the
+    /// re-resolved `peer_pid()` call right before SIGTERM.
+    stream: UnixStream,
 }
 
 async fn probe_daemon(attach_path: &Path) -> Result<ProbeOutcome, HandshakeError> {
-    let stream = UnixStream::connect(attach_path)
+    let mut stream = UnixStream::connect(attach_path)
         .await
         .map_err(HandshakeError::Probe)?;
     let pid = peer_pid(&stream).map_err(HandshakeError::PeerPid)?;
-    let (mut rd, mut wr) = stream.into_split();
-    let req = AttachRequest::Hello {
-        client_version: PROTOCOL_VERSION,
-        // Same `local_build_id()` the comparison uses — keeps the
-        // wire-advertised `client_build_version` consistent with the
-        // value we're matching against, even under the test-only
-        // `DOT_AGENT_DECK_BUILD_ID_OVERRIDE`.
-        client_build_version: Some(local_build_id()),
+    // Borrow-split so the original `stream` survives the Hello exchange
+    // and can be held across the interactive prompt. `into_split()`
+    // (which consumes the stream) would force us to reunite the halves
+    // afterwards; the borrow-split is simpler.
+    let resp = {
+        let (mut rd, mut wr) = stream.split();
+        let req = AttachRequest::Hello {
+            client_version: PROTOCOL_VERSION,
+            // Same `local_build_id()` the comparison uses — keeps the
+            // wire-advertised `client_build_version` consistent with the
+            // value we're matching against, even under the test-only
+            // `DOT_AGENT_DECK_BUILD_ID_OVERRIDE`.
+            client_build_version: Some(local_build_id()),
+        };
+        issue_command(&mut rd, &mut wr, &req)
+            .await
+            .map_err(|e| HandshakeError::Probe(io::Error::other(e.to_string())))?
     };
-    let resp = issue_command(&mut rd, &mut wr, &req)
-        .await
-        .map_err(|e| HandshakeError::Probe(io::Error::other(e.to_string())))?;
     Ok(ProbeOutcome {
         response: resp,
         peer_pid: pid,
+        stream,
     })
 }
 
@@ -435,6 +468,13 @@ fn render_mismatch_prompt(
             "⚠  Daemon version mismatch  ({n} managed agent(s) running)\n",
             n = agents.len()
         ));
+        // Surface both build-ids in the live-agent variant too — the
+        // no-agent branch shows them and the user loses crucial context
+        // (which side is "newer") if they're only visible in one of the
+        // two prompts. PRD #103 M4.2 / CodeRabbit finding #3.
+        out.push_str(&format!("   running daemon:  {daemon_display}\n"));
+        out.push_str(&format!("   this binary:     {local_build}\n"));
+        out.push('\n');
         for id in agents {
             out.push_str(&format!("   {id}\n"));
         }
@@ -584,6 +624,9 @@ mod tests {
             &["agent-1".into(), "agent-2".into()],
         );
         let expected = "⚠  Daemon version mismatch  (2 managed agent(s) running)\n\
+             \x20  running daemon:  0.25.0-gabc1234\n\
+             \x20  this binary:     0.25.0-gdeadbee\n\
+             \n\
              \x20  agent-1\n\
              \x20  agent-2\n\
              \n\

--- a/src/build_version_handshake.rs
+++ b/src/build_version_handshake.rs
@@ -1,0 +1,806 @@
+//! PRD #103 Phase 2 — local TUI build-version handshake against the
+//! external daemon.
+//!
+//! After [`crate::daemon_attach::ensure_external_daemon_or_die`] returns
+//! Ok, the TUI opens one short-lived attach connection and sends a
+//! [`crate::daemon_protocol::AttachRequest::Hello`] carrying its own
+//! `client_build_version`. The daemon replies with its compiled-in
+//! `build_version` (PRD #103 M1.1). If the two differ — or the daemon
+//! omits the field entirely (a pre-PRD-103 binary) — the handshake
+//! enters a recovery flow:
+//!
+//! - **TTY**: render an interactive prompt naming both build-ids and the
+//!   live agent IDs (from a `ListAgents` round-trip). The user can press
+//!   `S` to terminate the daemon and continue, or `Q`/`Ctrl+C`/`Ctrl+D`
+//!   to abort. When live agents are present, two consecutive `S` presses
+//!   are required (data-loss guard).
+//! - **Non-TTY** (CI, piped stdout): print the equivalent error to
+//!   stderr and exit non-zero. No prompt is rendered; the documented
+//!   recovery is `dot-agent-deck daemon stop`.
+//!
+//! The handshake runs unconditionally — even when
+//! [`ensure_external_daemon_or_die`] just lazy-spawned the daemon and
+//! the build-ids are necessarily equal (PRD M2.3). The cost is one
+//! extra Unix-socket round-trip on cold start; the upside is a smoke
+//! test of the handshake on every launch, which catches regressions
+//! in `ensure_external_daemon_or_die` itself or in the wire format.
+//!
+//! The `SIGTERM` + poll-socket-disappearance helper
+//! ([`terminate_daemon_graceful`]) is factored out so PRD #103 Phase 3
+//! (`dot-agent-deck daemon stop`) can reuse it — Phase 3 adds an
+//! optional `SIGKILL` escalation on top, but the graceful path is
+//! identical.
+
+use std::io::{self, IsTerminal, Write};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use tokio::net::UnixStream;
+
+use crate::build_id::local_build_id;
+use crate::daemon_attach::peer_pid;
+use crate::daemon_client::{DaemonClient, issue_command};
+use crate::daemon_protocol::{AttachRequest, AttachResponse, PROTOCOL_VERSION};
+
+/// How long to wait for the daemon's attach socket to disappear after a
+/// `SIGTERM` before reporting failure. The daemon's own teardown runs a
+/// 3-second SIGTERM grace on its agents, so 5 s is comfortable headroom.
+pub const TERMINATE_POLL_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Outcome of [`ensure_compatible_daemon_or_die`] when the call resolves
+/// successfully. Callers proceed to attach in either case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandshakeOutcome {
+    /// Daemon's `build_version` matched the TUI's compiled-in
+    /// `DAD_BUILD_ID`. No user interaction occurred.
+    Match,
+    /// Build-ids differed; the user pressed `S`, the old daemon was
+    /// terminated, and the socket disappeared within the timeout. The
+    /// caller should re-run [`crate::daemon_attach::ensure_external_daemon_or_die`]
+    /// before attaching — the next TUI startup lazy-spawns a fresh daemon
+    /// at the current build.
+    Recovered,
+}
+
+/// Errors that abort startup. The non-TTY fallback prints to stderr
+/// inside [`ensure_compatible_daemon_or_die`] before returning the
+/// `MismatchAborted` variant, and the interactive `Quit` path is also
+/// already user-visible — callers translate any error into
+/// [`std::process::ExitCode::FAILURE`] without rendering anything else.
+#[derive(Debug)]
+pub enum HandshakeError {
+    /// `UnixStream::connect` or the Hello round-trip failed. Indicates
+    /// the daemon socket is reachable (it exists per
+    /// `ensure_external_daemon_or_die`) but the daemon itself is not
+    /// answering — a near-miss with a crashing daemon, or a stale
+    /// socket inode that survived a kill -9 + reboot. Treated as a
+    /// pre-flight failure.
+    Probe(io::Error),
+    /// `peer_pid()` on the connected socket failed. macOS/Linux both
+    /// support the getsockopt this calls, so this is exceptional and
+    /// indicates a fundamentally broken host.
+    PeerPid(io::Error),
+    /// The build-id mismatch was reported and the user aborted (TTY
+    /// `Q`/`Ctrl+C`/`Ctrl+D`, or the non-TTY fallback).
+    MismatchAborted,
+    /// The user agreed to terminate the daemon but the SIGTERM didn't
+    /// take effect within [`TERMINATE_POLL_TIMEOUT`] (socket still
+    /// present). The user-facing remediation is
+    /// `dot-agent-deck daemon stop --force`.
+    TerminateTimedOut,
+    /// `libc::kill` itself failed (EPERM if the daemon belongs to a
+    /// different user — shouldn't happen because the attach socket is
+    /// already trust-checked uid-equal — or ESRCH if the daemon died
+    /// between probe and kill).
+    TerminateFailed(io::Error),
+}
+
+impl std::fmt::Display for HandshakeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Probe(e) => write!(f, "build-version handshake probe failed: {e}"),
+            Self::PeerPid(e) => write!(f, "build-version handshake peer-pid lookup failed: {e}"),
+            Self::MismatchAborted => write!(f, "build-version handshake aborted by user"),
+            Self::TerminateTimedOut => write!(
+                f,
+                "daemon did not exit within {}s after SIGTERM; try `dot-agent-deck daemon stop --force`",
+                TERMINATE_POLL_TIMEOUT.as_secs()
+            ),
+            Self::TerminateFailed(e) => write!(f, "SIGTERM to daemon failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for HandshakeError {}
+
+/// Public entry point used by `run_tui_session`. Performs the handshake,
+/// runs the recovery flow on mismatch, and returns once the laptop can
+/// safely attach (or `Err` if the user aborted / something failed).
+///
+/// PRD M2.3 — runs unconditionally, even when
+/// [`crate::daemon_attach::ensure_external_daemon_or_die`] just lazy-spawned
+/// the daemon. The cost is one extra Unix-socket round-trip on cold start;
+/// the upside is that the handshake itself gets a smoke test on every
+/// launch, which catches regressions in either `ensure_external_daemon_or_die`
+/// (wrong socket, wrong daemon binary) or the wire-format encoding of the
+/// `build_version` field.
+pub async fn ensure_compatible_daemon_or_die(
+    attach_path: &Path,
+) -> Result<HandshakeOutcome, HandshakeError> {
+    // `local_build_id()` returns the compile-time `env!("DAD_BUILD_ID")`
+    // in production; the `DOT_AGENT_DECK_BUILD_ID_OVERRIDE` env var
+    // (test-only, honoured by both this comparison and
+    // `AttachResponse::hello`) lets PRD #103 M4.2 integration tests
+    // simulate skew without rebuilding the binary.
+    let local_build = local_build_id();
+    let probe = probe_daemon(attach_path).await?;
+
+    let daemon_build = probe.response.build_version.clone();
+    if daemon_build.as_deref() == Some(local_build.as_str()) {
+        tracing::debug!(
+            target: "build_version_handshake",
+            local_build,
+            daemon_build = ?daemon_build,
+            "local daemon build_version handshake: match"
+        );
+        return Ok(HandshakeOutcome::Match);
+    }
+
+    // Mismatch path. Pull the live-agent list so the prompt can name
+    // them; treat a list_agents error as "no agents listed" — the
+    // mismatch itself is the important user signal, and a failing
+    // list_agents on top would just confuse the picture. (If the
+    // daemon is too broken to list agents it almost certainly can't
+    // host live ones either.)
+    let agents = match DaemonClient::new(attach_path.to_path_buf())
+        .list_agents()
+        .await
+    {
+        Ok(rs) => rs.into_iter().map(|r| r.id).collect::<Vec<_>>(),
+        Err(e) => {
+            tracing::debug!(
+                target: "build_version_handshake",
+                error = %e,
+                "list_agents failed during mismatch flow; treating as no live agents"
+            );
+            Vec::new()
+        }
+    };
+    tracing::debug!(
+        target: "build_version_handshake",
+        local_build,
+        daemon_build = ?daemon_build,
+        live_agents = agents.len(),
+        "local daemon build_version handshake: mismatch"
+    );
+
+    if !std::io::stdout().is_terminal() {
+        let msg = render_non_tty_error(daemon_build.as_deref(), &local_build);
+        eprint!("{msg}");
+        return Err(HandshakeError::MismatchAborted);
+    }
+
+    // TTY recovery flow: ask the user whether to terminate. The prompt
+    // is rendered in raw mode on a blocking thread (crossterm's
+    // event::read is synchronous; doing it directly would block the
+    // tokio worker).
+    let agents_for_prompt = agents.clone();
+    let daemon_build_for_prompt = daemon_build.clone();
+    let local_build_for_prompt = local_build.clone();
+    let decision = tokio::task::spawn_blocking(move || {
+        interactive_prompt(
+            daemon_build_for_prompt.as_deref(),
+            &local_build_for_prompt,
+            &agents_for_prompt,
+        )
+    })
+    .await
+    .map_err(|e| HandshakeError::Probe(io::Error::other(format!("prompt task join: {e}"))))?;
+
+    match decision {
+        InteractiveDecision::Quit => Err(HandshakeError::MismatchAborted),
+        InteractiveDecision::Stop => {
+            // Phase 2 doesn't escalate to SIGKILL — the user can re-run
+            // `dot-agent-deck daemon stop --force` for that. The
+            // graceful-SIGTERM outcome is the only success variant we
+            // care about here; treat both Stopped and Killed (the
+            // latter is unreachable with `None`) as Recovered.
+            terminate_daemon_graceful(probe.peer_pid, attach_path, TERMINATE_POLL_TIMEOUT, None)
+                .await?;
+            Ok(HandshakeOutcome::Recovered)
+        }
+    }
+}
+
+struct ProbeOutcome {
+    response: AttachResponse,
+    peer_pid: u32,
+}
+
+async fn probe_daemon(attach_path: &Path) -> Result<ProbeOutcome, HandshakeError> {
+    let stream = UnixStream::connect(attach_path)
+        .await
+        .map_err(HandshakeError::Probe)?;
+    let pid = peer_pid(&stream).map_err(HandshakeError::PeerPid)?;
+    let (mut rd, mut wr) = stream.into_split();
+    let req = AttachRequest::Hello {
+        client_version: PROTOCOL_VERSION,
+        // Same `local_build_id()` the comparison uses — keeps the
+        // wire-advertised `client_build_version` consistent with the
+        // value we're matching against, even under the test-only
+        // `DOT_AGENT_DECK_BUILD_ID_OVERRIDE`.
+        client_build_version: Some(local_build_id()),
+    };
+    let resp = issue_command(&mut rd, &mut wr, &req)
+        .await
+        .map_err(|e| HandshakeError::Probe(io::Error::other(e.to_string())))?;
+    Ok(ProbeOutcome {
+        response: resp,
+        peer_pid: pid,
+    })
+}
+
+/// What [`terminate_daemon_graceful`] actually did when it succeeded.
+/// Phase 2 ignores the variant; Phase 3 (`daemon stop`) surfaces the
+/// distinction to the user (`stopped` vs `force-killed`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminateOutcome {
+    /// SIGTERM was sufficient — the daemon went away within
+    /// `grace_timeout`.
+    Stopped,
+    /// SIGTERM timed out and the caller had passed
+    /// `force_kill_after = Some(...)`, so SIGKILL was sent and the
+    /// daemon went away within that extra window.
+    Killed,
+}
+
+/// SIGTERM the daemon (by PID, obtained from `peer_pid()` on the attach
+/// socket) and poll for the daemon to actually go away. `daemon-is-gone`
+/// is detected via `UnixStream::connect` failure (or the socket file
+/// being unlinked), polled every 100 ms up to `grace_timeout`. We don't
+/// rely on the socket *file* disappearing because the daemon doesn't
+/// unlink its socket inode on exit — only `bind(2)` cleanup on the
+/// next start does — so file-existence polling would unconditionally
+/// time out against a real production daemon.
+///
+/// Phase 2 (TUI prompt) calls this with `force_kill_after = None` and
+/// surfaces a timeout as [`HandshakeError::TerminateTimedOut`]. Phase 3
+/// (`daemon stop --force`) passes a non-`None` second window: on
+/// SIGTERM timeout we escalate to SIGKILL and poll for an additional
+/// `force_kill_after` before giving up. The graceful path is shared so
+/// the two flows can't diverge.
+///
+/// Returns:
+/// - `Ok(TerminateOutcome::Stopped)` — SIGTERM took effect within
+///   `grace_timeout`.
+/// - `Ok(TerminateOutcome::Killed)` — SIGTERM timed out, SIGKILL was
+///   delivered, and the daemon went away within `force_kill_after`.
+///   Only reachable when `force_kill_after.is_some()`.
+/// - `Err(HandshakeError::TerminateTimedOut)` — daemon still alive after
+///   both timeouts (or just `grace_timeout` if no escalation requested).
+/// - `Err(HandshakeError::TerminateFailed(_))` — `libc::kill` itself
+///   failed (typically ESRCH if the daemon already exited between
+///   probe and kill, or EINVAL if the caller passed pid 0 — refused up
+///   front).
+pub async fn terminate_daemon_graceful(
+    pid: u32,
+    attach_path: &Path,
+    grace_timeout: Duration,
+    force_kill_after: Option<Duration>,
+) -> Result<TerminateOutcome, HandshakeError> {
+    let signal_pid = checked_signal_pid(pid)?;
+    // TOCTOU residual risk: between `peer_pid()` (on the connected
+    // attach socket) reading this PID and the SIGTERM below, the
+    // daemon could exit and the kernel could recycle the PID for an
+    // unrelated process. We accept the window because:
+    //   1. The caller (handshake / `daemon stop`) holds the attach
+    //      socket connection open across this call. While the kernel
+    //      considers our peer alive on that fd, it won't reuse the
+    //      PID for *another* process — recycling only happens after
+    //      the original process is fully reaped. So a same-UID PID
+    //      collision requires the daemon to die, reap, and a new
+    //      same-UID process to claim the recycled PID, all within
+    //      one syscall worth of latency. Vanishingly small in
+    //      practice.
+    //   2. If we do hit that window, the worst case is a SIGTERM
+    //      delivered to an unrelated same-UID process — uid-equality
+    //      is already enforced by the daemon's attach-socket trust
+    //      check upstream, so we can't cross a security boundary.
+    // Documenting rather than mitigating further: the `kill(pid, 0)`
+    // double-check the auditor suggested would only narrow the window,
+    // not close it (the recycle could still happen between the
+    // `kill(_, 0)` and the `kill(_, SIGTERM)`).
+    // SAFETY: `libc::kill` is async-signal-safe and has no in-process
+    // side effects beyond delivering the signal to the target PID.
+    let rc = unsafe { libc::kill(signal_pid, libc::SIGTERM) };
+    if rc != 0 {
+        return Err(HandshakeError::TerminateFailed(io::Error::last_os_error()));
+    }
+    if poll_daemon_gone(attach_path, grace_timeout).await {
+        return Ok(TerminateOutcome::Stopped);
+    }
+    let Some(kill_grace) = force_kill_after else {
+        return Err(HandshakeError::TerminateTimedOut);
+    };
+    // SAFETY: same as above; SIGKILL is uncatchable but the syscall
+    // itself is async-signal-safe.
+    let rc = unsafe { libc::kill(signal_pid, libc::SIGKILL) };
+    if rc != 0 {
+        return Err(HandshakeError::TerminateFailed(io::Error::last_os_error()));
+    }
+    if poll_daemon_gone(attach_path, kill_grace).await {
+        Ok(TerminateOutcome::Killed)
+    } else {
+        Err(HandshakeError::TerminateTimedOut)
+    }
+}
+
+/// Convert a `u32` PID (as returned by `peer_pid()`) into the `pid_t`
+/// (`i32`) shape `libc::kill` wants, refusing values that would
+/// dangerously change the syscall's meaning:
+/// - `pid == 0`: `kill(0, sig)` broadcasts to every process in the
+///   calling process group — would take down the parent shell.
+/// - `pid > i32::MAX`: the `as i32` cast would wrap to a negative
+///   value. `kill(-pgid, sig)` means "signal every process in process
+///   group `pgid`" — a wildcard kill. Refuse rather than send.
+/// - resulting `i32 <= 0` after the cast: defense-in-depth for any
+///   path that bypasses the explicit checks above.
+fn checked_signal_pid(pid: u32) -> Result<libc::pid_t, HandshakeError> {
+    if pid == 0 {
+        return Err(HandshakeError::TerminateFailed(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "peer pid is 0; refusing to kill(0, SIGTERM) (would broadcast to process group)",
+        )));
+    }
+    if pid > i32::MAX as u32 {
+        return Err(HandshakeError::TerminateFailed(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "peer pid {pid} does not fit in pid_t; refusing kill() (negative i32 would target a process group)"
+            ),
+        )));
+    }
+    let signed = pid as libc::pid_t;
+    if signed <= 0 {
+        return Err(HandshakeError::TerminateFailed(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("peer pid {pid} resolves to non-positive pid_t {signed}; refusing kill()"),
+        )));
+    }
+    Ok(signed)
+}
+
+/// Poll until the daemon stops answering connects on `attach_path`, or
+/// `budget` elapses. Returns `true` on the former. Used by
+/// [`terminate_daemon_graceful`]'s wait loops.
+///
+/// "Daemon is gone" is `UnixStream::connect` failure (typically
+/// `ECONNREFUSED` against a stale inode after the listener fd was
+/// closed, or `ENOENT` if something out-of-band unlinked the file).
+/// File-existence alone is not a reliable signal — the daemon process
+/// does not unlink its socket on exit; only the next `daemon serve`'s
+/// `bind(2)` cleanup does — so a file-existence poll would unconditionally
+/// time out against a real production daemon that just died.
+async fn poll_daemon_gone(attach_path: &Path, budget: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < budget {
+        if !attach_path.exists() {
+            return true;
+        }
+        if tokio::net::UnixStream::connect(attach_path).await.is_err() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Rendering / interactive prompt
+// ---------------------------------------------------------------------------
+
+/// Render the non-TTY (CI / piped-stdout) error message. Trailing
+/// newline included so the caller can write it directly.
+fn render_non_tty_error(daemon_build: Option<&str>, local_build: &str) -> String {
+    let daemon_display = daemon_build.unwrap_or("<unknown>");
+    format!(
+        "error: local daemon is build {daemon_display} but this TUI is build {local_build}\n\
+         recover with: dot-agent-deck daemon stop\n"
+    )
+}
+
+/// Render the interactive mismatch prompt as plain newline-separated
+/// text. Raw-mode display converts `\n` to `\r\n` at write time so
+/// tests can assert on the canonical form. Trailing newline omitted so
+/// the cursor sits one line below the prompt body — the next keystroke
+/// then echoes (well, would echo if raw mode left echo on) under the
+/// "[S] / [Q]" line.
+fn render_mismatch_prompt(
+    daemon_build: Option<&str>,
+    local_build: &str,
+    agents: &[String],
+) -> String {
+    let daemon_display = daemon_build.unwrap_or("<unknown>");
+    if agents.is_empty() {
+        format!(
+            "⚠  Daemon version mismatch\n\
+             \x20  running daemon:  {daemon_display}\n\
+             \x20  this binary:     {local_build}\n\
+             \n\
+             \x20  [S] stop daemon and continue   [Q] quit\n"
+        )
+    } else {
+        let mut out = String::new();
+        out.push_str(&format!(
+            "⚠  Daemon version mismatch  ({n} managed agent(s) running)\n",
+            n = agents.len()
+        ));
+        for id in agents {
+            out.push_str(&format!("   {id}\n"));
+        }
+        out.push('\n');
+        out.push_str("   Stopping the daemon will end these agents.\n");
+        out.push('\n');
+        out.push_str("   [S] stop daemon and continue   [Q] quit\n");
+        out
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InteractiveDecision {
+    Stop,
+    Quit,
+}
+
+/// Render the prompt in raw mode and block on `crossterm::event::read`
+/// until the user picks `S` or `Q` (or sends `Ctrl+C`/`Ctrl+D`). When
+/// `agents` is non-empty, two `S` presses are required — the live-agent
+/// data-loss guard (PRD #103 M2.1 / worker-task line 41).
+///
+/// Runs on a blocking thread because `crossterm::event::read` is
+/// synchronous; the caller spawn_blocking()s this function.
+fn interactive_prompt(
+    daemon_build: Option<&str>,
+    local_build: &str,
+    agents: &[String],
+) -> InteractiveDecision {
+    use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+    use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+
+    struct RawModeGuard;
+    impl Drop for RawModeGuard {
+        fn drop(&mut self) {
+            let _ = disable_raw_mode();
+        }
+    }
+
+    let prompt = render_mismatch_prompt(daemon_build, local_build, agents);
+    let raw_ok = enable_raw_mode().is_ok();
+    let _guard = raw_ok.then_some(RawModeGuard);
+
+    let render = |body: &str| {
+        let mut out = std::io::stdout().lock();
+        // Raw mode disables cooked LF→CRLF translation, so each `\n`
+        // must become `\r\n` for the prompt to land on consecutive
+        // left-aligned lines.
+        let with_cr = body.replace('\n', "\r\n");
+        let _ = out.write_all(with_cr.as_bytes());
+        let _ = out.flush();
+    };
+    render(&prompt);
+
+    let needs_two_s = !agents.is_empty();
+    let mut s_count = 0usize;
+
+    loop {
+        let ev = match event::read() {
+            Ok(ev) => ev,
+            // A read error in raw mode (terminal yanked, TTY closed)
+            // is functionally equivalent to the user giving up. Quit
+            // safely rather than looping on a broken fd.
+            Err(_) => return InteractiveDecision::Quit,
+        };
+        let Event::Key(KeyEvent {
+            code, modifiers, ..
+        }) = ev
+        else {
+            continue;
+        };
+        match (code, modifiers) {
+            (KeyCode::Char('s' | 'S'), m) if !m.contains(KeyModifiers::CONTROL) => {
+                s_count += 1;
+                if !needs_two_s || s_count >= 2 {
+                    return InteractiveDecision::Stop;
+                }
+                // First S with live agents: re-render the prompt so
+                // the user sees that the keystroke was received but
+                // a second confirmation is still required. The text
+                // is unchanged (PRD pins it character-for-character).
+                render(&prompt);
+            }
+            (KeyCode::Char('q' | 'Q'), m) if !m.contains(KeyModifiers::CONTROL) => {
+                return InteractiveDecision::Quit;
+            }
+            (KeyCode::Char('c' | 'd'), m) if m.contains(KeyModifiers::CONTROL) => {
+                return InteractiveDecision::Quit;
+            }
+            (KeyCode::Esc, _) => return InteractiveDecision::Quit,
+            _ => continue,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_tty_error_message_names_both_build_ids() {
+        let msg = render_non_tty_error(Some("0.25.0-gabc1234"), "0.25.0-gdeadbee-dirty");
+        assert_eq!(
+            msg,
+            "error: local daemon is build 0.25.0-gabc1234 but this TUI is build 0.25.0-gdeadbee-dirty\n\
+             recover with: dot-agent-deck daemon stop\n"
+        );
+    }
+
+    #[test]
+    fn non_tty_error_message_renders_unknown_daemon_build() {
+        // PRD #103 M2.1: a pre-PRD-103 daemon omits `build_version` on
+        // the wire; the prompt still needs to surface a sensible
+        // placeholder rather than `error: local daemon is build  but
+        // this TUI is build ...` (note the empty span).
+        let msg = render_non_tty_error(None, "0.25.0-gabc1234");
+        assert!(
+            msg.contains(
+                "error: local daemon is build <unknown> but this TUI is build 0.25.0-gabc1234"
+            ),
+            "missing daemon build_version must surface <unknown> placeholder, got: {msg:?}"
+        );
+        assert!(msg.ends_with("recover with: dot-agent-deck daemon stop\n"));
+    }
+
+    #[test]
+    fn mismatch_prompt_no_agents_matches_prd_form() {
+        // PRD #103 M2.1 pins this text character-for-character; the
+        // Phase 4 integration tests (M4.2) will assert against the
+        // same form, so any drift here fails the future test too.
+        let out = render_mismatch_prompt(Some("0.25.0-gabc1234"), "0.25.0-gdeadbee", &[]);
+        assert_eq!(
+            out,
+            "⚠  Daemon version mismatch\n\
+             \x20  running daemon:  0.25.0-gabc1234\n\
+             \x20  this binary:     0.25.0-gdeadbee\n\
+             \n\
+             \x20  [S] stop daemon and continue   [Q] quit\n"
+        );
+    }
+
+    #[test]
+    fn mismatch_prompt_with_agents_lists_them_under_header_and_warns_about_data_loss() {
+        let out = render_mismatch_prompt(
+            Some("0.25.0-gabc1234"),
+            "0.25.0-gdeadbee",
+            &["agent-1".into(), "agent-2".into()],
+        );
+        let expected = "⚠  Daemon version mismatch  (2 managed agent(s) running)\n\
+             \x20  agent-1\n\
+             \x20  agent-2\n\
+             \n\
+             \x20  Stopping the daemon will end these agents.\n\
+             \n\
+             \x20  [S] stop daemon and continue   [Q] quit\n";
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn mismatch_prompt_pluralization_pinned_at_n_managed_agents() {
+        // The PRD-pinned form is "(N managed agent(s) running)" with a
+        // literal "(s)" — no clever singular/plural switching. Pin it
+        // so a future "be helpful" cleanup doesn't drift the string
+        // out from under the M4.2 assertions.
+        let single = render_mismatch_prompt(Some("a"), "b", &["only".into()]);
+        assert!(
+            single.contains("(1 managed agent(s) running)"),
+            "single-agent header must keep the literal '(s)', got: {single:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminate_rejects_pid_zero() {
+        // kill(0, SIGTERM) is "send to every process in the calling
+        // process's process group" — refusing pid 0 up front prevents
+        // a sentinel/uninitialized value from accidentally taking
+        // down the parent shell.
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("ignored.sock");
+        let err = terminate_daemon_graceful(0, &sock, Duration::from_millis(100), None)
+            .await
+            .expect_err("pid 0 must be rejected");
+        match err {
+            HandshakeError::TerminateFailed(e) => {
+                assert_eq!(e.kind(), io::ErrorKind::InvalidInput);
+            }
+            other => panic!("expected TerminateFailed(InvalidInput), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn terminate_returns_stopped_when_socket_disappears() {
+        // Bind a real Unix socket, spawn a kill+unlink helper, and
+        // confirm `terminate_daemon_graceful` returns `Stopped` once
+        // the socket vanishes. We can't actually SIGTERM ourselves in
+        // a test (test runner dies), so we target a freshly forked
+        // child that never receives any visible SIGTERM and instead
+        // unlink the socket out-of-band partway through — exercising
+        // just the polling half.
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("attach.sock");
+        let _listener = UnixListener::bind(&sock).unwrap();
+
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+
+        let sock_for_drop = sock.clone();
+        let unlink_task = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            let _ = std::fs::remove_file(&sock_for_drop);
+        });
+
+        let result = terminate_daemon_graceful(pid, &sock, Duration::from_secs(2), None).await;
+        unlink_task.await.unwrap();
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert!(
+            matches!(result, Ok(TerminateOutcome::Stopped)),
+            "expected Ok(Stopped) once socket disappears, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminate_returns_stopped_when_listener_stops_accepting() {
+        // Production daemons don't unlink their socket file on exit —
+        // the inode lingers and only the next `daemon serve`'s bind()
+        // cleanup removes it. The poll loop therefore can't rely on
+        // file existence; it must also accept "connect failed" as
+        // "daemon is gone". This test pins that behavior: bind a
+        // listener, drop it (closes the fd; the socket file lingers
+        // but connect returns ECONNREFUSED), and confirm
+        // terminate_daemon_graceful exits Stopped.
+        use std::os::unix::net::UnixListener;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("attach.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id();
+
+        let listener_holder = std::sync::Mutex::new(Some(listener));
+        let drop_task = {
+            let listener_holder = &listener_holder;
+            async move {
+                tokio::time::sleep(Duration::from_millis(150)).await;
+                let _ = listener_holder.lock().unwrap().take();
+            }
+        };
+
+        let (result, _) = tokio::join!(
+            terminate_daemon_graceful(pid, &sock, Duration::from_secs(2), None),
+            drop_task,
+        );
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert!(
+            matches!(result, Ok(TerminateOutcome::Stopped)),
+            "expected Ok(Stopped) once the listener stops accepting (socket file may persist), got {result:?}"
+        );
+        // Sanity: the file IS still present — proves we detected
+        // daemon-gone via the connect-fail path, not the file-gone
+        // path.
+        assert!(
+            sock.exists(),
+            "regression: this test must exercise the connect-fail path, but the socket file was unlinked"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminate_returns_killed_when_force_escalates() {
+        // SIGTERM-ignoring child + force_kill_after = Some: SIGKILL
+        // takes the child down (uncatchable), the listener fd closes,
+        // the connect-fail poll fires, and we return Killed.
+        use std::os::unix::net::UnixListener;
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("attach.sock");
+        // Bind the listener inside the child's lifetime so its fd is
+        // held by the child (via `nc -lU` or similar). Without a real
+        // bound listener inside the child, the test process's
+        // listener stays alive across the SIGKILL and connect-fail
+        // never trips. Use `sh` to bind via a Python one-liner... too
+        // brittle. Cheaper approach: bind in this process and CLOSE
+        // it AFTER the SIGTERM grace times out — simulating "daemon
+        // process held the listener, SIGKILL closes the daemon's fd
+        // → listener dies".
+        let listener = UnixListener::bind(&sock).unwrap();
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("trap '' TERM; sleep 30")
+            .spawn()
+            .expect("spawn ignoring-sigterm child");
+        let pid = child.id();
+
+        // After ~250ms (well past SIGTERM grace of 200ms below) drop
+        // the listener — that's the moment SIGKILL would close the
+        // daemon's listener fd in production.
+        let listener_holder = std::sync::Mutex::new(Some(listener));
+        let drop_task = {
+            let listener_holder = &listener_holder;
+            async move {
+                tokio::time::sleep(Duration::from_millis(350)).await;
+                let _ = listener_holder.lock().unwrap().take();
+            }
+        };
+
+        let (result, _) = tokio::join!(
+            terminate_daemon_graceful(
+                pid,
+                &sock,
+                Duration::from_millis(200),
+                Some(Duration::from_secs(2)),
+            ),
+            drop_task,
+        );
+
+        let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+        let _ = child.wait();
+
+        assert!(
+            matches!(result, Ok(TerminateOutcome::Killed)),
+            "expected Ok(Killed) on SIGKILL escalation, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn terminate_times_out_when_socket_never_disappears() {
+        // The SIGTERM hits a real (sleeping) child that ignores the
+        // signal and stays alive; we cap the wait at 200 ms and
+        // expect `TerminateTimedOut`. This pins the failure-mode
+        // contract: if the daemon doesn't go away, the recovery flow
+        // surfaces a clean error instead of hanging.
+        use std::os::unix::net::UnixListener;
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("attach.sock");
+        let _listener = UnixListener::bind(&sock).unwrap();
+
+        // `trap '' TERM; sleep 5` ignores SIGTERM so the socket
+        // (which we don't unlink) stays present. The polling loop
+        // must time out.
+        let mut child = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("trap '' TERM; sleep 5")
+            .spawn()
+            .expect("spawn ignoring-sigterm child");
+        let pid = child.id();
+
+        let result = terminate_daemon_graceful(pid, &sock, Duration::from_millis(200), None).await;
+
+        // Tear down with SIGKILL — the test must not leak the child.
+        let _ = unsafe { libc::kill(pid as libc::pid_t, libc::SIGKILL) };
+        let _ = child.wait();
+
+        assert!(
+            matches!(result, Err(HandshakeError::TerminateTimedOut)),
+            "expected TerminateTimedOut when socket lingers, got {result:?}"
+        );
+    }
+}

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -25,6 +25,7 @@ use std::process::Command;
 
 use thiserror::Error;
 
+use crate::build_id::local_build_id;
 use crate::daemon_protocol::{AttachResponse, PROTOCOL_VERSION};
 use crate::remote::{
     RemoteConfigError, RemoteEntry, RemotesFile, SshError, SshExecutor, SshTarget,
@@ -549,18 +550,23 @@ pub fn probe_remote_protocol(
                     // identically to a real mismatch so the user re-runs
                     // `remote upgrade <name>` and the laptop gains the
                     // precision on the next probe.
-                    let local_build = env!("DAD_BUILD_ID");
+                    // Route through `local_build_id()` rather than
+                    // `env!("DAD_BUILD_ID")` so the
+                    // `DOT_AGENT_DECK_BUILD_ID_OVERRIDE` test hook (used by
+                    // the M4.2 integration tests) takes effect on the
+                    // remote-mismatch path too.
+                    let local_build = local_build_id();
                     match resp.build_version.as_deref() {
-                        Some(remote_build) if remote_build == local_build => Ok(()),
+                        Some(remote_build) if remote_build == local_build.as_str() => Ok(()),
                         Some(remote_build) => Err(RemoteConnectError::BuildVersionMismatch {
                             name: name.to_string(),
                             remote: Some(remote_build.to_string()),
-                            local: local_build.to_string(),
+                            local: local_build,
                         }),
                         None => Err(RemoteConnectError::BuildVersionMismatch {
                             name: name.to_string(),
                             remote: None,
-                            local: local_build.to_string(),
+                            local: local_build,
                         }),
                     }
                 }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -145,6 +145,25 @@ pub enum RemoteConnectError {
         message_suffix = if message.is_empty() { String::new() } else { format!(": {message}") }
     )]
     RemoteHandshakeError { name: String, message: String },
+    /// PRD #103 M1.4: the laptop and the remote have compatible
+    /// `PROTOCOL_VERSION`s but different `DAD_BUILD_ID`s. Same-tag-different-commit
+    /// (or dirty-tree) skew is the exact case that PROTOCOL_VERSION alone
+    /// can't catch — semantically divergent handler code behind a stable
+    /// wire shape. `remote` is `None` when the remote omits `build_version`
+    /// entirely (pre-PRD-103 binary): treated identically to a real mismatch
+    /// so the user upgrades the remote and the laptop gains the precision
+    /// on the next probe.
+    ///
+    /// Recovery routes to `remote upgrade <name>` (NOT `daemon stop` — the
+    /// local-daemon-stop command is only meaningful for the laptop-side
+    /// stale-daemon case).
+    #[error("Remote '{name}' was built as {remote_str}; laptop was built as {local}. Run `dot-agent-deck remote upgrade {name}` to re-install the remote at the current build.",
+            remote_str = remote.as_deref().unwrap_or("<unknown>"))]
+    BuildVersionMismatch {
+        name: String,
+        remote: Option<String>,
+        local: String,
+    },
     #[error(transparent)]
     Registry(#[from] RemoteConfigError),
     #[error("I/O error: {0}")]
@@ -450,6 +469,12 @@ const PROBE_PROTOCOL_STDOUT_CAP: usize = 64 * 1024;
 ///   `daemon hello`) → `ProtocolMismatch { remote: None, .. }`.
 /// - Remote exits 0 but stdout doesn't parse as a JSON response with a
 ///   `server_version` field → same treatment as "remote too old".
+/// - PRD #103 M1.4: `server_version` matches but `build_version` differs (or
+///   is missing on the remote) → [`RemoteConnectError::BuildVersionMismatch`]
+///   whose user-facing message names both build_ids and points at
+///   `dot-agent-deck remote upgrade <name>`. The local-side `daemon stop`
+///   command is NOT suggested here — that recovery applies only to the
+///   laptop's own stale daemon, not to a remote.
 ///
 /// Transport failures (`SshError`) fold into `HostUnreachable` via the same
 /// `map_probe_ssh_error` the binary-version probe uses — the user's
@@ -515,7 +540,30 @@ pub fn probe_remote_protocol(
                 });
             }
             match resp.server_version {
-                Some(v) if v == PROTOCOL_VERSION => Ok(()),
+                Some(v) if v == PROTOCOL_VERSION => {
+                    // PRD #103 M1.4: PROTOCOL_VERSION matches — now check
+                    // the finer-grained `build_version` (which catches
+                    // same-tag-different-commit skew the protocol version
+                    // can't). A `None` here means a pre-PRD-103 remote
+                    // binary that doesn't emit `build_version`; treat it
+                    // identically to a real mismatch so the user re-runs
+                    // `remote upgrade <name>` and the laptop gains the
+                    // precision on the next probe.
+                    let local_build = env!("DAD_BUILD_ID");
+                    match resp.build_version.as_deref() {
+                        Some(remote_build) if remote_build == local_build => Ok(()),
+                        Some(remote_build) => Err(RemoteConnectError::BuildVersionMismatch {
+                            name: name.to_string(),
+                            remote: Some(remote_build.to_string()),
+                            local: local_build.to_string(),
+                        }),
+                        None => Err(RemoteConnectError::BuildVersionMismatch {
+                            name: name.to_string(),
+                            remote: None,
+                            local: local_build.to_string(),
+                        }),
+                    }
+                }
                 Some(v) => {
                     let upgrade_hint = if v < PROTOCOL_VERSION {
                         format!("Run `dot-agent-deck remote upgrade {name}`")
@@ -1818,6 +1866,105 @@ mod tests {
         let err = probe_remote_protocol(&executor, &target, "lab", REMOTE_INSTALL_PATH)
             .expect_err("transport failure must error");
         assert!(matches!(err, RemoteConnectError::HostUnreachable { .. }));
+    }
+
+    // ----- PRD #103 M1.4: build_version comparison on the remote probe -----
+
+    #[test]
+    fn probe_protocol_build_version_match_returns_ok() {
+        // PROTOCOL_VERSION matches AND build_version matches → Ok. This is
+        // the same shape `AttachResponse::hello` produces locally, so the
+        // happy path needs no special construction.
+        let resp = AttachResponse::hello(PROTOCOL_VERSION);
+        let executor =
+            FakeSshExecutor::new(vec![ok_stdout(&serde_json::to_string(&resp).unwrap())]);
+        let target = ssh_target("u@h", 22);
+        probe_remote_protocol(&executor, &target, "lab", REMOTE_INSTALL_PATH)
+            .expect("matching build_version is Ok");
+    }
+
+    #[test]
+    fn probe_protocol_build_version_mismatch_returns_build_version_mismatch() {
+        // PROTOCOL_VERSION matches, but the remote was built at a different
+        // commit / dirty tree. Surface BuildVersionMismatch carrying both
+        // ids and pointing at `remote upgrade <name>` (NOT `daemon stop`).
+        let resp = AttachResponse {
+            ok: true,
+            server_version: Some(PROTOCOL_VERSION),
+            build_version: Some("0.25.0-gdeadbee-dirty".to_string()),
+            ..Default::default()
+        };
+        let executor =
+            FakeSshExecutor::new(vec![ok_stdout(&serde_json::to_string(&resp).unwrap())]);
+        let target = ssh_target("u@h", 22);
+        let err = probe_remote_protocol(&executor, &target, "lab", REMOTE_INSTALL_PATH)
+            .expect_err("differing build_version must error");
+        match err {
+            RemoteConnectError::BuildVersionMismatch {
+                name,
+                remote,
+                local,
+            } => {
+                assert_eq!(name, "lab");
+                assert_eq!(remote.as_deref(), Some("0.25.0-gdeadbee-dirty"));
+                assert_eq!(local, env!("DAD_BUILD_ID"));
+                // Sanity: rendered error names BOTH build ids and points at
+                // `remote upgrade` (not `daemon stop`).
+                let rendered = RemoteConnectError::BuildVersionMismatch {
+                    name: "lab".to_string(),
+                    remote: Some("0.25.0-gdeadbee-dirty".to_string()),
+                    local: env!("DAD_BUILD_ID").to_string(),
+                }
+                .to_string();
+                assert!(
+                    rendered.contains("0.25.0-gdeadbee-dirty"),
+                    "rendered error must name remote build_id: {rendered}"
+                );
+                assert!(
+                    rendered.contains(env!("DAD_BUILD_ID")),
+                    "rendered error must name local build_id: {rendered}"
+                );
+                assert!(
+                    rendered.contains("remote upgrade lab"),
+                    "rendered error must point at `remote upgrade <name>`: {rendered}"
+                );
+                assert!(
+                    !rendered.contains("daemon stop"),
+                    "remote-build skew must NOT suggest `daemon stop`: {rendered}"
+                );
+            }
+            other => panic!("expected BuildVersionMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn probe_protocol_build_version_missing_treated_as_mismatch() {
+        // A pre-PRD-103 remote daemon emits `server_version` but no
+        // `build_version`. The PROTOCOL_VERSION matches (a pre-PRD-103
+        // binary at a matching protocol version is possible), so the
+        // protocol-version test passes — the missing build_version is what
+        // signals "remote needs upgrade to gain the precision". Treat
+        // None identically to a real mismatch.
+        let json = format!(r#"{{"ok":true,"server_version":{PROTOCOL_VERSION}}}"#);
+        let executor = FakeSshExecutor::new(vec![ok_stdout(&json)]);
+        let target = ssh_target("u@h", 22);
+        let err = probe_remote_protocol(&executor, &target, "lab", REMOTE_INSTALL_PATH)
+            .expect_err("missing build_version must error");
+        match err {
+            RemoteConnectError::BuildVersionMismatch {
+                name,
+                remote,
+                local,
+            } => {
+                assert_eq!(name, "lab");
+                assert!(
+                    remote.is_none(),
+                    "remote=None signals pre-PRD-103 binary, got {remote:?}"
+                );
+                assert_eq!(local, env!("DAD_BUILD_ID"));
+            }
+            other => panic!("expected BuildVersionMismatch, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/daemon_attach.rs
+++ b/src/daemon_attach.rs
@@ -403,6 +403,86 @@ pub async fn ensure_external_daemon_or_die(attach_path: &Path) -> Result<(), Att
     .await
 }
 
+// ---------------------------------------------------------------------------
+// PRD #103 M1.5 — peer-credential PID discovery on a connected attach socket.
+// ---------------------------------------------------------------------------
+
+/// Return the PID of the process holding the other end of a connected
+/// Unix-domain stream.
+///
+/// Uses `libc::getsockopt` directly (`SO_PEERCRED` on Linux,
+/// `LOCAL_PEERPID` on macOS). The PRD considered
+/// `std::os::unix::net::UnixStream::peer_cred()` and rejected it — on
+/// rustc 1.94 stable that API is still nightly-only behind the
+/// `peer_credentials_unix_socket` feature, so depending on it would not
+/// compile.
+///
+/// **Crucially: this helper exchanges zero protocol bytes with the
+/// peer.** That's the load-bearing property: the entire point of having
+/// it is to drive `dot-agent-deck daemon stop` against a *stale* daemon
+/// (PRD #103 Phase 3), and a stale daemon by definition does not
+/// implement any new protocol surface we add. PID discovery via
+/// `getsockopt` is an OS-level facility and works against any daemon
+/// version, including the v0.24.x daemon that motivated the PRD.
+///
+/// Generic over `AsRawFd` so the same helper covers both
+/// `std::os::unix::net::UnixStream` and `tokio::net::UnixStream` — the
+/// `getsockopt` syscall doesn't care which runtime owns the fd.
+#[cfg(target_os = "linux")]
+pub fn peer_pid<S: AsRawFd>(stream: &S) -> std::io::Result<u32> {
+    let mut cred: libc::ucred = unsafe { std::mem::zeroed() };
+    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    // SAFETY: `cred` is a freshly-zeroed `libc::ucred` allocated on the
+    // stack and outlives the syscall; `len` tracks its size by value.
+    // `getsockopt` writes at most `len` bytes into the pointee, which is
+    // exactly the layout libc guarantees for `ucred`. The fd comes from
+    // `AsRawFd` so it's owned by the caller for the duration of this
+    // call. No unwinding can leak resources because there are no Drop
+    // types involved.
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            &mut cred as *mut _ as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(cred.pid as u32)
+}
+
+/// macOS variant — uses `LOCAL_PEERPID` (not `LOCAL_PEERCRED`, which
+/// returns a `struct xucred` without a PID). `nix` does not yet ship a
+/// typed wrapper for `LOCAL_PEERPID`, so a small `libc::getsockopt` call
+/// is fine; the unsafe surface is one syscall with a stack-allocated
+/// output.
+#[cfg(target_os = "macos")]
+pub fn peer_pid<S: AsRawFd>(stream: &S) -> std::io::Result<u32> {
+    let mut pid: libc::pid_t = 0;
+    let mut len = std::mem::size_of::<libc::pid_t>() as libc::socklen_t;
+    // SAFETY: `pid` is a stack-allocated `pid_t` that outlives the call;
+    // `len` matches its size by value. `getsockopt(LOCAL_PEERPID)`
+    // writes at most `len` bytes into the pointee, which is exactly
+    // `sizeof(pid_t)`. The fd is owned by the caller for the duration
+    // of this call.
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_LOCAL,
+            libc::LOCAL_PEERPID,
+            &mut pid as *mut _ as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(pid as u32)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1037,5 +1117,45 @@ mod tests {
             post_mode, 0o700,
             "prepare_state_dir must repair a loose-mode pre-existing state_dir to 0o700, got {post_mode:o}"
         );
+    }
+
+    // PRD #103 M1.5: per-OS unit tests for the `peer_pid` helper. Bind a
+    // Unix listener, connect from the same process, accept, and assert
+    // the server-side stream sees the current process's PID. Both arms
+    // (Linux SO_PEERCRED, macOS LOCAL_PEERPID) must agree with
+    // `std::process::id()` since both ends of the pair live in this test
+    // process.
+
+    /// Shared body for the Linux and macOS `peer_pid` smoke tests.
+    /// Both arms exercise an identical scenario (bind, connect from
+    /// this process, accept, assert the server-side stream sees the
+    /// current PID); the per-OS `#[cfg]` wrappers exist only because
+    /// `peer_pid` itself has two distinct getsockopt implementations
+    /// behind matching `#[cfg]`s.
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    fn peer_pid_smoke_test() {
+        let dir = race_safe_tempdir();
+        let sock = dir.path().join("peer.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
+        let _client = std::os::unix::net::UnixStream::connect(&sock).unwrap();
+        let (server, _addr) = listener.accept().unwrap();
+        let pid = peer_pid(&server).expect("peer_pid must succeed on a connected stream");
+        assert_eq!(
+            pid,
+            std::process::id(),
+            "peer_pid must return the current process's PID for a same-process connection"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn peer_pid_returns_current_process_id_on_linux() {
+        peer_pid_smoke_test();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn peer_pid_returns_current_process_id_on_macos() {
+        peer_pid_smoke_test();
     }
 }

--- a/src/daemon_protocol.rs
+++ b/src/daemon_protocol.rs
@@ -328,8 +328,16 @@ pub enum AttachRequest {
     /// `client_version` — only the client decides whether to fail (the
     /// `connect` strict path) or continue (call sites that have no version
     /// dependency).
+    ///
+    /// PRD #103 M1.2: optional `client_build_version` carries the client's
+    /// compiled-in `DAD_BUILD_ID`. The daemon logs it but never rejects on
+    /// it — mirroring the server-policy on `client_version`. Older clients
+    /// omit the field; deserialization tolerates that via
+    /// `#[serde(default)]`.
     Hello {
         client_version: u32,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        client_build_version: Option<String>,
     },
 }
 
@@ -370,6 +378,15 @@ pub struct AttachResponse {
     /// (in which case the client treats `None` as "incompatible").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server_version: Option<u32>,
+    /// PRD #103 M1.1: daemon's compiled-in `env!("DAD_BUILD_ID")` — a
+    /// finer-grained identifier than [`PROTOCOL_VERSION`] (it includes the
+    /// commit hash and dirty marker) used by the laptop to detect
+    /// same-tag-different-commit handler-code skew the protocol version
+    /// can't catch. Optional so the field is omitted on unrelated responses
+    /// and absent from pre-PRD-103 daemons (the client treats `None` as
+    /// "incompatible — recycle the daemon").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_version: Option<String>,
 }
 
 impl AttachResponse {
@@ -416,10 +433,22 @@ impl AttachResponse {
     }
     /// PRD #76 M2.21: protocol-version handshake reply. `version` is the
     /// daemon's [`PROTOCOL_VERSION`]; the client compares it against its own.
+    ///
+    /// PRD #103 M1.1: also carries the daemon's compiled-in `DAD_BUILD_ID`
+    /// so the laptop can detect handler-code skew (same protocol version,
+    /// different commit / dirty tree) the protocol version alone can't
+    /// catch.
     pub fn hello(version: u32) -> Self {
         Self {
             ok: true,
             server_version: Some(version),
+            // `local_build_id()` returns the compile-time
+            // `env!("DAD_BUILD_ID")` in production; integration tests
+            // (PRD #103 M4.2) inject a synthetic value via the
+            // `DOT_AGENT_DECK_BUILD_ID_OVERRIDE` env var so they can
+            // simulate same-tag / different-commit skew without
+            // rebuilding the binary.
+            build_version: Some(crate::build_id::local_build_id()),
             ..Default::default()
         }
     }
@@ -901,7 +930,10 @@ async fn handle_connection(
         AttachRequest::SubscribeEvents => {
             handle_subscribe_events(stream, event_tx).await?;
         }
-        AttachRequest::Hello { client_version: _ } => {
+        AttachRequest::Hello {
+            client_version: _,
+            client_build_version,
+        } => {
             // PRD #76 M2.21: the daemon never enforces or rejects on
             // `client_version` — we always reply with our own
             // `PROTOCOL_VERSION` and let the caller decide. Centralizing the
@@ -909,6 +941,28 @@ async fn handle_connection(
             // older daemon (the upgrade-skew direction the daemon can't
             // detect anyway) still gets a sensible mismatch error instead of
             // the daemon rejecting what *would* be its own future shape.
+            //
+            // PRD #103 M1.2: log the client's build_version when present
+            // for post-hoc debugging of mismatch reports. Same server
+            // policy — never reject; the laptop decides.
+            //
+            // `client_build_version` is advisory, not trust-bearing: a
+            // hostile or buggy client could embed newlines / ANSI escapes
+            // that would corrupt log files or terminal display when an
+            // operator tails the log. Pass through `escape_debug` to
+            // render any control bytes as printable escapes before
+            // formatting. The daemon-side `local_build_id()` is from our
+            // own compile-time env and doesn't need the same treatment,
+            // but escaping both keeps the log line consistently quoted.
+            if let Some(cbv) = client_build_version.as_deref() {
+                let daemon_build = crate::build_id::local_build_id();
+                let cbv_safe = cbv.escape_debug().to_string();
+                let daemon_build_safe = daemon_build.escape_debug().to_string();
+                info!(
+                    target: "daemon_protocol",
+                    "Hello from client build_version=\"{cbv_safe}\" (daemon build_version=\"{daemon_build_safe}\")",
+                );
+            }
             write_resp(&mut stream, &AttachResponse::hello(PROTOCOL_VERSION)).await?;
         }
     }
@@ -1627,16 +1681,60 @@ mod tests {
         // `kind_event_frame_round_trip` precedent.
         let req = AttachRequest::Hello {
             client_version: PROTOCOL_VERSION,
+            client_build_version: Some(env!("DAD_BUILD_ID").to_string()),
         };
         let json = serde_json::to_string(&req).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["op"], "hello");
         assert_eq!(v["client_version"], PROTOCOL_VERSION);
+        assert_eq!(v["client_build_version"], env!("DAD_BUILD_ID"));
 
         let back: AttachRequest = serde_json::from_str(&json).unwrap();
         match back {
-            AttachRequest::Hello { client_version } => {
+            AttachRequest::Hello {
+                client_version,
+                client_build_version,
+            } => {
                 assert_eq!(client_version, PROTOCOL_VERSION);
+                assert_eq!(client_build_version.as_deref(), Some(env!("DAD_BUILD_ID")));
+            }
+            other => panic!("expected Hello, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn hello_request_omits_client_build_version_when_none() {
+        // PRD #103 M1.2: when a (legacy) client doesn't populate
+        // `client_build_version`, the wire payload must not carry the
+        // field. Older daemons would reject any unknown key as a strictness
+        // failure (they don't, but the contract holds anyway).
+        let req = AttachRequest::Hello {
+            client_version: PROTOCOL_VERSION,
+            client_build_version: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(
+            !v.as_object().unwrap().contains_key("client_build_version"),
+            "client_build_version=None must be omitted from the wire payload"
+        );
+    }
+
+    #[test]
+    fn hello_request_deserializes_legacy_shape_without_client_build_version() {
+        // PRD #103 M1.2: a pre-PRD-103 client emits only `client_version`.
+        // The daemon side must accept the payload and decode
+        // `client_build_version` as None — `#[serde(default)]` makes this
+        // work, but the test pins the wire contract.
+        let json = r#"{"op":"hello","client_version":2}"#;
+        let req: AttachRequest = serde_json::from_str(json).unwrap();
+        match req {
+            AttachRequest::Hello {
+                client_version,
+                client_build_version,
+            } => {
+                assert_eq!(client_version, 2);
+                assert!(client_build_version.is_none());
             }
             other => panic!("expected Hello, got {other:?}"),
         }
@@ -1649,10 +1747,51 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(v["ok"], true);
         assert_eq!(v["server_version"], PROTOCOL_VERSION);
+        // PRD #103 M1.1: hello() must populate `build_version` from the
+        // daemon's compiled-in DAD_BUILD_ID so the laptop can detect
+        // handler-code skew. The exact value is build-time-derived; we just
+        // require it's present and non-empty here.
+        let wire_build_version = v["build_version"]
+            .as_str()
+            .expect("hello() must emit build_version on the wire");
+        assert!(
+            !wire_build_version.is_empty(),
+            "build_version must be non-empty"
+        );
+        assert_eq!(wire_build_version, env!("DAD_BUILD_ID"));
 
         let back: AttachResponse = serde_json::from_str(&json).unwrap();
         assert!(back.ok);
         assert_eq!(back.server_version, Some(PROTOCOL_VERSION));
+        assert_eq!(back.build_version.as_deref(), Some(env!("DAD_BUILD_ID")));
+    }
+
+    #[test]
+    fn response_omits_build_version_when_none() {
+        // PRD #103 M1.1: forward compat. An unrelated response (e.g.
+        // list-agents) must NOT carry `build_version` on the wire — older
+        // peers ignore the field, newer peers treat its absence on a hello
+        // reply as "incompatible / recycle the daemon".
+        let resp = AttachResponse::ok();
+        let v: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&resp).unwrap()).unwrap();
+        assert!(
+            !v.as_object().unwrap().contains_key("build_version"),
+            "build_version=None should be omitted from the wire payload"
+        );
+    }
+
+    #[test]
+    fn response_deserializes_legacy_shape_without_build_version() {
+        // PRD #103 M1.1: a pre-PRD-103 daemon emits `server_version` but
+        // not `build_version`. The newer client must accept the payload
+        // and decode the field as None — which is what the mismatch logic
+        // uses to flag "daemon too old / recycle it".
+        let json = r#"{"ok":true,"server_version":2}"#;
+        let resp: AttachResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.ok);
+        assert_eq!(resp.server_version, Some(2));
+        assert!(resp.build_version.is_none());
     }
 
     #[test]
@@ -1707,6 +1846,7 @@ mod tests {
         let (mut rd, mut wr) = client.into_split();
         let req = AttachRequest::Hello {
             client_version: 99, // deliberately not PROTOCOL_VERSION
+            client_build_version: None,
         };
         let payload = serde_json::to_vec(&req).unwrap();
         write_frame(&mut wr, KIND_REQ, &payload).await.unwrap();
@@ -1751,6 +1891,7 @@ mod tests {
         let (mut rd, mut wr) = client.into_split();
         let req = AttachRequest::Hello {
             client_version: u32::MAX,
+            client_build_version: None,
         };
         let payload = serde_json::to_vec(&req).unwrap();
         write_frame(&mut wr, KIND_REQ, &payload).await.unwrap();

--- a/src/daemon_stop.rs
+++ b/src/daemon_stop.rs
@@ -1,0 +1,301 @@
+//! PRD #103 Phase 3 — `dot-agent-deck daemon stop` / `daemon restart`.
+//!
+//! Documented, non-`kill -9` way to recycle the local daemon. Three
+//! load-bearing properties:
+//!
+//! 1. **PID discovery via `peer_pid()`** ([`crate::daemon_attach::peer_pid`])
+//!    — `SO_PEERCRED` / `LOCAL_PEERPID` on the connected attach socket.
+//!    No protocol surface required, so this works against *any* daemon
+//!    version including the v0.24.x daemon that motivated this PRD.
+//! 2. **Agent-liveness check via existing `ListAgents`** — predates
+//!    every change in this PRD, so a stale daemon answers normally.
+//!    Refuse without `--force` when ≥1 agent is alive (data-loss
+//!    guard).
+//! 3. **SIGTERM + poll + optional SIGKILL escalation** —
+//!    [`crate::build_version_handshake::terminate_daemon_graceful`]
+//!    handles both stages; this module just decides whether to pass
+//!    `force_kill_after = Some(...)` based on the `--force` flag.
+//!
+//! `restart` is implemented as a thin wrapper: it runs `stop` and
+//! returns. The next TUI invocation lazy-spawns a fresh daemon per
+//! PRD #93.
+
+use std::io;
+use std::path::Path;
+use std::time::Duration;
+
+use tokio::net::UnixStream;
+use tracing::debug;
+
+use crate::build_version_handshake::{HandshakeError, TerminateOutcome, terminate_daemon_graceful};
+use crate::daemon_attach::peer_pid;
+use crate::daemon_client::issue_command;
+use crate::daemon_protocol::AttachRequest;
+
+/// SIGTERM grace before reporting "daemon did not exit cleanly". PRD #103
+/// M3.2: 5 s.
+pub const STOP_GRACE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// SIGKILL grace after SIGTERM timed out (only used with `--force`).
+/// PRD #103 M3.2: ~1 s.
+pub const STOP_FORCE_KILL_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Successful outcomes. `Stopped` is the normal case; `ForceKilled` only
+/// reachable with `--force` after SIGTERM timed out;
+/// `NoDaemonRunning` is the idempotent missing-socket case (exit 0).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StopOutcome {
+    NoDaemonRunning,
+    Stopped { pid: u32 },
+    ForceKilled { pid: u32 },
+}
+
+#[derive(Debug)]
+pub enum StopError {
+    /// `UnixStream::connect` failed in a non-idempotent way (i.e. not
+    /// ECONNREFUSED / ENOENT — those are folded into
+    /// [`StopOutcome::NoDaemonRunning`]).
+    ConnectFailed(io::Error),
+    /// `peer_pid` syscall failed. macOS/Linux both support it, so this
+    /// is exceptional.
+    PeerPid(io::Error),
+    /// `ListAgents` round-trip failed (transport or daemon-level error).
+    ListAgents(String),
+    /// Daemon is hosting `ids` and `--force` was not passed.
+    LiveAgents { ids: Vec<String> },
+    /// SIGTERM (and SIGKILL if `--force`) failed to take the daemon
+    /// down within the configured timeouts.
+    TimedOut { pid: u32 },
+    /// `libc::kill` itself failed (typically ESRCH if the daemon already
+    /// exited between probe and signal).
+    KillFailed(io::Error),
+}
+
+impl std::fmt::Display for StopError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConnectFailed(e) => write!(f, "failed to connect to daemon: {e}"),
+            Self::PeerPid(e) => write!(f, "failed to read daemon's peer PID: {e}"),
+            Self::ListAgents(msg) => write!(f, "list-agents failed: {msg}"),
+            Self::LiveAgents { ids } => {
+                write!(
+                    f,
+                    "daemon has {n} managed agent(s) running; pass --force to terminate them",
+                    n = ids.len()
+                )
+            }
+            Self::TimedOut { pid } => {
+                write!(
+                    f,
+                    "daemon (pid {pid}) did not exit cleanly within {}s; re-run with --force to SIGKILL",
+                    STOP_GRACE_TIMEOUT.as_secs()
+                )
+            }
+            Self::KillFailed(e) => write!(f, "kill syscall failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for StopError {}
+
+/// Drive the `daemon stop` flow against `attach_path`. Reusable from
+/// `cmd_daemon_stop`, `cmd_daemon_restart`, and the integration test
+/// suite (`tests/daemon_stop.rs`).
+///
+/// Step-by-step:
+/// 1. `connect`. `ECONNREFUSED` / `ENOENT` fold into
+///    [`StopOutcome::NoDaemonRunning`] — covers both "socket file
+///    missing" (ENOENT) and "stale socket inode after a crash"
+///    (ECONNREFUSED). No separate `exists()` pre-check: that opens a
+///    TOCTOU window where the daemon could exit (or be created)
+///    between the file probe and the connect, and `connect` itself is
+///    the authoritative liveness signal.
+/// 2. `peer_pid(&stream)` — load-bearing: works against any daemon
+///    version because no protocol bytes are exchanged.
+/// 3. Send `ListAgents`. If ≥1 alive and `!force`, return
+///    [`StopError::LiveAgents`] *without* signaling — the user must
+///    detach the agents or pass `--force` consciously.
+/// 4. `terminate_daemon_graceful(pid, attach_path, 5s, force.then(|| 1s))`:
+///    - SIGTERM, poll up to 5 s for the daemon to stop accepting connects.
+///    - On timeout with `force`: SIGKILL, poll up to 1 s.
+///    - On timeout without `force`: surface as `TimedOut`.
+pub async fn run_daemon_stop(attach_path: &Path, force: bool) -> Result<StopOutcome, StopError> {
+    let stream = match UnixStream::connect(attach_path).await {
+        Ok(s) => s,
+        Err(e)
+            if e.kind() == io::ErrorKind::ConnectionRefused
+                || e.kind() == io::ErrorKind::NotFound =>
+        {
+            // ENOENT — socket file is gone; the daemon never started
+            // or its cleanup unlinked the inode.
+            // ECONNREFUSED — stale socket inode after a crash / kill
+            // -9 / host reboot.
+            // Both are "no daemon" per the PRD's recovery contract;
+            // idempotent exit 0. A subsequent `daemon serve`
+            // (lazy-spawn or explicit) will unlink and rebind via the
+            // existing probe-remove-bind path under flock.
+            debug!(
+                target: "daemon_stop",
+                path = %attach_path.display(),
+                err = %e,
+                "no daemon running (connect failed)"
+            );
+            return Ok(StopOutcome::NoDaemonRunning);
+        }
+        Err(e) => return Err(StopError::ConnectFailed(e)),
+    };
+
+    let pid = peer_pid(&stream).map_err(StopError::PeerPid)?;
+    let (mut rd, mut wr) = stream.into_split();
+    let resp = issue_command(&mut rd, &mut wr, &AttachRequest::ListAgents)
+        .await
+        .map_err(|e| StopError::ListAgents(e.to_string()))?;
+    if !resp.ok {
+        return Err(StopError::ListAgents(resp.error.unwrap_or_default()));
+    }
+    // Prefer the typed agent_records (carries pane_id_env, display_name,
+    // etc.) but fall back to the legacy `agents` array of ids for
+    // forward-compat with daemons that don't emit agent_records.
+    let agent_ids: Vec<String> = resp
+        .agent_records
+        .map(|rs| rs.into_iter().map(|r| r.id).collect::<Vec<_>>())
+        .or(resp.agents)
+        .unwrap_or_default();
+    drop(rd);
+    drop(wr);
+
+    debug!(
+        target: "daemon_stop",
+        pid,
+        agent_count = agent_ids.len(),
+        force,
+        "daemon_stop: probed daemon, deciding policy"
+    );
+
+    if !agent_ids.is_empty() && !force {
+        return Err(StopError::LiveAgents { ids: agent_ids });
+    }
+
+    let force_window = if force {
+        Some(STOP_FORCE_KILL_TIMEOUT)
+    } else {
+        None
+    };
+    match terminate_daemon_graceful(pid, attach_path, STOP_GRACE_TIMEOUT, force_window).await {
+        Ok(TerminateOutcome::Stopped) => Ok(StopOutcome::Stopped { pid }),
+        Ok(TerminateOutcome::Killed) => Ok(StopOutcome::ForceKilled { pid }),
+        Err(HandshakeError::TerminateTimedOut) => Err(StopError::TimedOut { pid }),
+        Err(HandshakeError::TerminateFailed(e)) => Err(StopError::KillFailed(e)),
+        // The remaining HandshakeError variants are produced only by
+        // the Phase 2 probe/prompt paths in build_version_handshake.rs.
+        // terminate_daemon_graceful itself cannot surface them; fold
+        // them into KillFailed for forward-compat if that ever changes.
+        Err(other) => Err(StopError::KillFailed(io::Error::other(other.to_string()))),
+    }
+}
+
+/// Render the multi-line `LiveAgents` refusal message used by both
+/// `daemon stop` and `daemon restart` CLI handlers (PRD #103 M3.2/M3.3).
+/// Centralised so the two CLI sites can't drift — the user-visible
+/// header (`daemon has N managed agent(s) running`), the indented agent
+/// list, and the recovery hint (`pass --force to terminate them`) are
+/// all pinned by the M4.x integration tests via `live_agents_refusal()`.
+///
+/// Trailing newline included so callers can `eprint!` the result
+/// directly without an extra `println!`.
+pub fn format_live_agents_refusal(ids: &[String]) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "daemon has {n} managed agent(s) running:",
+        n = ids.len()
+    );
+    for id in ids {
+        let _ = writeln!(out, "  {id}");
+    }
+    let _ = writeln!(out, "pass --force to terminate them");
+    out
+}
+
+/// `daemon restart`: PRD #103 M3.3 — same logic as `daemon stop`. The
+/// next TUI invocation lazy-spawns a fresh daemon (PRD #93). This is
+/// intentionally a thin wrapper rather than a stop-then-spawn flow,
+/// because spawning a daemon out of `daemon restart` would either
+/// race the next TUI's `ensure_external_daemon_or_die` (two daemons
+/// trying to bind under flock) or require duplicating the lazy-spawn
+/// machinery here.
+pub async fn run_daemon_restart(attach_path: &Path, force: bool) -> Result<StopOutcome, StopError> {
+    run_daemon_stop(attach_path, force).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn stop_returns_no_daemon_running_when_socket_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let attach_path = dir.path().join("nonexistent.sock");
+        let outcome = run_daemon_stop(&attach_path, false).await.unwrap();
+        assert_eq!(outcome, StopOutcome::NoDaemonRunning);
+    }
+
+    #[tokio::test]
+    async fn restart_no_daemon_running_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let attach_path = dir.path().join("nonexistent.sock");
+        let outcome = run_daemon_restart(&attach_path, false).await.unwrap();
+        assert_eq!(outcome, StopOutcome::NoDaemonRunning);
+    }
+
+    #[tokio::test]
+    async fn stop_returns_no_daemon_running_when_connect_refused() {
+        // Bind and immediately drop a Unix listener: the inode lingers
+        // but connect returns ECONNREFUSED. This is the "stale socket
+        // after a crash" case the PRD calls out — must fold into
+        // NoDaemonRunning, not surface as an error.
+        use std::os::unix::net::UnixListener;
+        let dir = tempfile::tempdir().unwrap();
+        let attach_path = dir.path().join("stale.sock");
+        let listener = UnixListener::bind(&attach_path).unwrap();
+        drop(listener);
+        // File should still be on disk (bind didn't unlink on drop).
+        assert!(attach_path.exists());
+        let outcome = run_daemon_stop(&attach_path, false).await.unwrap();
+        assert_eq!(outcome, StopOutcome::NoDaemonRunning);
+    }
+
+    #[test]
+    fn live_agents_error_message_mentions_force_flag() {
+        // Pin the user-visible refusal message so the M4.x tests
+        // and docs can rely on it. The exact phrasing surfaces in
+        // run_daemon_stop_cli's eprintln; keep this in sync.
+        let err = StopError::LiveAgents {
+            ids: vec!["a".into(), "b".into()],
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--force"),
+            "live-agents refusal must mention --force, got: {msg:?}"
+        );
+        assert!(
+            msg.contains("2 managed agent(s) running"),
+            "live-agents refusal must include the count, got: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn timed_out_error_message_mentions_force_recovery() {
+        let err = StopError::TimedOut { pid: 12345 };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--force"),
+            "TimedOut message must point at --force, got: {msg:?}"
+        );
+        assert!(
+            msg.contains("12345"),
+            "TimedOut message must include the daemon PID, got: {msg:?}"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod agent_pty;
 pub mod ascii_art;
+pub mod build_id;
+pub mod build_version_handshake;
 pub mod config;
 pub mod config_gen;
 pub mod config_validation;
@@ -8,6 +10,7 @@ pub mod daemon;
 pub mod daemon_attach;
 pub mod daemon_client;
 pub mod daemon_protocol;
+pub mod daemon_stop;
 pub mod embedded_pane;
 pub mod error;
 pub mod event;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use tokio::sync::RwLock;
 
 use dot_agent_deck::agent_pty::DOT_AGENT_DECK_PANE_ID;
+use dot_agent_deck::build_version_handshake;
 use dot_agent_deck::config::{DashboardConfig, attach_socket_path, socket_path};
 use dot_agent_deck::daemon::{Daemon, run_daemon_with};
 use dot_agent_deck::daemon_attach::ensure_external_daemon_or_die;
@@ -147,6 +148,25 @@ enum DaemonCmd {
     /// `AttachResponse` carrying `server_version` so the client side can
     /// reuse its existing deserializer.
     Hello,
+    /// Stop the local daemon gracefully (SIGTERM, then poll for it to
+    /// stop accepting connections). PRD #103 Phase 3 — documented
+    /// alternative to `kill -9` after upgrading the binary. Refuses
+    /// without `--force` when managed agents are still running.
+    Stop {
+        /// Terminate even when managed agents are running, and escalate
+        /// to SIGKILL if SIGTERM doesn't take effect within the grace
+        /// window. Data-loss guard — only pass this when you have
+        /// already detached anything you cared about.
+        #[arg(long)]
+        force: bool,
+    },
+    /// Stop the local daemon (same flags as `stop`). The next
+    /// `dot-agent-deck` invocation lazy-spawns a fresh daemon.
+    Restart {
+        /// See `stop --force`.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Default, clap::ValueEnum)]
@@ -405,6 +425,8 @@ fn main() -> ExitCode {
         Some(Commands::Daemon { cmd }) => match cmd {
             DaemonCmd::Serve => run_daemon_serve_cli(),
             DaemonCmd::Hello => run_daemon_hello_cli(),
+            DaemonCmd::Stop { force } => run_daemon_stop_cli(force),
+            DaemonCmd::Restart { force } => run_daemon_restart_cli(force),
         },
         Some(Commands::Remote { cmd }) => match cmd {
             RemoteCmd::Add {
@@ -587,6 +609,58 @@ async fn run_tui_session(cli_theme: Option<Theme>, continue_session: bool) -> Ex
         );
         return ExitCode::FAILURE;
     }
+    // PRD #103 Phase 2: build-version handshake against the running daemon.
+    // Runs unconditionally — including the freshly-spawned case where the
+    // build-ids are necessarily equal (PRD M2.3). The cost is one extra
+    // Unix-socket round-trip on cold start; the upside is a smoke test of
+    // the handshake on every launch, which catches regressions in
+    // `ensure_external_daemon_or_die` itself (wrong socket / wrong binary)
+    // or in the wire encoding of the `build_version` field.
+    //
+    // On mismatch + TTY: presents an interactive prompt; on S the daemon
+    // is SIGTERM'd and we fall through (the next attach lazy-spawns a
+    // fresh daemon at the current build). On mismatch + non-TTY: prints
+    // the recovery hint to stderr and exits non-zero. Errors are already
+    // user-visible inside the helper, so we render no further message
+    // here.
+    let handshake_outcome =
+        match build_version_handshake::ensure_compatible_daemon_or_die(&attach_path).await {
+            Ok(outcome) => outcome,
+            Err(build_version_handshake::HandshakeError::MismatchAborted) => {
+                return ExitCode::FAILURE;
+            }
+            Err(e) => {
+                eprintln!("{e}");
+                return ExitCode::FAILURE;
+            }
+        };
+    // After a `Recovered` outcome the old daemon was just SIGTERM'd; the
+    // next attach lazy-spawns a fresh one. Re-run the bootstrap so the
+    // socket is back before any client (DaemonClient::list_agents,
+    // spawn_event_subscriber, the embedded-pane controller) touches it.
+    // On `Match` the daemon is already running and compatible — re-running
+    // the bootstrap would just be wasted I/O.
+    if matches!(
+        handshake_outcome,
+        build_version_handshake::HandshakeOutcome::Recovered
+    ) && let Err(e) = ensure_external_daemon_or_die(&attach_path).await
+    {
+        eprintln!(
+            "failed to re-spawn daemon at {} after version-mismatch recovery: {e}",
+            attach_path.display()
+        );
+        return ExitCode::FAILURE;
+    }
+    // Test-only escape hatch (PRD #103 M4.2): integration tests in
+    // tests/build_version_handshake.rs need to exercise the handshake
+    // path (including SIGTERM + lazy re-spawn) without entering the
+    // full TUI. Setting `DOT_AGENT_DECK_EXIT_AFTER_HANDSHAKE` causes
+    // the TUI to exit cleanly here, after the handshake completed and
+    // the daemon socket is back up. Production code never sets it; the
+    // env-var name is grep-ably explicit so a future audit can confirm.
+    if std::env::var_os("DOT_AGENT_DECK_EXIT_AFTER_HANDSHAKE").is_some() {
+        return ExitCode::SUCCESS;
+    }
     // PRD #76 M2.17: subscribe to the daemon's `AgentEvent` broadcast so
     // the TUI's `AppState` mirrors live agent activity.
     spawn_event_subscriber(attach_path.clone(), state.clone());
@@ -760,7 +834,8 @@ fn run_connect(
 
 /// `dot-agent-deck daemon hello` — PRD #76 M2.21 protocol-version handshake.
 /// Prints a JSON-encoded [`dot_agent_deck::daemon_protocol::AttachResponse`]
-/// carrying `server_version = PROTOCOL_VERSION` and exits.
+/// carrying `server_version = PROTOCOL_VERSION` (and, per PRD #103 M1.3,
+/// `build_version = env!("DAD_BUILD_ID")`) and exits.
 ///
 /// Used by the laptop-side `connect` flow over ssh: the remote binary's
 /// compiled-in `PROTOCOL_VERSION` is what its daemon would speak, so a static
@@ -786,6 +861,79 @@ fn run_daemon_hello_cli() -> ExitCode {
     };
     println!("{json}");
     ExitCode::SUCCESS
+}
+
+/// `dot-agent-deck daemon stop [--force]` — PRD #103 Phase 3 (M3.2).
+/// Documented, non-`kill -9` way to recycle the local daemon after a
+/// binary upgrade. Idempotent (no-op exit 0 when no daemon is running)
+/// and safe-by-default (refuses when managed agents are alive unless
+/// `--force` is passed). The recovery flow is in
+/// [`dot_agent_deck::daemon_stop::run_daemon_stop`]; this function
+/// only translates outcomes into stdout/stderr text and exit codes.
+#[tokio::main]
+async fn run_daemon_stop_cli(force: bool) -> ExitCode {
+    let attach_path = attach_socket_path();
+    match dot_agent_deck::daemon_stop::run_daemon_stop(&attach_path, force).await {
+        Ok(dot_agent_deck::daemon_stop::StopOutcome::NoDaemonRunning) => {
+            println!("no daemon running");
+            ExitCode::SUCCESS
+        }
+        Ok(dot_agent_deck::daemon_stop::StopOutcome::Stopped { pid }) => {
+            println!("daemon stopped (pid {pid})");
+            ExitCode::SUCCESS
+        }
+        Ok(dot_agent_deck::daemon_stop::StopOutcome::ForceKilled { pid }) => {
+            println!("daemon force-killed via SIGKILL (pid {pid})");
+            ExitCode::SUCCESS
+        }
+        Err(dot_agent_deck::daemon_stop::StopError::LiveAgents { ids }) => {
+            eprint!(
+                "{}",
+                dot_agent_deck::daemon_stop::format_live_agents_refusal(&ids)
+            );
+            ExitCode::FAILURE
+        }
+        Err(e) => {
+            eprintln!("daemon stop: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// `dot-agent-deck daemon restart [--force]` — PRD #103 Phase 3 (M3.3).
+/// Thin wrapper over `daemon stop`: the next TUI invocation lazy-spawns
+/// a fresh daemon per PRD #93. Shares the same `--force` semantics as
+/// `daemon stop`.
+#[tokio::main]
+async fn run_daemon_restart_cli(force: bool) -> ExitCode {
+    let attach_path = attach_socket_path();
+    match dot_agent_deck::daemon_stop::run_daemon_restart(&attach_path, force).await {
+        Ok(dot_agent_deck::daemon_stop::StopOutcome::NoDaemonRunning) => {
+            println!("no daemon running; next invocation will spawn one");
+            ExitCode::SUCCESS
+        }
+        Ok(dot_agent_deck::daemon_stop::StopOutcome::Stopped { pid }) => {
+            println!("daemon stopped (pid {pid}); next invocation will spawn a fresh daemon");
+            ExitCode::SUCCESS
+        }
+        Ok(dot_agent_deck::daemon_stop::StopOutcome::ForceKilled { pid }) => {
+            println!(
+                "daemon force-killed via SIGKILL (pid {pid}); next invocation will spawn a fresh daemon"
+            );
+            ExitCode::SUCCESS
+        }
+        Err(dot_agent_deck::daemon_stop::StopError::LiveAgents { ids }) => {
+            eprint!(
+                "{}",
+                dot_agent_deck::daemon_stop::format_live_agents_refusal(&ids)
+            );
+            ExitCode::FAILURE
+        }
+        Err(e) => {
+            eprintln!("daemon restart: {e}");
+            ExitCode::FAILURE
+        }
+    }
 }
 
 /// `dot-agent-deck daemon serve` — PRD #76 M4.3. Runs the daemon (hook

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1113,6 +1113,14 @@ fn build_orchestrator_context(config: &OrchestrationConfig) -> String {
          Never send a new task to a worker that is still working on a previous task. \
          Wait for its work-done signal before delegating again to the same worker. \
          Delegating to different workers in parallel is fine.\n\n\
+         Delegation is one-way: orchestrator → worker. Workers NEVER delegate to other workers \
+         — a `dot-agent-deck delegate` call from inside a worker does not route back through your \
+         notification stream, so the downstream task is silently dropped and the calling worker \
+         waits forever (or signals work-done in a paused state). When briefing a worker, never \
+         instruct them to \"delegate the fix to coder\" or \"hand off to <other role>\". \
+         Instead, tell them to report the diagnosis back and signal work-done; you (the orchestrator) \
+         will delegate the next hop. The chain you coordinate is: worker A diagnoses → reports → \
+         you delegate to worker B → worker B works → reports → you re-engage worker A.\n\n\
          When a task related to a PRD is fully completed (all workers done, reviews passed), \
          run `/prd-update-progress` yourself before signaling `--done` or moving to the next task.\n",
     );
@@ -7788,6 +7796,9 @@ mod tests {
         // Instructs orchestrator to wait then delegate.
         assert!(content.contains("Wait for the user to tell you what to work on"));
         assert!(content.contains("delegate immediately"));
+        // Enforces one-way delegation (workers never delegate to other workers).
+        assert!(content.contains("Delegation is one-way"));
+        assert!(content.contains("Workers NEVER delegate to other workers"));
     }
 
     #[test]

--- a/tests/build_id.rs
+++ b/tests/build_id.rs
@@ -1,0 +1,83 @@
+//! PRD #103 M1.0: smoke test for the `DAD_BUILD_ID` env var emitted by `build.rs`.
+//!
+//! Asserts that the build script produced a non-empty identifier and that it
+//! starts with `DAD_VERSION` — the two invariants the handshake comparison
+//! relies on (the rest of the suffix is `g<sha>[-dirty]` or `-unknown`, both
+//! of which start with `<DAD_VERSION>-`).
+
+#[test]
+fn dad_build_id_is_non_empty_and_starts_with_version() {
+    let build_id = env!("DAD_BUILD_ID");
+    let version = env!("DAD_VERSION");
+
+    assert!(!build_id.is_empty(), "DAD_BUILD_ID must not be empty");
+    assert!(!version.is_empty(), "DAD_VERSION must not be empty");
+    assert!(
+        build_id.starts_with(version),
+        "DAD_BUILD_ID ({build_id}) must start with DAD_VERSION ({version})"
+    );
+    // The suffix must be one of `-g<sha>[-dirty]` or `-unknown` — both begin
+    // with the version prefix followed by a `-`.
+    let suffix = &build_id[version.len()..];
+    assert!(
+        suffix.starts_with('-'),
+        "DAD_BUILD_ID suffix must start with '-' (got {suffix:?})"
+    );
+}
+
+/// PRD #103 invariant 6 regression guard. `build.rs` emits
+/// `cargo:rerun-if-changed=<resolved>` for `.git/HEAD`, `.git/index`,
+/// `.git/packed-refs`, and the resolved `refs/heads/<branch>`. In a git
+/// worktree, those literal paths don't exist — `.git` is a *file*
+/// pointing at the main repo's worktree storage — and the cargo
+/// directive silently no-ops, so a stale `DAD_BUILD_ID` would survive a
+/// commit on the current branch (the exact bug the PRD names).
+///
+/// We can't directly assert that cargo *would* rebuild on a new commit
+/// (cargo's incremental machinery isn't exposed to test code). What we
+/// can assert cheaply, with the same load-bearing signal, is that the
+/// `DAD_BUILD_ID` that *was* baked into this test binary actually
+/// reflects the current `HEAD` short-SHA. If the resolution logic ever
+/// regresses to a wrong path — or a future refactor goes back to the
+/// literal `.git/HEAD` and starts no-op'ing in worktrees — this test
+/// pins a build_id that doesn't carry the current SHA and fails.
+///
+/// Skipped if `git rev-parse` isn't on PATH or this isn't a git repo
+/// (tarball / shallow clone build): in those cases `compose_build_id`
+/// falls back to `<version>-unknown`, which the assertion above already
+/// pins.
+#[test]
+fn dad_build_id_carries_current_head_short_sha() {
+    let build_id = env!("DAD_BUILD_ID");
+
+    let Ok(output) = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+    else {
+        eprintln!("skipping: `git rev-parse` not available");
+        return;
+    };
+    if !output.status.success() {
+        eprintln!("skipping: not a git repo or git failed");
+        return;
+    }
+    let short_sha = String::from_utf8(output.stdout)
+        .expect("git rev-parse output must be UTF-8")
+        .trim()
+        .to_string();
+    if short_sha.is_empty() {
+        eprintln!("skipping: empty short SHA");
+        return;
+    }
+
+    // The build_id format is `<version>-g<short-sha>[-dirty]` or
+    // `<version>-unknown`. The `-unknown` branch is only reached when
+    // `git rev-parse --short HEAD` itself fails — which we just verified
+    // succeeded — so we must be in the `g<short-sha>` branch.
+    assert!(
+        build_id.contains(&short_sha),
+        "DAD_BUILD_ID ({build_id}) must contain the current HEAD short SHA ({short_sha}); \
+         if you just rebased or committed and this fails, build.rs's rerun-if-changed paths \
+         likely no longer resolve in the current worktree (PRD #103 invariant 6)"
+    );
+}

--- a/tests/build_version_handshake.rs
+++ b/tests/build_version_handshake.rs
@@ -1,0 +1,537 @@
+//! PRD #103 M4.2 — integration tests for the local-attach build-version
+//! handshake (`build_version_handshake::ensure_compatible_daemon_or_die`).
+//!
+//! Each test spawns:
+//!   * a real `dot-agent-deck daemon serve` subprocess (the same binary
+//!     pattern as `tests/daemon_stop.rs`), so peer-credential PID
+//!     lookups and SIGTERM-driven recovery exercise the production code
+//!     paths rather than an in-process tokio task; and
+//!   * a real `dot-agent-deck` TUI subprocess, either under a piped
+//!     stdio (non-TTY scenarios 4 + 5) or a portable-pty PTY pair (TTY
+//!     scenarios 1–3).
+//!
+//! The build_id under comparison is injected via the test-only
+//! `DOT_AGENT_DECK_BUILD_ID_OVERRIDE` env var. Both
+//! `AttachResponse::hello` (daemon side, via
+//! [`dot_agent_deck::build_id::local_build_id`]) and
+//! `ensure_compatible_daemon_or_die` (TUI side, same helper) honour the
+//! same variable, so setting it independently on the daemon and TUI
+//! subprocesses simulates the same-tag / different-commit skew without
+//! rebuilding the binary at a synthetic `DAD_BUILD_ID`.
+//!
+//! The TUI subprocess additionally sets `DOT_AGENT_DECK_EXIT_AFTER_HANDSHAKE`
+//! to bail out cleanly after the handshake + lazy-respawn succeed,
+//! instead of entering the full ratatui session (which would never exit
+//! on its own inside `cargo test`).
+
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use portable_pty::{CommandBuilder, MasterPty, NativePtySystem, PtySize, PtySystem};
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+
+use dot_agent_deck::daemon_client::{DaemonClient, StartAgentOptions};
+
+/// Build-ids sharing the `0.25.0-` tag prefix but differing in the
+/// `-g<sha>` suffix — the same-tag / different-commit case that the
+/// PRD explicitly calls out. Used in the "no agents, S press" test
+/// since the recovery flow there is the most thorough exercise of the
+/// mismatch path.
+const DAEMON_BUILD: &str = "0.25.0-gdaemon00";
+const TUI_BUILD: &str = "0.25.0-gclient00";
+
+/// Subprocess daemon scoped to a tempdir. On drop, kills the
+/// originally-spawned daemon and additionally runs `daemon stop
+/// --force` against the socket path so any lazy-respawn that replaced
+/// our child (after the TUI's SIGTERM in the recovery flow) is also
+/// cleaned up. Without that second step a successful recovery test
+/// would leak a detached daemon between cargo test invocations.
+struct TestDaemon {
+    _dir: TempDir,
+    attach_path: PathBuf,
+    hook_path: PathBuf,
+    state_dir: PathBuf,
+    lock_dir: PathBuf,
+    child: Option<Child>,
+}
+
+impl Drop for TestDaemon {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        // Best-effort cleanup of any lazy-respawned daemon. Ignored
+        // failures are fine — if nothing is listening, this is a no-op.
+        let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
+        let _ = Command::new(bin)
+            .args(["daemon", "stop", "--force"])
+            .env("DOT_AGENT_DECK_SOCKET", &self.hook_path)
+            .env("DOT_AGENT_DECK_ATTACH_SOCKET", &self.attach_path)
+            .env("DOT_AGENT_DECK_STATE_DIR", &self.state_dir)
+            .env("DOT_AGENT_DECK_LOCK_DIR", &self.lock_dir)
+            .env("RUST_LOG", "error")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+/// Spawn the daemon subprocess and wait for the attach socket to be
+/// accepting connections. `build_id_override` is set on the daemon's
+/// env iff `Some(_)` — `None` lets the daemon fall back to its
+/// compile-time `DAD_BUILD_ID`.
+async fn spawn_daemon(build_id_override: Option<&str>) -> TestDaemon {
+    let dir = tempfile::tempdir().unwrap();
+    let attach_path = dir.path().join("attach.sock");
+    let hook_path = dir.path().join("hook.sock");
+    let state_dir = dir.path().join("state");
+    let lock_dir = dir.path().join("lock");
+    std::fs::create_dir_all(&state_dir).unwrap();
+    std::fs::create_dir_all(&lock_dir).unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
+    let mut cmd = Command::new(bin);
+    cmd.args(["daemon", "serve"])
+        .env("DOT_AGENT_DECK_SOCKET", &hook_path)
+        .env("DOT_AGENT_DECK_ATTACH_SOCKET", &attach_path)
+        .env("DOT_AGENT_DECK_STATE_DIR", &state_dir)
+        .env("DOT_AGENT_DECK_LOCK_DIR", &lock_dir)
+        .env("RUST_LOG", "error")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if let Some(bid) = build_id_override {
+        cmd.env("DOT_AGENT_DECK_BUILD_ID_OVERRIDE", bid);
+    } else {
+        // Defensive: ensure no leaked override from the test runner's
+        // own env reaches the daemon. We never set it on the test
+        // process, but a future change could.
+        cmd.env_remove("DOT_AGENT_DECK_BUILD_ID_OVERRIDE");
+    }
+    let mut child = cmd
+        .spawn()
+        .expect("spawn dot-agent-deck daemon serve subprocess");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if attach_path.exists() && UnixStream::connect(&attach_path).await.is_ok() {
+            return TestDaemon {
+                _dir: dir,
+                attach_path,
+                hook_path,
+                state_dir,
+                lock_dir,
+                child: Some(child),
+            };
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    panic!(
+        "subprocess daemon failed to bind {} within 15s",
+        attach_path.display()
+    );
+}
+
+/// Build the env-var block applied to a TUI subprocess. Pinned to the
+/// same socket / state paths the daemon was started with.
+fn tui_env_pairs(d: &TestDaemon) -> Vec<(&'static str, String)> {
+    vec![
+        (
+            "DOT_AGENT_DECK_SOCKET",
+            d.hook_path.to_string_lossy().into_owned(),
+        ),
+        (
+            "DOT_AGENT_DECK_ATTACH_SOCKET",
+            d.attach_path.to_string_lossy().into_owned(),
+        ),
+        (
+            "DOT_AGENT_DECK_STATE_DIR",
+            d.state_dir.to_string_lossy().into_owned(),
+        ),
+        (
+            "DOT_AGENT_DECK_LOCK_DIR",
+            d.lock_dir.to_string_lossy().into_owned(),
+        ),
+        // Bail out after the handshake (+ optional lazy-respawn)
+        // instead of entering the full TUI. PRD #103 M4.2.
+        ("DOT_AGENT_DECK_EXIT_AFTER_HANDSHAKE", "1".to_string()),
+        ("RUST_LOG", "error".to_string()),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — non-TTY / CI fallback. stdout piped → `is_terminal()` is
+// false → handshake prints the plain stderr message and exits non-zero.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn non_tty_mismatch_prints_stderr_and_exits_nonzero() {
+    let daemon = spawn_daemon(Some(DAEMON_BUILD)).await;
+    let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
+
+    let mut cmd = Command::new(bin);
+    cmd.env("DOT_AGENT_DECK_BUILD_ID_OVERRIDE", TUI_BUILD)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped());
+    for (k, v) in tui_env_pairs(&daemon) {
+        cmd.env(k, v);
+    }
+    let output = cmd.output().expect("spawn TUI subprocess");
+
+    assert!(
+        !output.status.success(),
+        "non-TTY mismatch must exit non-zero, got status {:?}",
+        output.status
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    // PRD #103 M2.1 / `render_non_tty_error` pin this text exactly:
+    // both build-ids on one line, recovery hint on the next.
+    let expected = format!(
+        "error: local daemon is build {DAEMON_BUILD} but this TUI is build {TUI_BUILD}\n\
+         recover with: dot-agent-deck daemon stop\n"
+    );
+    assert!(
+        stderr.contains(&expected),
+        "stderr must contain the canonical mismatch error.\n\
+         expected:\n{expected}\n\
+         actual:\n{stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 5 — match. Daemon and TUI advertise the same build_id; the
+// handshake returns silently and the TUI proceeds (we early-exit via
+// `DOT_AGENT_DECK_EXIT_AFTER_HANDSHAKE`).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn match_path_is_silent_and_exits_zero() {
+    // Both daemon and TUI use the same override: a pinned synthetic
+    // value, so the test does not depend on the value of the
+    // compile-time `DAD_BUILD_ID`.
+    let daemon = spawn_daemon(Some(DAEMON_BUILD)).await;
+    let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
+
+    let mut cmd = Command::new(bin);
+    cmd.env("DOT_AGENT_DECK_BUILD_ID_OVERRIDE", DAEMON_BUILD)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (k, v) in tui_env_pairs(&daemon) {
+        cmd.env(k, v);
+    }
+    let output = cmd.output().expect("spawn TUI subprocess");
+
+    assert!(
+        output.status.success(),
+        "match path must exit 0, got {:?}; stderr={:?}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Daemon version mismatch"),
+        "match path must not render the mismatch prompt on stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("error: local daemon is build"),
+        "match path must not print the non-TTY mismatch error: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// PTY harness — used by scenarios 1, 2, 3. `portable-pty` is already a
+// regular dependency of the crate (for agent PTYs), so we reuse it
+// here rather than introducing a new dev-dep.
+// ---------------------------------------------------------------------------
+
+struct PtyChild {
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    master: Box<dyn MasterPty + Send>,
+    writer: Box<dyn Write + Send>,
+    /// PTY output captured by a background reader thread. Tests poll
+    /// this for the prompt text; in raw mode `\n` is rendered as
+    /// `\r\n` so callers must normalise before strict comparisons.
+    output: Arc<Mutex<Vec<u8>>>,
+}
+
+impl PtyChild {
+    fn spawn(daemon: &TestDaemon, build_id_override: &str) -> Self {
+        let pty_system = NativePtySystem::default();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows: 40,
+                cols: 120,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty");
+
+        let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
+        let mut cmd = CommandBuilder::new(bin);
+        cmd.env("DOT_AGENT_DECK_BUILD_ID_OVERRIDE", build_id_override);
+        for (k, v) in tui_env_pairs(daemon) {
+            cmd.env(k, v);
+        }
+        // `TERM` would normally be inherited from the cargo test env;
+        // pin it to a safe value so crossterm's raw-mode probe doesn't
+        // drift across CI runners.
+        cmd.env("TERM", "xterm-256color");
+
+        let child = pair.slave.spawn_command(cmd).expect("spawn pty TUI");
+        drop(pair.slave);
+
+        let writer = pair.master.take_writer().expect("take_writer");
+        let mut reader = pair.master.try_clone_reader().expect("clone reader");
+
+        let output = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let output_for_thread = Arc::clone(&output);
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let mut guard = output_for_thread.lock().unwrap();
+                        guard.extend_from_slice(&buf[..n]);
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Self {
+            child,
+            master: pair.master,
+            writer,
+            output,
+        }
+    }
+
+    /// Wait until the captured PTY output contains `needle`, or the
+    /// deadline elapses. Returns the normalised (`\r\n` → `\n`)
+    /// snapshot of the output at the moment the needle was found.
+    fn wait_for(&self, needle: &str, timeout: Duration) -> Result<String, String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let normalised = {
+                let guard = self.output.lock().unwrap();
+                String::from_utf8_lossy(&guard).replace("\r\n", "\n")
+            };
+            if normalised.contains(needle) {
+                return Ok(normalised);
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "timed out waiting for {needle:?} in PTY output.\n\
+                     captured (normalised):\n{normalised}"
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    fn send(&mut self, bytes: &[u8]) {
+        self.writer.write_all(bytes).expect("pty write");
+        self.writer.flush().expect("pty flush");
+    }
+
+    /// Block on the child exiting (`portable_pty::Child::wait` is
+    /// synchronous). Drops the master afterwards so the PTY backing
+    /// store is released.
+    fn wait_exit(mut self, timeout: Duration) -> Result<portable_pty::ExitStatus, String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(status)) => {
+                    drop(self.master);
+                    return Ok(status);
+                }
+                Ok(None) => {
+                    if Instant::now() >= deadline {
+                        let _ = self.child.kill();
+                        let _ = self.child.wait();
+                        return Err(format!(
+                            "child did not exit within {timeout:?}; killed.\n\
+                             captured:\n{}",
+                            String::from_utf8_lossy(&self.output.lock().unwrap())
+                        ));
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+                Err(e) => return Err(format!("wait error: {e}")),
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — TTY, no live agents, user presses S. Daemon stops, TUI
+// proceeds normally. Also the same-tag / different-commit case (both
+// build-ids share the `0.25.0-` prefix but differ in `-g<sha>`).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tty_no_agents_press_s_stops_daemon_and_exits_zero() {
+    let mut daemon = spawn_daemon(Some(DAEMON_BUILD)).await;
+
+    let mut pty = PtyChild::spawn(&daemon, TUI_BUILD);
+
+    // Wait for the prompt body to render. The PRD pins this text
+    // character-for-character; we anchor on the closing keybind line
+    // because the leading `⚠` glyph is multi-byte and any partial-utf8
+    // capture would still contain the keybind line in full.
+    let snapshot = pty
+        .wait_for("[S] stop daemon and continue", Duration::from_secs(15))
+        .expect("prompt must render");
+
+    // Assert the PRD-pinned text in full — every byte must be present,
+    // proving both build-ids surfaced correctly and the no-agents
+    // branch was taken.
+    let expected_block = format!(
+        "⚠  Daemon version mismatch\n\
+         \x20  running daemon:  {DAEMON_BUILD}\n\
+         \x20  this binary:     {TUI_BUILD}\n\
+         \n\
+         \x20  [S] stop daemon and continue   [Q] quit\n"
+    );
+    assert!(
+        snapshot.contains(&expected_block),
+        "prompt body must match the no-agents PRD form exactly.\n\
+         expected:\n{expected_block}\n\
+         got:\n{snapshot}"
+    );
+
+    // Press S. The handshake SIGTERMs the daemon and the TUI re-runs
+    // `ensure_external_daemon_or_die`, which lazy-spawns a fresh
+    // daemon at the (overridden) TUI build_id. Then the
+    // `DOT_AGENT_DECK_EXIT_AFTER_HANDSHAKE` escape hatch fires and
+    // the TUI exits 0.
+    pty.send(b"S");
+
+    let status = pty
+        .wait_exit(Duration::from_secs(15))
+        .expect("TUI must exit after S");
+    assert!(
+        status.success(),
+        "TUI must exit 0 after stopping the daemon and lazy-respawning, got {status:?}"
+    );
+
+    // The OG daemon process must be gone — confirms peer_pid +
+    // SIGTERM actually ran end-to-end against the right subprocess.
+    // `wait()` returns once the kernel reaps the child; if SIGTERM
+    // did nothing, this would hang past the spawn_blocking budget.
+    let mut og_child = daemon.child.take().expect("og child handle");
+    let _exit = tokio::task::spawn_blocking(move || og_child.wait().expect("wait og daemon"))
+        .await
+        .unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — TTY, no live agents, user presses Q. Daemon untouched,
+// process exits non-zero.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tty_no_agents_press_q_aborts_and_leaves_daemon_running() {
+    let daemon = spawn_daemon(Some(DAEMON_BUILD)).await;
+    let mut pty = PtyChild::spawn(&daemon, TUI_BUILD);
+
+    pty.wait_for("[Q] quit", Duration::from_secs(15))
+        .expect("prompt must render");
+
+    pty.send(b"Q");
+
+    let status = pty
+        .wait_exit(Duration::from_secs(15))
+        .expect("TUI must exit after Q");
+    assert!(
+        !status.success(),
+        "Q press must exit non-zero, got {status:?}"
+    );
+
+    // Daemon must still be accepting connections — the Q branch must
+    // not SIGTERM anything.
+    let connect = UnixStream::connect(&daemon.attach_path).await;
+    assert!(
+        connect.is_ok(),
+        "daemon must still be alive after Q: connect result = {connect:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — TTY, live agent(s) present, user presses S. First S
+// re-renders the prompt naming the agents; second S stops the daemon.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn tty_with_live_agents_requires_two_s_presses_and_names_agents() {
+    let daemon = spawn_daemon(Some(DAEMON_BUILD)).await;
+
+    // Start a long-lived agent so the handshake's ListAgents round
+    // -trip returns at least one entry — this is what triggers the
+    // data-loss-guard branch of the prompt.
+    let client = DaemonClient::new(daemon.attach_path.clone());
+    let agent_id = client
+        .start_agent(StartAgentOptions {
+            command: Some("sleep 60".into()),
+            ..StartAgentOptions::default()
+        })
+        .await
+        .expect("StartAgent must succeed");
+    assert!(!agent_id.is_empty(), "agent_id must be populated");
+
+    let mut pty = PtyChild::spawn(&daemon, TUI_BUILD);
+
+    // Wait for the with-agents prompt. The PRD pins the header at
+    // `(N managed agent(s) running)` and the agent IDs as indented
+    // lines beneath; the data-loss warning sits between the list and
+    // the keybinds.
+    let snapshot = pty
+        .wait_for("[S] stop daemon and continue", Duration::from_secs(15))
+        .expect("with-agents prompt must render");
+    assert!(
+        snapshot.contains("(1 managed agent(s) running)"),
+        "header must use the PRD-pinned plural form '(N managed agent(s) running)': {snapshot}"
+    );
+    assert!(
+        snapshot.contains(&agent_id),
+        "prompt must name the live agent id ({agent_id}): {snapshot}"
+    );
+    assert!(
+        snapshot.contains("Stopping the daemon will end these agents."),
+        "prompt must warn about data loss: {snapshot}"
+    );
+
+    // First S — must NOT terminate yet. The implementation re-renders
+    // the prompt and waits for a second S. We can't reliably observe
+    // the re-render (raw mode doesn't acknowledge the keystroke
+    // out-of-band), so we just confirm the daemon is still up after a
+    // brief delay.
+    pty.send(b"S");
+    std::thread::sleep(Duration::from_millis(300));
+    let still_alive = UnixStream::connect(&daemon.attach_path).await;
+    assert!(
+        still_alive.is_ok(),
+        "first S with live agents must not SIGTERM the daemon: {still_alive:?}"
+    );
+
+    // Second S — now the handshake SIGTERMs and the TUI lazy-respawns
+    // before early-exiting.
+    pty.send(b"S");
+
+    let status = pty
+        .wait_exit(Duration::from_secs(15))
+        .expect("TUI must exit after second S");
+    assert!(
+        status.success(),
+        "TUI must exit 0 after second S, got {status:?}"
+    );
+}

--- a/tests/build_version_handshake.rs
+++ b/tests/build_version_handshake.rs
@@ -36,6 +36,8 @@ use tokio::net::UnixStream;
 
 use dot_agent_deck::daemon_client::{DaemonClient, StartAgentOptions};
 
+mod common;
+
 /// Build-ids sharing the `0.25.0-` tag prefix but differing in the
 /// `-g<sha>` suffix — the same-tag / different-commit case that the
 /// PRD explicitly calls out. Used in the "no agents, S press" test
@@ -86,7 +88,11 @@ impl Drop for TestDaemon {
 /// env iff `Some(_)` — `None` lets the daemon fall back to its
 /// compile-time `DAD_BUILD_ID`.
 async fn spawn_daemon(build_id_override: Option<&str>) -> TestDaemon {
-    let dir = tempfile::tempdir().unwrap();
+    // PRD #103 / CodeRabbit finding #5: bare `tempfile::tempdir()`
+    // races with the daemon's umask flip during socket bind and lands
+    // at 0o600, which then trips EACCES on subsequent `bind(2)`. The
+    // race-safe helper re-chmods to 0o700 immediately after creation.
+    let dir = common::race_safe_tempdir();
     let attach_path = dir.path().join("attach.sock");
     let hook_path = dir.path().join("hook.sock");
     let state_dir = dir.path().join("state");
@@ -508,6 +514,18 @@ async fn tty_with_live_agents_requires_two_s_presses_and_names_agents() {
     assert!(
         snapshot.contains("Stopping the daemon will end these agents."),
         "prompt must warn about data loss: {snapshot}"
+    );
+    // PRD #103 M4.2 / CodeRabbit finding #3: the live-agent prompt
+    // must surface the same `running daemon:` / `this binary:` build
+    // IDs as the no-agent prompt — without them the user can't tell
+    // which side of the mismatch is newer.
+    assert!(
+        snapshot.contains(&format!("running daemon:  {DAEMON_BUILD}")),
+        "live-agent prompt must name the daemon build id: {snapshot}"
+    );
+    assert!(
+        snapshot.contains(&format!("this binary:     {TUI_BUILD}")),
+        "live-agent prompt must name the TUI build id: {snapshot}"
     );
 
     // First S — must NOT terminate yet. The implementation re-renders

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -32,6 +32,7 @@
 //! daemon's lock root cannot be steered by code other than the
 //! constructor.
 
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 use tempfile::TempDir;
@@ -57,4 +58,24 @@ pub fn init_test_env() {
 /// `None` if [`init_test_env`] was never called.
 pub fn lock_dir_path() -> Option<PathBuf> {
     LOCK_DIR_GUARD.get().map(|d| d.path().to_path_buf())
+}
+
+/// `tempfile::tempdir()` calls `mkdir(2)` with mode `0o700 & ~umask`. The
+/// crate's `bind_socket` (src/daemon.rs) briefly flips the process-global
+/// umask to `0o177`, and any concurrent `mkdir` (in another test) lands
+/// during that window with mode `0o700 & ~0o177 = 0o600` — no execute
+/// bit, so the directory is no longer traversable and any subsequent
+/// `bind(2)` of a socket inside it fails with `EACCES`. Re-apply 0o700
+/// after creation so concurrent integration tests are robust to the race.
+///
+/// This is the integration-test counterpart of the same-named helper in
+/// `src/daemon_attach.rs` tests module; promoted here so every test
+/// binary that spawns daemons (orchestration_delegate, daemon_protocol,
+/// etc.) gets the fix without duplicating the workaround.
+#[allow(dead_code)]
+pub fn race_safe_tempdir() -> TempDir {
+    let dir = tempfile::tempdir().expect("create tempdir");
+    std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o700))
+        .expect("chmod tempdir to 0o700");
+    dir
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -38,11 +38,13 @@ use std::sync::OnceLock;
 use tempfile::TempDir;
 
 /// Holds the per-binary tempdir for the entire test run.
+#[allow(dead_code)]
 static LOCK_DIR_GUARD: OnceLock<TempDir> = OnceLock::new();
 
 /// Idempotent setup hook. Call once before constructing a daemon in a
 /// test — typically at the start of a `spawn_daemon` helper. Creates
 /// the per-binary tempdir on first call; subsequent calls are no-ops.
+#[allow(dead_code)]
 pub fn init_test_env() {
     LOCK_DIR_GUARD.get_or_init(|| {
         tempfile::Builder::new()
@@ -56,6 +58,7 @@ pub fn init_test_env() {
 /// [`dot_agent_deck::daemon::Daemon::with_lock_dir_override`] (in-process
 /// tests) or to `Command::env` for subprocess-based tests. Returns
 /// `None` if [`init_test_env`] was never called.
+#[allow(dead_code)]
 pub fn lock_dir_path() -> Option<PathBuf> {
     LOCK_DIR_GUARD.get().map(|d| d.path().to_path_buf())
 }

--- a/tests/daemon_stop.rs
+++ b/tests/daemon_stop.rs
@@ -1,0 +1,272 @@
+//! PRD #103 Phase 3 integration tests for `dot-agent-deck daemon stop`
+//! and `daemon restart`.
+//!
+//! Unlike most daemon tests in this crate, these spawn a *real* child
+//! process (the test binary itself, invoked as
+//! `<CARGO_BIN_EXE_dot-agent-deck> daemon serve`) rather than an
+//! in-process tokio task. That's load-bearing: `daemon stop` calls
+//! `peer_pid()` on its attach socket and SIGTERMs whatever PID that
+//! returns. With an in-process daemon the PID would be the test
+//! runner itself — SIGTERM-ing the test runner kills the test.
+//! Subprocess-based tests get a real, isolated PID we can safely
+//! signal.
+//!
+//! Each test gets an isolated tempdir and points the daemon's socket
+//! / state / lock paths inside it via the existing
+//! `DOT_AGENT_DECK_{ATTACH_SOCKET,SOCKET,STATE_DIR,LOCK_DIR}` env
+//! overrides — no cross-test interference.
+
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+
+use dot_agent_deck::daemon_client::{DaemonClient, StartAgentOptions};
+use dot_agent_deck::daemon_stop::{StopError, StopOutcome, run_daemon_restart, run_daemon_stop};
+
+struct SubprocessDaemon {
+    _dir: TempDir,
+    attach_path: PathBuf,
+    child: Child,
+}
+
+impl Drop for SubprocessDaemon {
+    fn drop(&mut self) {
+        // Belt-and-suspenders cleanup so a failing test doesn't leak
+        // the daemon subprocess. Calling kill() on an already-exited
+        // child is harmless (returns InvalidInput on Linux); wait()
+        // reaps in either case.
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+async fn spawn_subprocess_daemon() -> SubprocessDaemon {
+    let dir = tempfile::tempdir().unwrap();
+    let attach_path = dir.path().join("attach.sock");
+    let hook_path = dir.path().join("hook.sock");
+    let state_dir = dir.path().join("state");
+    let lock_dir = dir.path().join("lock");
+    std::fs::create_dir_all(&state_dir).unwrap();
+    std::fs::create_dir_all(&lock_dir).unwrap();
+
+    let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
+    let mut child = Command::new(bin)
+        .args(["daemon", "serve"])
+        .env("DOT_AGENT_DECK_SOCKET", &hook_path)
+        .env("DOT_AGENT_DECK_ATTACH_SOCKET", &attach_path)
+        .env("DOT_AGENT_DECK_STATE_DIR", &state_dir)
+        .env("DOT_AGENT_DECK_LOCK_DIR", &lock_dir)
+        // Silence the daemon's tracing output so test logs stay
+        // readable; we don't inspect stdout/stderr.
+        .env("RUST_LOG", "error")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn dot-agent-deck daemon serve subprocess");
+
+    // Poll the attach socket: bind, then trial-connect to confirm the
+    // listener is accepting. 15s is generous headroom for a cold
+    // cargo-build cache hit on slow CI.
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if attach_path.exists() && UnixStream::connect(&attach_path).await.is_ok() {
+            return SubprocessDaemon {
+                _dir: dir,
+                attach_path,
+                child,
+            };
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    // Reap the subprocess before panicking — otherwise clippy's
+    // zombie_processes lint trips, and more importantly the child
+    // would outlive this test as an orphan.
+    let _ = child.kill();
+    let _ = child.wait();
+    panic!(
+        "subprocess daemon failed to bind {} within 15s",
+        attach_path.display()
+    );
+}
+
+#[tokio::test]
+async fn stop_with_no_daemon_running_is_idempotent() {
+    let dir = tempfile::tempdir().unwrap();
+    let attach_path = dir.path().join("nonexistent.sock");
+    let outcome = run_daemon_stop(&attach_path, false).await.unwrap();
+    assert_eq!(outcome, StopOutcome::NoDaemonRunning);
+}
+
+#[tokio::test]
+async fn stop_stale_daemon_recovers_via_peer_pid_and_sigterm() {
+    // PRD #103 line 211 regression guard: this is the entire raison
+    // d'être of the command. The recovery flow must work via
+    //   (a) peer_pid()  — non-zero PID
+    //   (b) ListAgents  — existing variant, supported by every daemon
+    //   (c) SIGTERM     — process dies, socket stops accepting
+    // and NONE of those depend on protocol surface added by this PRD,
+    // which is why the same command can rescue a stale v0.24.x daemon.
+    let mut daemon = spawn_subprocess_daemon().await;
+    let pid_before = daemon.child.id();
+    let attach_path = daemon.attach_path.clone();
+
+    let outcome = run_daemon_stop(&attach_path, false)
+        .await
+        .expect("daemon stop must succeed against a clean daemon");
+    match outcome {
+        StopOutcome::Stopped { pid } => {
+            // (a) peer_pid returned a non-zero PID and (b) it matched
+            // the subprocess we spawned. ListAgents succeeded (we got
+            // past it to the SIGTERM stage). SIGTERM took the daemon
+            // down (we observed Stopped).
+            assert_eq!(
+                pid, pid_before,
+                "peer_pid must return the daemon's subprocess PID"
+            );
+            assert_ne!(pid, 0, "peer_pid must return a non-zero PID");
+        }
+        other => panic!("expected Stopped, got {other:?}"),
+    }
+    // Daemon process must be gone: wait() reaps it without hanging.
+    let exit_status =
+        tokio::task::spawn_blocking(move || daemon.child.wait().expect("child must reap"))
+            .await
+            .unwrap();
+    assert!(
+        !exit_status.success() || exit_status.success(),
+        "exit status irrelevant — what matters is wait() returned, got {exit_status:?}"
+    );
+    // The daemon doesn't unlink its socket on SIGTERM exit; the next
+    // `daemon serve` would clean it up. We assert the listener is
+    // dead by trying a fresh connect.
+    let connect_result = UnixStream::connect(&attach_path).await;
+    assert!(
+        connect_result.is_err(),
+        "after daemon stop, attach socket must reject new connects"
+    );
+}
+
+#[tokio::test]
+async fn stop_refuses_when_live_agents_present_without_force() {
+    let daemon = spawn_subprocess_daemon().await;
+    let client = DaemonClient::new(daemon.attach_path.clone());
+
+    // Spawn a long-lived agent. `sleep 60` is portable across Linux
+    // and macOS and outlives the test trivially.
+    let agent_id = client
+        .start_agent(StartAgentOptions {
+            command: Some("sleep 60".into()),
+            ..StartAgentOptions::default()
+        })
+        .await
+        .expect("StartAgent must succeed");
+    assert!(!agent_id.is_empty(), "agent_id must be populated");
+
+    let err = run_daemon_stop(&daemon.attach_path, false)
+        .await
+        .expect_err("daemon stop without --force must refuse");
+    match err {
+        StopError::LiveAgents { ids } => {
+            assert!(
+                ids.iter().any(|id| id == &agent_id),
+                "refusal must list the live agent id; got {ids:?}"
+            );
+        }
+        other => panic!("expected StopError::LiveAgents, got {other:?}"),
+    }
+
+    // Subprocess must still be running — peer_pid + SIGTERM never
+    // fired. A fresh connect must succeed.
+    let still_alive = UnixStream::connect(&daemon.attach_path).await;
+    assert!(
+        still_alive.is_ok(),
+        "daemon must still be running after refusal: {still_alive:?}"
+    );
+}
+
+#[tokio::test]
+async fn stop_with_force_terminates_daemon_even_with_live_agents() {
+    let mut daemon = spawn_subprocess_daemon().await;
+    let client = DaemonClient::new(daemon.attach_path.clone());
+
+    let _agent_id = client
+        .start_agent(StartAgentOptions {
+            command: Some("sleep 60".into()),
+            ..StartAgentOptions::default()
+        })
+        .await
+        .expect("StartAgent must succeed");
+
+    // --force = true. The data-loss guard is bypassed; SIGTERM (and
+    // SIGKILL on timeout) takes the daemon down regardless of live
+    // agents.
+    let outcome = run_daemon_stop(&daemon.attach_path, true)
+        .await
+        .expect("daemon stop --force must succeed");
+    match outcome {
+        StopOutcome::Stopped { .. } | StopOutcome::ForceKilled { .. } => {}
+        other => panic!("expected Stopped or ForceKilled, got {other:?}"),
+    }
+    let _ = daemon.child.wait();
+    let connect_result = UnixStream::connect(&daemon.attach_path).await;
+    assert!(
+        connect_result.is_err(),
+        "after --force stop, attach socket must reject new connects"
+    );
+}
+
+#[tokio::test]
+async fn restart_stops_existing_daemon_and_allows_relaunch() {
+    let mut daemon = spawn_subprocess_daemon().await;
+    let pid_before = daemon.child.id();
+    let attach_path = daemon.attach_path.clone();
+
+    let outcome = run_daemon_restart(&attach_path, false)
+        .await
+        .expect("daemon restart must succeed against a clean daemon");
+    match outcome {
+        StopOutcome::Stopped { pid } => assert_eq!(pid, pid_before),
+        other => panic!("expected Stopped, got {other:?}"),
+    }
+    let _ = daemon.child.wait();
+
+    // Lazy-respawn: kick off a second daemon at the same paths to
+    // confirm the first one is well and truly gone (otherwise this
+    // second spawn would fail under flock contention or AddrInUse).
+    // We can't reuse spawn_subprocess_daemon's tempdir because the
+    // env vars need to point at the SAME paths — re-spawn with a
+    // hand-rolled Command.
+    let hook_path = attach_path.with_file_name("hook.sock");
+    let state_dir = attach_path.with_file_name("state");
+    let lock_dir = attach_path.with_file_name("lock");
+    let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
+    let mut second = Command::new(bin)
+        .args(["daemon", "serve"])
+        .env("DOT_AGENT_DECK_SOCKET", &hook_path)
+        .env("DOT_AGENT_DECK_ATTACH_SOCKET", &attach_path)
+        .env("DOT_AGENT_DECK_STATE_DIR", &state_dir)
+        .env("DOT_AGENT_DECK_LOCK_DIR", &lock_dir)
+        .env("RUST_LOG", "error")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("second daemon spawn");
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut up = false;
+    while Instant::now() < deadline {
+        if UnixStream::connect(&attach_path).await.is_ok() {
+            up = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    let _ = second.kill();
+    let _ = second.wait();
+    assert!(
+        up,
+        "second daemon must come up at the same socket path after restart"
+    );
+}

--- a/tests/daemon_stop.rs
+++ b/tests/daemon_stop.rs
@@ -17,7 +17,7 @@
 //! overrides — no cross-test interference.
 
 use std::path::PathBuf;
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, Command, ExitStatus, Stdio};
 use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
@@ -25,6 +25,32 @@ use tokio::net::UnixStream;
 
 use dot_agent_deck::daemon_client::{DaemonClient, StartAgentOptions};
 use dot_agent_deck::daemon_stop::{StopError, StopOutcome, run_daemon_restart, run_daemon_stop};
+
+mod common;
+
+/// Bounded counterpart to `Child::wait`. PRD #103 / CodeRabbit finding
+/// #7: an unbounded `wait()` would hang the whole test suite if the
+/// daemon ever fails to exit. `try_wait()` polling caps the wait at
+/// `timeout` and turns the hang into a diagnostic error.
+fn wait_with_timeout(child: &mut Child, timeout: Duration) -> std::io::Result<ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        if Instant::now() >= deadline {
+            let _ = child.kill();
+            return Err(std::io::Error::other(format!(
+                "daemon child did not exit within {timeout:?}"
+            )));
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// 5-second deadline matches the rest of the daemon-stop test
+/// conventions (the SIGTERM grace upstream of these tests is also 5 s).
+const CHILD_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
 struct SubprocessDaemon {
     _dir: TempDir,
@@ -44,7 +70,10 @@ impl Drop for SubprocessDaemon {
 }
 
 async fn spawn_subprocess_daemon() -> SubprocessDaemon {
-    let dir = tempfile::tempdir().unwrap();
+    // PRD #103 / CodeRabbit finding #6: bare `tempfile::tempdir()`
+    // races with the daemon's umask flip during socket bind and lands
+    // at 0o600. The race-safe helper re-chmods to 0o700 immediately.
+    let dir = common::race_safe_tempdir();
     let attach_path = dir.path().join("attach.sock");
     let hook_path = dir.path().join("hook.sock");
     let state_dir = dir.path().join("state");
@@ -94,7 +123,7 @@ async fn spawn_subprocess_daemon() -> SubprocessDaemon {
 
 #[tokio::test]
 async fn stop_with_no_daemon_running_is_idempotent() {
-    let dir = tempfile::tempdir().unwrap();
+    let dir = common::race_safe_tempdir();
     let attach_path = dir.path().join("nonexistent.sock");
     let outcome = run_daemon_stop(&attach_path, false).await.unwrap();
     assert_eq!(outcome, StopOutcome::NoDaemonRunning);
@@ -130,11 +159,14 @@ async fn stop_stale_daemon_recovers_via_peer_pid_and_sigterm() {
         }
         other => panic!("expected Stopped, got {other:?}"),
     }
-    // Daemon process must be gone: wait() reaps it without hanging.
-    let exit_status =
-        tokio::task::spawn_blocking(move || daemon.child.wait().expect("child must reap"))
-            .await
-            .unwrap();
+    // Daemon process must be gone: wait_with_timeout reaps it within
+    // CHILD_WAIT_TIMEOUT and turns a hang into a diagnostic error
+    // rather than blocking the whole test suite.
+    let exit_status = tokio::task::spawn_blocking(move || {
+        wait_with_timeout(&mut daemon.child, CHILD_WAIT_TIMEOUT).expect("child must reap")
+    })
+    .await
+    .unwrap();
     assert!(
         !exit_status.success() || exit_status.success(),
         "exit status irrelevant — what matters is wait() returned, got {exit_status:?}"
@@ -210,7 +242,7 @@ async fn stop_with_force_terminates_daemon_even_with_live_agents() {
         StopOutcome::Stopped { .. } | StopOutcome::ForceKilled { .. } => {}
         other => panic!("expected Stopped or ForceKilled, got {other:?}"),
     }
-    let _ = daemon.child.wait();
+    let _ = wait_with_timeout(&mut daemon.child, CHILD_WAIT_TIMEOUT);
     let connect_result = UnixStream::connect(&daemon.attach_path).await;
     assert!(
         connect_result.is_err(),
@@ -231,7 +263,7 @@ async fn restart_stops_existing_daemon_and_allows_relaunch() {
         StopOutcome::Stopped { pid } => assert_eq!(pid, pid_before),
         other => panic!("expected Stopped, got {other:?}"),
     }
-    let _ = daemon.child.wait();
+    let _ = wait_with_timeout(&mut daemon.child, CHILD_WAIT_TIMEOUT);
 
     // Lazy-respawn: kick off a second daemon at the same paths to
     // confirm the first one is well and truly gone (otherwise this
@@ -264,7 +296,7 @@ async fn restart_stops_existing_daemon_and_allows_relaunch() {
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
     let _ = second.kill();
-    let _ = second.wait();
+    let _ = wait_with_timeout(&mut second, CHILD_WAIT_TIMEOUT);
     assert!(
         up,
         "second daemon must come up at the same socket path after restart"

--- a/tests/orchestration_delegate.rs
+++ b/tests/orchestration_delegate.rs
@@ -70,9 +70,15 @@ impl Drop for DaemonHandle {
 
 async fn spawn_daemon() -> DaemonHandle {
     common::init_test_env();
+    // `common::race_safe_tempdir()` chmods the tempdir to 0o700 after
+    // creation. Without that, a concurrent daemon's `bind_socket` (which
+    // briefly sets the process-global umask to 0o177) can land in between
+    // `mkdir(2)` and the test's first use of the dir, leaving the parent
+    // at mode 0o600 — no execute bit, so the test's subsequent socket
+    // bind fails with EACCES.
     let (dir, hook_path, attach_path) = {
         let _g = HARNESS_BIND_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        let dir = tempfile::tempdir().unwrap();
+        let dir = common::race_safe_tempdir();
         let hook = dir.path().join("hook.sock");
         let attach = dir.path().join("attach.sock");
         (dir, hook, attach)
@@ -89,6 +95,10 @@ async fn spawn_daemon() -> DaemonHandle {
         let _ = run_daemon_with(&hook_for_daemon, daemon).await;
     });
 
+    // 5s is plenty once the umask race is closed (race_safe_tempdir
+    // above): without contention the daemon binds in <100ms; the only
+    // legitimate stall under parallel load is brief flock serialization
+    // on the per-socket spawn lock.
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     while tokio::time::Instant::now() < deadline {
         if attach_path.exists() && UnixStream::connect(&attach_path).await.is_ok() {
@@ -268,7 +278,7 @@ async fn wait_for_in_snapshot(
 #[tokio::test]
 async fn daemon_writes_delegate_prompt_to_target_role_pane() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let _orch_agent_id = start_role_pane(
@@ -348,7 +358,7 @@ async fn daemon_writes_delegate_prompt_to_target_role_pane() {
 #[tokio::test]
 async fn daemon_writes_work_done_feedback_to_orchestrator_pane() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let orch_agent_id = start_role_pane(
@@ -416,9 +426,9 @@ async fn daemon_writes_work_done_feedback_to_orchestrator_pane() {
 #[tokio::test]
 async fn delegate_writes_task_file_to_each_workers_own_cwd() {
     let daemon = spawn_daemon().await;
-    let orch_cwd_dir = tempfile::tempdir().unwrap();
+    let orch_cwd_dir = common::race_safe_tempdir();
     let orch_cwd = orch_cwd_dir.path().to_string_lossy().into_owned();
-    let worker_cwd_dir = tempfile::tempdir().unwrap();
+    let worker_cwd_dir = common::race_safe_tempdir();
     let worker_cwd = worker_cwd_dir.path().to_string_lossy().into_owned();
     assert_ne!(
         orch_cwd, worker_cwd,
@@ -500,7 +510,7 @@ async fn delegate_writes_task_file_to_each_workers_own_cwd() {
 #[tokio::test]
 async fn delegate_wraps_task_with_role_prompt_template() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     // Write a project config file with a prompt_template on the coder
@@ -599,7 +609,7 @@ prompt_template = "You are the coder. Always run tests before finishing."
 #[tokio::test]
 async fn delegate_applies_prompt_template_for_unnamed_orchestration() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
     // The daemon's loader resolves an empty/missing config name to the
     // cwd basename — same fallback the TUI applies when building
@@ -697,12 +707,18 @@ async fn delegate_does_not_cross_route_between_same_basename_orchestrations() {
     let daemon = spawn_daemon().await;
     // Two distinct cwds whose basenames are identical (the
     // resolve_orchestration_name fallback would collapse them).
-    let parent_a = tempfile::tempdir().unwrap();
+    // Same umask race as race_safe_tempdir: a concurrent `bind_socket`
+    // can leave these freshly created subdirs at mode 0o600 (no exec),
+    // so chmod each back to 0o700 before any code tries to traverse.
+    use std::os::unix::fs::PermissionsExt;
+    let parent_a = common::race_safe_tempdir();
     let cwd_a = parent_a.path().join("collision");
     std::fs::create_dir_all(&cwd_a).unwrap();
-    let parent_b = tempfile::tempdir().unwrap();
+    std::fs::set_permissions(&cwd_a, std::fs::Permissions::from_mode(0o700)).unwrap();
+    let parent_b = common::race_safe_tempdir();
     let cwd_b = parent_b.path().join("collision");
     std::fs::create_dir_all(&cwd_b).unwrap();
+    std::fs::set_permissions(&cwd_b, std::fs::Permissions::from_mode(0o700)).unwrap();
     assert_ne!(cwd_a, cwd_b);
 
     let cwd_a_str = cwd_a.to_string_lossy().into_owned();
@@ -802,7 +818,7 @@ async fn delegate_does_not_cross_route_between_same_basename_orchestrations() {
 #[tokio::test]
 async fn delegate_from_non_orchestrator_is_rejected_daemon_side() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let _orch_agent_id = start_role_pane(
@@ -862,7 +878,7 @@ async fn delegate_from_non_orchestrator_is_rejected_daemon_side() {
 #[tokio::test]
 async fn work_done_survives_subscriber_detach_and_reattach() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let orch_agent_id = start_role_pane(
@@ -976,7 +992,7 @@ async fn wait_for_bytes_in_snapshot(
 #[tokio::test]
 async fn write_to_pane_and_submit_emits_cr_after_single_line_prompt() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let coder_agent_id =
@@ -1024,7 +1040,7 @@ async fn write_to_pane_and_submit_emits_cr_after_single_line_prompt() {
 #[tokio::test]
 async fn write_to_pane_and_submit_wraps_multiline_in_bracketed_paste() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let coder_agent_id =
@@ -1086,7 +1102,7 @@ async fn write_to_pane_and_submit_wraps_multiline_in_bracketed_paste() {
 #[tokio::test]
 async fn write_to_pane_and_submit_serializes_concurrent_writes_per_pane() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let coder_agent_id =
@@ -1185,7 +1201,7 @@ async fn write_to_pane_and_submit_serializes_concurrent_writes_per_pane() {
 #[tokio::test]
 async fn write_to_pane_and_submit_concurrent_writes_to_different_panes_run_in_parallel() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let _orch_id = start_role_pane(
@@ -1307,7 +1323,7 @@ async fn wait_for_in_pane_snapshot(
 #[tokio::test]
 async fn delegate_respawns_worker_agent_when_role_clear_is_true() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     // No `clear` line means default `true` per
@@ -1501,7 +1517,7 @@ command = "cat -u"
 #[tokio::test]
 async fn delegate_does_not_respawn_worker_when_role_clear_is_false() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let config_toml = r#"
@@ -1611,7 +1627,7 @@ clear = false
 #[tokio::test]
 async fn delegate_respawn_rotates_agent_bus_when_role_clear_is_true() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let config_toml = r#"
@@ -1736,7 +1752,7 @@ command = "cat -u"
 #[tokio::test]
 async fn concurrent_clear_true_delegates_both_reach_worker() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let config_toml = r#"
@@ -1908,7 +1924,7 @@ command = "cat -u"
 #[tokio::test]
 async fn delegate_clear_true_writes_prompt_promptly_after_session_start() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let config_toml = r#"
@@ -2028,7 +2044,7 @@ command = "cat -u"
 #[tokio::test]
 async fn delegate_clear_true_rejects_session_start_from_old_agent_id() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let config_toml = r#"
@@ -2148,7 +2164,7 @@ command = "cat -u"
 #[tokio::test]
 async fn respawn_failure_surfaces_visible_error_in_orchestrator_pane() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     // The coder role's command points at a path that doesn't exist
@@ -2244,7 +2260,7 @@ command = "/nonexistent/dot-agent-deck-test-bin-12345"
 #[tokio::test]
 async fn concurrent_fan_out_respawns_overlap_across_panes() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let config_toml = r#"
@@ -2431,7 +2447,7 @@ command = "cat -u"
 #[tokio::test]
 async fn respawn_preserves_original_spawn_env() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let marker_value = "preserve-me-please";
@@ -2558,7 +2574,7 @@ command = "{role_command}"
 #[tokio::test]
 async fn respawn_preserves_last_known_pty_size() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     let config_toml = r#"
@@ -2654,7 +2670,7 @@ command = "cat -u"
 #[tokio::test]
 async fn delegate_with_missing_role_config_skips_respawn_and_still_delivers_prompt() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     // Config: only the orchestrator role is listed. The coder pane
@@ -2822,7 +2838,7 @@ start = true
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn e2e_pane_renders_new_agent_after_sigterm_trap_respawn() {
     let daemon = spawn_daemon().await;
-    let cwd_dir = tempfile::tempdir().unwrap();
+    let cwd_dir = common::race_safe_tempdir();
     let cwd = cwd_dir.path().to_string_lossy().into_owned();
 
     // SIGTERM-trapping shell. The diagnostic recipe used


### PR DESCRIPTION
## Summary

Closes #103

Addresses the silent-misfiring bug introduced in PRD #93 (always-external daemon): when the TUI attached to a stale daemon built at a different commit, delegate signals were accepted at the wire layer but silently no-op'd inside the daemon due to internal role-map schema drift.

## Changes

### Build identity
- `build.rs` now emits `DAD_BUILD_ID` of the form `<version>-g<sha>[-dirty]` (e.g. `0.25.0-g243b049`) with a correct `rerun-if-changed` strategy that invalidates on new commits even when the tag is unchanged

### Build-version handshake
- `AttachResponse` gains `build_version: Option<String>` (optional/backward-compat)
- `AttachRequest::Hello` gains `client_build_version: Option<String>` (symmetric, daemon logs only)
- TUI performs handshake on local attach; on mismatch prints clear error naming both build IDs and `daemon stop` recovery command, exits non-zero
- `probe_remote_protocol` compares `build_version` on remote attach; error points at `remote upgrade`, not `daemon stop`

### Daemon stop/restart
- `peer_pid()` helper reads daemon PID via `SO_PEERCRED` (Linux) / `LOCAL_PEERPID` (macOS) — OS-level, works against any daemon version
- `dot-agent-deck daemon stop`: sends SIGTERM, polls socket disappearance up to 5 s, data-loss guard via existing `ListAgents` (refuses if agents alive unless `--force`)
- `dot-agent-deck daemon restart`: thin wrapper over `daemon stop`

### Docs & tests
- `docs/installation.md`: upgrade flow (run `daemon stop` after upgrading binary)
- `docs/troubleshooting.md`: stale-daemon entry with recovery steps
- `docs/remote-environments.md`: remote-upgrade note
- Unit + integration tests: serde backward-compat, build-id shape, mismatch/match attach paths, daemon stop with/without agents
- Pre-existing EACCES race in `orchestration_delegate.rs` tempdir fixed

## No breaking changes

`PROTOCOL_VERSION` is unchanged. All new wire fields use `#[serde(default, skip_serializing_if = "Option::is_none")]` — older daemons that omit them round-trip cleanly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build-ID handshake: TUI and daemon now detect build mismatches and offer recovery (stop/restart) with interactive and non-interactive flows.
  * New CLI: `daemon stop` and `daemon restart` with `--force` behavior.

* **Documentation**
  * Expanded upgrade and recycling docs; added troubleshooting guidance for stale-daemon issues.

* **Bug Fixes**
  * Prevented silent failures when delegate features hit mismatched daemon versions.

* **Tests**
  * Added extensive integration tests covering handshakes, stop/restart, and build-id behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vfarcic/dot-agent-deck/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->