### PR TITLE
fix: agent-card lifecycle bugs after PRD #110 (duplicate cards on respawn + missing role on reconnect)

### DIFF
--- a/.env.vals.yaml
+++ b/.env.vals.yaml
@@ -1,2 +1,1 @@
 GITHUB_TOKEN: ref+gcpsecrets://vfarcic/github-token
-ANTHROPIC_API_KEY: ref+gcpsecrets://vfarcic/anthropic-api-key

--- a/src/state.rs
+++ b/src/state.rs
@@ -785,6 +785,17 @@ impl AppState {
         if let Some(ref pane_id) = event.pane_id {
             if !self.managed_pane_ids.contains(pane_id) {
                 if event.event_type == EventType::SessionStart {
+                    // Defense in depth (auditor finding #1 follow-up):
+                    // reject the synthetic dead-slot id format from the
+                    // auto-register branch so a forged hook event can't
+                    // bring an `__dead-slot__-…` id into existence.
+                    // Production never sets a synthetic id as
+                    // `DOT_AGENT_DECK_PANE_ID`, but `is_valid_pane_id_env`
+                    // admits the format on its own (it only checks for
+                    // `[A-Za-z0-9_-]`).
+                    if crate::ui::is_dead_slot_pane_id(pane_id) {
+                        return;
+                    }
                     // Auto-register the pane to handle the startup race where
                     // the hook fires before register_pane is called.
                     self.managed_pane_ids.insert(pane_id.clone());
@@ -826,7 +837,18 @@ impl AppState {
         // stale sibling(s) before falling through to the
         // session-create path below so the orchestration deck shows
         // exactly one card per pane after a respawn.
+        //
+        // Backward-compat (auditor finding #3 follow-up): skip the
+        // retire block entirely when the incoming event carries no
+        // `agent_id`. A pre-F9 hook script (no
+        // `DOT_AGENT_DECK_AGENT_ID` env var) running against an
+        // upgraded daemon would otherwise wipe a tagged session it
+        // doesn't know the identity of — losing its `recent_events`,
+        // `tool_count`, `first_prompts`, `started_at`. Mirrors the
+        // deliberately-permissive "both sides absent" branch of the
+        // reuse guard above.
         if event.event_type == EventType::SessionStart
+            && event.agent_id.is_some()
             && let Some(ref pane_id) = event.pane_id
         {
             let to_remove: Vec<String> = self
@@ -1782,6 +1804,81 @@ mod tests {
         assert!(
             !state.sessions.contains_key("session-A"),
             "agent-A's stale session card must be retired"
+        );
+    }
+
+    // Follow-up to 0d5e651 (auditor finding #3): a pre-F9 hook script
+    // (no `DOT_AGENT_DECK_AGENT_ID` env, so `agent_id = None`) firing
+    // `SessionStart` against a pane that already has a session with
+    // `agent_id = Some(…)` must NOT trigger the retire-stale-sibling
+    // block. Otherwise an upgraded daemon would silently wipe the
+    // tagged session — losing its `recent_events`, `tool_count`,
+    // `first_prompts`, and `started_at` — every time an old hook ran.
+    #[test]
+    fn pre_f9_hook_with_no_agent_id_does_not_wipe_tagged_session() {
+        let mut state = AppState::default();
+        state.register_pane("42".to_string());
+
+        // Existing session bound to agent-A with some accumulated state.
+        let mut start_a = make_event("session-A", EventType::SessionStart);
+        start_a.pane_id = Some("42".to_string());
+        start_a.agent_id = Some("agent-A".to_string());
+        state.apply_event(start_a);
+        // Add a tool event so the session has something to lose
+        // (tool_count increments on `ToolEnd`, not `ToolStart`).
+        let mut tool_start = make_event("session-A", EventType::ToolStart);
+        tool_start.pane_id = Some("42".to_string());
+        tool_start.agent_id = Some("agent-A".to_string());
+        tool_start.tool_name = Some("Bash".to_string());
+        state.apply_event(tool_start);
+        let mut tool_end = make_event("session-A", EventType::ToolEnd);
+        tool_end.pane_id = Some("42".to_string());
+        tool_end.agent_id = Some("agent-A".to_string());
+        state.apply_event(tool_end);
+        assert_eq!(state.sessions["session-A"].tool_count, 1);
+
+        // A pre-F9 hook (no agent_id) fires SessionStart on the same
+        // pane. The retire block must be skipped.
+        let mut legacy = make_event("session-legacy", EventType::SessionStart);
+        legacy.pane_id = Some("42".to_string());
+        legacy.agent_id = None;
+        state.apply_event(legacy);
+
+        // agent-A's session must still exist with its tool_count intact.
+        let agent_a = state
+            .sessions
+            .get("session-A")
+            .expect("agent-A session must be preserved when a pre-F9 hook fires");
+        assert_eq!(agent_a.tool_count, 1);
+        assert_eq!(agent_a.agent_id.as_deref(), Some("agent-A"));
+    }
+
+    // Follow-up to 0d5e651 (auditor finding #1): the auto-register
+    // branch in `apply_event` would happily admit any pane_id that
+    // matches `is_valid_pane_id_env`, including the synthetic
+    // dead-slot format `__dead-slot__-…`. Defense in depth — even
+    // though synthetic ids are never set as `DOT_AGENT_DECK_PANE_ID`
+    // in production, the docstring previously claimed the synthetic
+    // id was unreachable via hooks. Pin the reject.
+    #[test]
+    fn session_start_with_synthetic_dead_slot_id_does_not_auto_register() {
+        let mut state = AppState::default();
+        let synthetic = crate::ui::dead_slot_pane_id("/work", "tdd-cycle", 4);
+
+        let mut ev = make_event("forged-uuid", EventType::SessionStart);
+        ev.pane_id = Some(synthetic.clone());
+        ev.agent_id = Some("agent-X".to_string());
+        state.apply_event(ev);
+
+        assert!(
+            !state.managed_pane_ids.contains(&synthetic),
+            "synthetic dead-slot id must NOT be promoted into managed_pane_ids \
+             via the auto-register branch"
+        );
+        assert!(
+            !state.sessions.contains_key("forged-uuid"),
+            "no session should be created for a forged hook event against a \
+             synthetic id"
         );
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -815,6 +815,35 @@ impl AppState {
             }
         }
 
+        // PRD #110 follow-up: when a `SessionStart` arrives whose
+        // `agent_id` differs from an existing session on the same
+        // pane, the previous agent has been replaced (F9 clear=true
+        // respawn — the daemon SIGKILLs the old child so no graceful
+        // `SessionEnd` ever fires). The same-agent reuse guard above
+        // doesn't match, so without retiring the stale session here
+        // the dashboard would end up with two cards on the same pane:
+        // the dead-agent's card AND the fresh agent's card. Drop the
+        // stale sibling(s) before falling through to the
+        // session-create path below so the orchestration deck shows
+        // exactly one card per pane after a respawn.
+        if event.event_type == EventType::SessionStart
+            && let Some(ref pane_id) = event.pane_id
+        {
+            let to_remove: Vec<String> = self
+                .sessions
+                .iter()
+                .filter(|(id, session)| {
+                    session.pane_id.as_ref().is_some_and(|p| p == pane_id)
+                        && *id != &event.session_id
+                        && session.agent_id != event.agent_id
+                })
+                .map(|(id, _)| id.clone())
+                .collect();
+            for id in to_remove {
+                self.sessions.remove(&id);
+            }
+        }
+
         if event.event_type == EventType::SessionEnd {
             // Preserve started_at for the pane so a restarted session keeps its position.
             //
@@ -1066,7 +1095,10 @@ mod tests {
         state.apply_event(first);
 
         // F9 clear=true respawn — different agent process, same pane.
-        // The reuse guard must skip and create a fresh session card.
+        // The reuse guard must skip silent remapping and create a
+        // fresh session card. Symptom 1 follow-up: the stale agent-A
+        // sibling must also be retired so the pane ends with exactly
+        // one card, not two.
         let mut respawn = make_event("s2", EventType::SessionStart);
         respawn.pane_id = Some("pane-1".to_string());
         respawn.agent_id = Some("agent-B".to_string());
@@ -1078,11 +1110,12 @@ mod tests {
         );
         assert_eq!(state.sessions["s2"].pane_id.as_deref(), Some("pane-1"));
         assert_eq!(state.sessions["s2"].agent_id.as_deref(), Some("agent-B"));
-        // The old session card is preserved (no remap), so the new
-        // agent's card is additive rather than replacing the old one.
+        // Symptom 1: the stale agent-A card must be gone — the fresh
+        // card replaces it rather than sitting next to it.
         assert!(
-            state.sessions.contains_key("s1"),
-            "old session card must remain when reuse is skipped"
+            !state.sessions.contains_key("s1"),
+            "stale agent-A session must be retired when agent-B takes \
+             over the same pane"
         );
     }
 
@@ -1648,12 +1681,18 @@ mod tests {
         );
     }
 
-    // PRD #110 followup: SessionEnd from agent A, then a DIFFERENT agent
-    // (F9 clear=true respawn) emits SessionStart. The placeholder must NOT
-    // be remapped onto the new agent — it represents the dead agent A, and
-    // adopting it would silently rebrand the new agent's card.
+    // PRD #110 followup (revised): SessionEnd from agent A leaves a
+    // placeholder bound to agent A. When a DIFFERENT agent B then takes
+    // over the pane (F9 clear=true respawn case where the agent did
+    // emit SessionEnd before being killed, or any external pane
+    // takeover), the stale agent-A placeholder must be retired —
+    // otherwise the dashboard shows two cards in the same slot: a dead
+    // agent-A ghost and the live agent-B card. The reuse guard
+    // continues to refuse silent rebranding (the new card carries
+    // session_id `real-uuid-2`, not the placeholder's `pane-42`), but
+    // the dead sibling is no longer left lying around.
     #[test]
-    fn placeholder_not_reused_when_different_agent_starts_after_session_end() {
+    fn old_session_retired_when_different_agent_starts_after_session_end() {
         let mut state = AppState::default();
         state.register_pane("42".to_string());
 
@@ -1673,19 +1712,76 @@ mod tests {
         start2.agent_id = Some("agent-B".to_string());
         state.apply_event(start2);
 
-        // Two cards expected: the placeholder bound to agent-A (the dead
-        // session's restoration card), and a fresh card for agent-B.
-        let mut cards: Vec<(&str, Option<&str>)> = state
+        // Exactly one card expected: the fresh agent-B session. The
+        // agent-A placeholder restored at SessionEnd time has been
+        // retired because a different agent now owns the pane.
+        let cards: Vec<(&str, Option<&str>)> = state
             .sessions
             .values()
             .filter(|s| s.pane_id.as_deref() == Some("42"))
             .map(|s| (s.session_id.as_str(), s.agent_id.as_deref()))
             .collect();
-        cards.sort();
         assert_eq!(
             cards.len(),
-            2,
-            "F9-style respawn must NOT remap onto the dead agent's placeholder; got {cards:?}"
+            1,
+            "F9-style respawn must retire the dead agent's placeholder; \
+             got {cards:?}"
+        );
+        assert_eq!(
+            cards[0].1,
+            Some("agent-B"),
+            "the surviving card must belong to the NEW agent"
+        );
+        assert_eq!(
+            cards[0].0, "real-uuid-2",
+            "the surviving card must not be silently rebranded onto the \
+             placeholder's session id"
+        );
+    }
+
+    // Symptom 1 (post-PRD-110 regression): an F9 clear=true respawn
+    // emits a fresh `SessionStart` for the same pane with a DIFFERENT
+    // `agent_id`. No `SessionEnd` is sent (the daemon SIGKILLs the old
+    // child). Before this fix the stale agent-A session sat next to
+    // the agent-B card in the orchestration deck — two cards on the
+    // same pane. The fix retires the stale sibling.
+    #[test]
+    fn session_start_with_new_agent_id_retires_stale_session_on_same_pane() {
+        let mut state = AppState::default();
+        state.register_pane("42".to_string());
+
+        // Old agent A's session card.
+        let mut start_a = make_event("session-A", EventType::SessionStart);
+        start_a.pane_id = Some("42".to_string());
+        start_a.agent_id = Some("agent-A".to_string());
+        state.apply_event(start_a);
+        assert!(state.sessions.contains_key("session-A"));
+
+        // New agent B's session card (post-respawn). No SessionEnd
+        // from agent A in between — that's the F9 hard-kill shape.
+        let mut start_b = make_event("session-B", EventType::SessionStart);
+        start_b.pane_id = Some("42".to_string());
+        start_b.agent_id = Some("agent-B".to_string());
+        state.apply_event(start_b);
+
+        // Exactly one card for the pane, bound to agent-B.
+        let cards: Vec<(&str, Option<&str>)> = state
+            .sessions
+            .values()
+            .filter(|s| s.pane_id.as_deref() == Some("42"))
+            .map(|s| (s.session_id.as_str(), s.agent_id.as_deref()))
+            .collect();
+        assert_eq!(
+            cards.len(),
+            1,
+            "F9 clear=true respawn must leave exactly one card on the \
+             pane; got {cards:?}"
+        );
+        assert_eq!(cards[0].0, "session-B");
+        assert_eq!(cards[0].1, Some("agent-B"));
+        assert!(
+            !state.sessions.contains_key("session-A"),
+            "agent-A's stale session card must be retired"
         );
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -838,8 +838,9 @@ impl AppState {
         // session-create path below so the orchestration deck shows
         // exactly one card per pane after a respawn.
         //
-        // Backward-compat (auditor finding #3 follow-up): skip the
-        // retire block entirely when the incoming event carries no
+        // Backward-compat (auditor finding #3 follow-up; reaffirmed
+        // against CodeRabbit PR #118 finding #1): skip the retire
+        // block entirely when the incoming event carries no
         // `agent_id`. A pre-F9 hook script (no
         // `DOT_AGENT_DECK_AGENT_ID` env var) running against an
         // upgraded daemon would otherwise wipe a tagged session it
@@ -847,6 +848,18 @@ impl AppState {
         // `tool_count`, `first_prompts`, `started_at`. Mirrors the
         // deliberately-permissive "both sides absent" branch of the
         // reuse guard above.
+        //
+        // Trade-off: keeping this guard means a legacy hook can
+        // create a duplicate (untagged) card alongside the tagged
+        // one. Removing it (CodeRabbit's wildcard suggestion on PR
+        // #118) would silently drop accumulated history every time
+        // an old hook fires. PRD #110 prefers the visible duplicate
+        // over silent data loss; the duplicate is observable and
+        // self-resolves once the legacy hook is upgraded, whereas
+        // lost `recent_events` / `tool_count` / `first_prompts` are
+        // not recoverable. The pinned shape lives in the regression
+        // test `pre_f9_hook_with_no_agent_id_does_not_wipe_tagged_session`
+        // below.
         if event.event_type == EventType::SessionStart
             && event.agent_id.is_some()
             && let Some(ref pane_id) = event.pane_id
@@ -1851,6 +1864,37 @@ mod tests {
             .expect("agent-A session must be preserved when a pre-F9 hook fires");
         assert_eq!(agent_a.tool_count, 1);
         assert_eq!(agent_a.agent_id.as_deref(), Some("agent-A"));
+
+        // CodeRabbit PR #118 finding #2: pin the exact number of
+        // sessions that survive the pre-F9 hook on pane "42". The
+        // retire block is skipped (agent_id is None on the incoming
+        // event), the strict-equality reuse guard above doesn't
+        // match either (agent-A vs None), so the SessionStart falls
+        // through to the create path and a fresh `session-legacy`
+        // is inserted next to the preserved `session-A`. That
+        // duplicate is the intentional trade-off documented next to
+        // the `event.agent_id.is_some()` guard: visible duplicate
+        // card over silent data loss. If the count ever changes the
+        // trade-off has shifted — re-read PRD #110 + the guard
+        // comment before updating the expectation here.
+        let pane_42_sessions: Vec<&str> = state
+            .sessions
+            .iter()
+            .filter(|(_, s)| s.pane_id.as_deref() == Some("42"))
+            .map(|(id, _)| id.as_str())
+            .collect();
+        assert_eq!(
+            pane_42_sessions.len(),
+            2,
+            "expected the tagged session-A plus the legacy session-legacy on pane 42, got {pane_42_sessions:?}"
+        );
+        assert!(pane_42_sessions.contains(&"session-A"));
+        assert!(pane_42_sessions.contains(&"session-legacy"));
+        let legacy = &state.sessions["session-legacy"];
+        assert!(
+            legacy.agent_id.is_none(),
+            "the legacy session must carry no agent_id (that's what makes it the duplicate)"
+        );
     }
 
     // Follow-up to 0d5e651 (auditor finding #1): the auto-register

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -487,7 +487,12 @@ impl TabManager {
                     // for roles that didn't survive reconnect — there's
                     // no pane to close, and leaking "" through a pane-id
                     // API confuses downstream callers.
-                    if id.is_empty() {
+                    // Symptom 2 fix (`.dot-agent-deck/agent-card-lifecycle-bugs.md`):
+                    // also skip synthetic dead-slot pane ids
+                    // (`__dead-slot__-...`) — those carry a placeholder
+                    // session on the dashboard but have no backing PTY,
+                    // so `close_pane` would fail with NotFound.
+                    if id.is_empty() || crate::ui::is_dead_slot_pane_id(id) {
                         continue;
                     }
                     let result = self.pane_controller.close_pane(id);
@@ -523,7 +528,16 @@ impl TabManager {
                 }
                 Tab::Orchestration { role_pane_ids, .. } => {
                     // M2.12: skip the empty-string dead-slot sentinel.
-                    ids.extend(role_pane_ids.iter().filter(|id| !id.is_empty()).cloned());
+                    // Symptom 2 fix: also skip synthetic dead-slot pane
+                    // ids (`__dead-slot__-...`) — those are placeholder
+                    // sessions only, not real panes the embedded
+                    // controller owns.
+                    ids.extend(
+                        role_pane_ids
+                            .iter()
+                            .filter(|id| !id.is_empty() && !crate::ui::is_dead_slot_pane_id(id))
+                            .cloned(),
+                    );
                 }
                 Tab::Dashboard => {}
             }
@@ -1307,7 +1321,13 @@ mod tests {
         let mut tm = TabManager::new(mock);
         // No orchestration tab was rebuilt — `first_orchestration_tab_index`
         // is None, so `preferred_start_tab` collapses to 0 (dashboard).
-        let preferred_start_tab: usize = None::<usize>.unwrap_or(0);
+        // `black_box` is the canonical way to opacify the value so
+        // clippy's `unnecessary_literal_unwrap` lint stays quiet —
+        // the test's whole point is exercising the production
+        // `Option::unwrap_or(0)` path with a None input.
+        let first_orchestration_tab_index: Option<usize> =
+            std::hint::black_box::<Option<usize>>(None);
+        let preferred_start_tab: usize = first_orchestration_tab_index.unwrap_or(0);
 
         assert!(tm.switch_to(preferred_start_tab));
         assert!(tm.switch_to(preferred_start_tab));

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -398,9 +398,17 @@ impl TabManager {
         // for delegation routing in `ui.rs`) will see "" and find no
         // matching pane — same observable effect as the role being
         // missing.
+        // Follow-up to 0d5e651 (reviewer finding #5): synthetic
+        // dead-slot ids (`__dead-slot__-…`) are seeded into otherwise
+        // `None` slots BEFORE this call so the orchestration tab keeps
+        // the role's card visible. They are placeholder cards, not
+        // live agents — classify them as `Failed` instead of `Working`
+        // so any future consumer (e.g. a "role died" badge) reads the
+        // correct semantic signal.
         let role_statuses: Vec<OrchestrationRoleStatus> = role_pane_ids
             .iter()
             .map(|slot| match slot {
+                Some(id) if crate::ui::is_dead_slot_pane_id(id) => OrchestrationRoleStatus::Failed,
                 Some(_) => OrchestrationRoleStatus::Working,
                 None => OrchestrationRoleStatus::Failed,
             })
@@ -560,8 +568,18 @@ impl TabManager {
                 // dead-slot sentinel — skip the empty-string case
                 // explicitly so a caller asking about pane_id="" doesn't
                 // get a spurious orchestration tab match.
+                // Follow-up to 0d5e651 (reviewer finding #6): also skip
+                // synthetic dead-slot pane ids for consistency with
+                // `close_tab`, `all_managed_pane_ids`, and
+                // `resize_orchestration_role_panes_for`. No production
+                // caller hits the synthetic-id branch today, but the
+                // inconsistency is a footgun for any future code that
+                // assumes "if `tab_index_for_pane` returns Some, the
+                // pane is real."
                 Tab::Orchestration { role_pane_ids, .. }
-                    if !pane_id.is_empty() && role_pane_ids.contains(&pane_id.to_string()) =>
+                    if !pane_id.is_empty()
+                        && !crate::ui::is_dead_slot_pane_id(pane_id)
+                        && role_pane_ids.contains(&pane_id.to_string()) =>
                 {
                     return Some(i);
                 }
@@ -1205,6 +1223,101 @@ mod tests {
         assert_eq!(tm.active_index(), 0);
         let closed = mock.closed.lock().unwrap();
         assert_eq!(closed.len(), 2);
+    }
+
+    // Follow-up to 0d5e651 (reviewer finding #6): `tab_index_for_pane`
+    // must reject synthetic dead-slot ids for consistency with
+    // `close_tab`, `all_managed_pane_ids`, and
+    // `resize_orchestration_role_panes_for`. A synthetic id is a
+    // placeholder card, not a real pane — returning a tab index for
+    // it would mislead any future caller that assumes "Some ⇒ real
+    // pane."
+    #[test]
+    fn tab_index_for_pane_rejects_synthetic_dead_slot_id() {
+        let mock = Arc::new(MockPaneController::new());
+        let mut tm = TabManager::new(mock);
+
+        let role = |name: &str, start: bool| OrchestrationRoleConfig {
+            name: name.to_string(),
+            command: "claude".to_string(),
+            start,
+            description: None,
+            prompt_template: None,
+            clear: true,
+        };
+        let config = OrchestrationConfig {
+            name: "tab-index-dead-slot".to_string(),
+            roles: vec![role("tester", true), role("coder", false)],
+        };
+        let synthetic = crate::ui::dead_slot_pane_id("/tmp", "tab-index-dead-slot", 1);
+        tm.open_orchestration_tab_with_existing_role_panes(
+            &config,
+            "/tmp",
+            vec![Some("real-1".to_string()), Some(synthetic.clone())],
+        )
+        .unwrap();
+
+        assert_eq!(tm.tab_index_for_pane("real-1"), Some(1));
+        assert_eq!(
+            tm.tab_index_for_pane(&synthetic),
+            None,
+            "synthetic dead-slot id must NOT resolve to a tab index"
+        );
+    }
+
+    // Follow-up to 0d5e651 (reviewer finding #5): dead-slot synthetic
+    // ids are placeholder cards, not live agents. The
+    // `Some(_) → Working` mapping previously classified them as
+    // `Working` because the hydration path now fills `None` slots
+    // with `Some(synthetic)` BEFORE calling
+    // `open_orchestration_tab_with_existing_role_panes`. Pin that
+    // synthetic ids resolve to `Failed` so the semantic signal is
+    // correct for any future consumer.
+    #[test]
+    fn role_status_for_dead_slot_synthetic_id_is_failed() {
+        let mock = Arc::new(MockPaneController::new());
+        let mut tm = TabManager::new(mock);
+
+        let role = |name: &str, start: bool| OrchestrationRoleConfig {
+            name: name.to_string(),
+            command: "claude".to_string(),
+            start,
+            description: None,
+            prompt_template: None,
+            clear: true,
+        };
+        let config = OrchestrationConfig {
+            name: "with-dead-slot-status".to_string(),
+            roles: vec![
+                role("tester", true),
+                role("coder", false),
+                role("reviewer", false),
+            ],
+        };
+
+        let synthetic = crate::ui::dead_slot_pane_id("/tmp", "with-dead-slot-status", 1);
+        tm.open_orchestration_tab_with_existing_role_panes(
+            &config,
+            "/tmp",
+            vec![
+                Some("real-1".to_string()),
+                Some(synthetic),
+                Some("real-2".to_string()),
+            ],
+        )
+        .unwrap();
+
+        if let Tab::Orchestration { role_statuses, .. } = tm.active_tab() {
+            assert_eq!(role_statuses[0], OrchestrationRoleStatus::Working);
+            assert_eq!(
+                role_statuses[1],
+                OrchestrationRoleStatus::Failed,
+                "dead-slot synthetic id must resolve to Failed, not Working"
+            );
+            assert_eq!(role_statuses[2], OrchestrationRoleStatus::Working);
+        } else {
+            panic!("expected Orchestration tab");
+        }
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1500,6 +1500,35 @@ pub fn is_dead_slot_pane_id(pane_id: &str) -> bool {
 }
 
 /// Fill missing role slots in `role_pane_ids` with synthetic dead-slot
+/// pane ids. Returns the list of synthetic ids that were assigned (in
+/// `role_index` order) so callers can later seed placeholder sessions
+/// for them — or skip the seeding entirely if a subsequent step fails.
+///
+/// This is the pure half of [`fill_dead_slots_with_placeholders`]: it
+/// only mutates `role_pane_ids`, never touches `AppState`. Splitting
+/// the two phases is what lets the production hydration loop defer
+/// placeholder-session insertion until AFTER
+/// `open_orchestration_tab_with_existing_role_panes` succeeds
+/// (CodeRabbit PR #118 finding #3). The old fill-first-then-open
+/// ordering leaked placeholder sessions into `AppState` whenever the
+/// tab-open call returned `Err` — there was no rollback path.
+pub fn assign_synthetic_dead_slot_ids(
+    role_pane_ids: &mut [Option<String>],
+    cwd: &str,
+    orchestration_name: &str,
+) -> Vec<String> {
+    let mut assigned = Vec::new();
+    for (role_index, slot) in role_pane_ids.iter_mut().enumerate() {
+        if slot.is_none() {
+            let synthetic = dead_slot_pane_id(cwd, orchestration_name, role_index);
+            assigned.push(synthetic.clone());
+            *slot = Some(synthetic);
+        }
+    }
+    assigned
+}
+
+/// Fill missing role slots in `role_pane_ids` with synthetic dead-slot
 /// pane ids and insert a placeholder session into `state` for each one.
 ///
 /// Symptom 2 (bug task `agent-card-lifecycle-bugs.md`): when an
@@ -1516,18 +1545,21 @@ pub fn is_dead_slot_pane_id(pane_id: &str) -> bool {
 /// `apply_event` additionally rejects synthetic ids from its
 /// auto-register branch so a forged hook event cannot promote one
 /// into `managed_pane_ids`.
+///
+/// Production hydration no longer calls this convenience directly — it
+/// uses [`assign_synthetic_dead_slot_ids`] and then seeds placeholder
+/// sessions only on the `Ok` branch of `open_orchestration_tab_*` (see
+/// CodeRabbit PR #118 finding #3). Tests still use this helper because
+/// they exercise the synthetic-id + placeholder shape together.
 pub fn fill_dead_slots_with_placeholders(
     role_pane_ids: &mut [Option<String>],
     cwd: &str,
     orchestration_name: &str,
     state: &mut AppState,
 ) {
-    for (role_index, slot) in role_pane_ids.iter_mut().enumerate() {
-        if slot.is_none() {
-            let synthetic = dead_slot_pane_id(cwd, orchestration_name, role_index);
-            state.insert_placeholder_session(synthetic.clone(), Some(cwd.to_string()), None, None);
-            *slot = Some(synthetic);
-        }
+    let assigned = assign_synthetic_dead_slot_ids(role_pane_ids, cwd, orchestration_name);
+    for synthetic in assigned {
+        state.insert_placeholder_session(synthetic, Some(cwd.to_string()), None, None);
     }
 }
 
@@ -2869,20 +2901,26 @@ pub fn run_tui(
             // exits cleanly) is absent from `agent_records()` and
             // therefore absent from `bucket.role_slots`. Pre-fix the
             // role just disappeared from the orchestration tab on
-            // reconnect — the user lost the slot entirely. Fill the
-            // remaining `None` slots with synthetic dead-slot pane
-            // ids and seed placeholder sessions so every role in the
-            // config keeps its card on the rebuilt tab, even though
-            // only the live ones have backing PTYs on the right.
-            {
-                let mut st = state.blocking_write();
-                fill_dead_slots_with_placeholders(
-                    &mut role_pane_ids,
-                    &bucket.cwd,
-                    &bucket.orchestration_name,
-                    &mut st,
-                );
-            }
+            // reconnect — the user lost the slot entirely. Assign a
+            // synthetic dead-slot pane id to every remaining `None`
+            // slot so every role in the config keeps its card on the
+            // rebuilt tab, even though only the live ones have
+            // backing PTYs on the right.
+            //
+            // CodeRabbit PR #118 finding #3: split assignment from
+            // placeholder-session seeding. Synthetic ids go into
+            // `role_pane_ids` first so they're reflected in the
+            // `role_statuses` the tab-open call computes (dead slots
+            // classify as `Failed`). Placeholder sessions are only
+            // inserted into `AppState` once the tab open succeeds —
+            // see the matching `Ok` branch below. On `Err`, no
+            // placeholder sessions are seeded, so the `Err` arm has
+            // nothing to clean up.
+            let dead_slot_synthetic_ids = assign_synthetic_dead_slot_ids(
+                &mut role_pane_ids,
+                &bucket.cwd,
+                &bucket.orchestration_name,
+            );
             // Now register the orchestrator pane mapping for any live
             // start role so M5 dispatch keeps routing work-done events
             // back to the right place.
@@ -2898,6 +2936,19 @@ pub fn run_tui(
                         first_orchestration_tab_index = Some(tab_index);
                     }
                     let mut st = state.blocking_write();
+                    // CodeRabbit PR #118 finding #3: seed placeholder
+                    // sessions for dead slots only after the tab has
+                    // been built. If `open_orchestration_tab_*`
+                    // returned `Err`, we'd skip this loop entirely and
+                    // never orphan placeholder sessions in `AppState`.
+                    for synthetic in &dead_slot_synthetic_ids {
+                        st.insert_placeholder_session(
+                            synthetic.clone(),
+                            Some(bucket.cwd.clone()),
+                            None,
+                            None,
+                        );
+                    }
                     for (i, role) in orch_config.roles.iter().enumerate() {
                         if let Some(Some(pane_id)) = role_pane_ids.get(i) {
                             // Symptom 2 fix
@@ -2930,6 +2981,12 @@ pub fn run_tui(
                         error = %e,
                         "hydration: failed to rebuild orchestration tab; role panes stay on dashboard"
                     );
+                    // CodeRabbit PR #118 finding #3: nothing to roll
+                    // back. Placeholder sessions for the synthetic
+                    // ids in `dead_slot_synthetic_ids` were
+                    // deliberately NOT inserted into `AppState`
+                    // (that step lives in the `Ok` arm above), so
+                    // there are no orphaned sessions to clean up.
                 }
             }
         }
@@ -7920,6 +7977,175 @@ mod tests {
             "repeated reconnect loops must not accumulate dead-slot \
              placeholder sessions; got {dead_session_count}"
         );
+    }
+
+    // CodeRabbit PR #118 finding #3: the production hydration loop
+    // splits dead-slot pane-id assignment from placeholder-session
+    // seeding, so `open_orchestration_tab_with_existing_role_panes`'s
+    // Err arm doesn't orphan placeholder sessions in `AppState`. Pin
+    // the contract that `assign_synthetic_dead_slot_ids` is pure (no
+    // state mutation) — that's the prerequisite for the deferred-seed
+    // pattern at `src/ui.rs::hydrate_from_daemon`.
+    #[test]
+    fn assign_synthetic_dead_slot_ids_does_not_mutate_state() {
+        use crate::state::AppState;
+
+        let state = AppState::default();
+        let mut slots: Vec<Option<String>> = vec![
+            Some("p-live".to_string()),
+            None,
+            Some("p-other".to_string()),
+            None,
+        ];
+        let assigned = assign_synthetic_dead_slot_ids(&mut slots, "/work", "tdd-cycle");
+        assert_eq!(
+            assigned.len(),
+            2,
+            "the two `None` slots must each yield a synthetic id"
+        );
+        assert!(assigned.iter().all(|id| is_dead_slot_pane_id(id)));
+        // Slots reflect the assignment …
+        assert_eq!(slots[1].as_deref(), Some(assigned[0].as_str()));
+        assert_eq!(slots[3].as_deref(), Some(assigned[1].as_str()));
+        // … but `AppState` is untouched. The split-phase pattern relies
+        // on this so a tab-open `Err` cannot leak placeholder sessions.
+        assert!(
+            state.sessions.is_empty(),
+            "assign_synthetic_dead_slot_ids must be pure; sessions={:?}",
+            state.sessions.keys().collect::<Vec<_>>()
+        );
+    }
+
+    // CodeRabbit PR #118 finding #3: when
+    // `open_orchestration_tab_with_existing_role_panes` returns Err
+    // (e.g., `MismatchedRoleCount` from a malformed daemon record),
+    // the hydration loop must not leave orphaned placeholder sessions
+    // behind for the synthetic dead-slot ids it just minted. The fix
+    // defers `insert_placeholder_session` calls into the `Ok` arm
+    // only; the `Err` arm is a no-op for `AppState`. This test pins
+    // that contract by replaying the production sequence end-to-end.
+    #[test]
+    fn dead_slot_placeholders_not_seeded_when_tab_open_fails() {
+        use crate::project_config::{OrchestrationConfig, OrchestrationRoleConfig};
+        use crate::state::AppState;
+
+        fn mk_role(name: &str, start: bool) -> OrchestrationRoleConfig {
+            OrchestrationRoleConfig {
+                name: name.to_string(),
+                command: String::new(),
+                start,
+                description: None,
+                prompt_template: None,
+                clear: true,
+            }
+        }
+
+        let mut state = AppState::default();
+        let cfg = OrchestrationConfig {
+            name: "tdd-cycle".into(),
+            roles: vec![
+                mk_role("orch", true),
+                mk_role("coder", false),
+                mk_role("release", false),
+            ],
+        };
+
+        // Bucket-driven shape: roles 0 + 1 alive, role 2 dead.
+        let mut role_pane_ids: Vec<Option<String>> =
+            vec![Some("p-orch".into()), Some("p-coder".into()), None];
+
+        // Phase 1 (production hydration): mint synthetic ids for the
+        // dead slot. State must remain untouched.
+        let synthetic_ids =
+            assign_synthetic_dead_slot_ids(&mut role_pane_ids, "/work", "tdd-cycle");
+        assert_eq!(synthetic_ids.len(), 1, "exactly the role 2 slot is dead");
+        assert!(state.sessions.is_empty(), "phase 1 must not seed sessions");
+
+        // Force the tab-open Err by passing a length-mismatched vec.
+        // In production this is unreachable (the vec is built from
+        // `cfg.roles.len()`); the Err arm exists defensively for
+        // malformed daemon records and future-caller bugs. This is
+        // what we want to pin: even on Err, no orphan sessions.
+        struct NoopPC;
+        impl crate::pane::PaneController for NoopPC {
+            fn create_pane(
+                &self,
+                _cmd: Option<&str>,
+                _cwd: Option<&str>,
+            ) -> Result<String, crate::pane::PaneError> {
+                Ok(String::new())
+            }
+            fn write_to_pane(&self, _id: &str, _text: &str) -> Result<(), crate::pane::PaneError> {
+                Ok(())
+            }
+            fn close_pane(&self, _id: &str) -> Result<(), crate::pane::PaneError> {
+                Ok(())
+            }
+            fn rename_pane(
+                &self,
+                _id: &str,
+                name: &str,
+            ) -> Result<crate::pane::RenameOutcome, crate::pane::PaneError> {
+                Ok(crate::pane::RenameOutcome::applied(name))
+            }
+            fn focus_pane(&self, _id: &str) -> Result<(), crate::pane::PaneError> {
+                Ok(())
+            }
+            fn list_panes(&self) -> Result<Vec<crate::pane::PaneInfo>, crate::pane::PaneError> {
+                Ok(Vec::new())
+            }
+            fn resize_pane(
+                &self,
+                _id: &str,
+                _direction: crate::pane::PaneDirection,
+                _amount: u16,
+            ) -> Result<(), crate::pane::PaneError> {
+                Ok(())
+            }
+            fn toggle_layout(&self) -> Result<(), crate::pane::PaneError> {
+                Ok(())
+            }
+            fn name(&self) -> &str {
+                "noop"
+            }
+            fn is_available(&self) -> bool {
+                true
+            }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+        let mut tm = crate::tab::TabManager::new(Arc::new(NoopPC));
+        let mut bad_vec = role_pane_ids.clone();
+        bad_vec.truncate(role_pane_ids.len() - 1);
+        let result = tm.open_orchestration_tab_with_existing_role_panes(&cfg, "/work", bad_vec);
+        assert!(
+            result.is_err(),
+            "test precondition: mismatched-length role_pane_ids must Err"
+        );
+
+        // Phase 2 (production hydration `Ok` arm) was deliberately
+        // skipped because of the Err. The `Err` arm is a no-op for
+        // `AppState`, so no synthetic placeholder must remain.
+        let leaked: Vec<String> = state
+            .sessions
+            .keys()
+            .filter(|k| is_dead_slot_pane_id(k))
+            .cloned()
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "tab-open Err must not leave orphan placeholder sessions; got {leaked:?}"
+        );
+        // And the synthetic ids we minted should be gone from state
+        // entirely — `assign_synthetic_dead_slot_ids` never touched
+        // it, and the Err arm never seeded them.
+        for synthetic in &synthetic_ids {
+            assert!(
+                !state.sessions.contains_key(synthetic),
+                "synthetic id {synthetic} must not have an `AppState` entry"
+            );
+        }
     }
 
     // Follow-up to 0d5e651 (auditor finding #2): dead-slot placeholder

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -981,7 +981,12 @@ fn resize_orchestration_role_panes_for(
     if let Some(embedded) = pane.as_any().downcast_ref::<EmbeddedPaneController>() {
         // Filter out empty-string sentinels for dead orchestration slots
         // (M2.12) so we don't issue a resize against a non-existent pane id.
-        let live: Vec<&String> = role_pane_ids.iter().filter(|id| !id.is_empty()).collect();
+        // Symptom 2 fix: also drop synthetic dead-slot pane ids
+        // (`__dead-slot__-...`) — they have no PTY to resize.
+        let live: Vec<&String> = role_pane_ids
+            .iter()
+            .filter(|id| !id.is_empty() && !is_dead_slot_pane_id(id))
+            .collect();
         if live.is_empty() {
             return;
         }
@@ -1447,6 +1452,69 @@ pub(crate) fn partition_hydrated_panes(hydrated: &[HydratedPane]) -> HydrationPa
     }
 
     out
+}
+
+/// Build the synthetic dead-slot pane id used to keep a role visible on
+/// the orchestration tab even when no live daemon agent backs it. The
+/// `__dead-slot__-` prefix is reserved for this synthesis and namespaced
+/// by `(cwd, orchestration_name, role_index)` so distinct dead slots
+/// never collide and a later reconnect produces the same id (idempotent
+/// across reconnects).
+///
+/// The synthesised id is NOT a real pane: it is intentionally absent
+/// from `EmbeddedPaneController::pane_ids()`, so the orchestration tab's
+/// right-side terminal grid renders 4 panes for the 4 live agents while
+/// the left-side card grid renders 5 cards (one per role) because the
+/// placeholder session sitting on the synthetic id satisfies the
+/// `pane_id ∈ role_pane_ids` filter in [`render_frame`].
+pub fn dead_slot_pane_id(cwd: &str, orchestration_name: &str, role_index: usize) -> String {
+    format!("{DEAD_SLOT_PREFIX}{cwd}-{orchestration_name}-{role_index}")
+}
+
+/// Reserved prefix for synthetic dead-slot pane ids produced by
+/// [`dead_slot_pane_id`]. Anything starting with this prefix is a
+/// placeholder used only by the orchestration tab's card grid — it has
+/// no backing PTY, isn't tracked by `EmbeddedPaneController`, and must
+/// be skipped by close / managed-pane traversals.
+pub const DEAD_SLOT_PREFIX: &str = "__dead-slot__-";
+
+/// Returns true if `pane_id` is one of the synthetic dead-slot ids
+/// produced by [`dead_slot_pane_id`]. Used by `close_tab` and
+/// `all_managed_pane_ids` to skip synthesised slots — there is no
+/// daemon-side pane to close and no real terminal to render on the
+/// right-hand side of the orchestration tab.
+pub fn is_dead_slot_pane_id(pane_id: &str) -> bool {
+    pane_id.starts_with(DEAD_SLOT_PREFIX)
+}
+
+/// Fill missing role slots in `role_pane_ids` with synthetic dead-slot
+/// pane ids and insert a placeholder session into `state` for each one.
+///
+/// Symptom 2 (bug task `agent-card-lifecycle-bugs.md`): when an
+/// orchestration role's daemon agent dies (e.g., a `clear = false`
+/// release agent that runs through its workflow and exits cleanly),
+/// `agent_records()` no longer returns it, the hydration bucket loses
+/// that role's slot, and the role used to disappear from the
+/// orchestration tab on reconnect. This helper bridges the gap: it
+/// generates a stable synthetic id per missing role, inserts a
+/// `agent_type = None` placeholder session keyed on it (so the dead
+/// slot renders as "No agent" in the card grid), and returns the
+/// fully-populated `role_pane_ids` to the caller. The synthetic id is
+/// NOT a managed pane — `register_pane` is deliberately skipped so
+/// `apply_event` won't accept hook events forged against it.
+pub fn fill_dead_slots_with_placeholders(
+    role_pane_ids: &mut [Option<String>],
+    cwd: &str,
+    orchestration_name: &str,
+    state: &mut AppState,
+) {
+    for (role_index, slot) in role_pane_ids.iter_mut().enumerate() {
+        if slot.is_none() {
+            let synthetic = dead_slot_pane_id(cwd, orchestration_name, role_index);
+            state.insert_placeholder_session(synthetic.clone(), Some(cwd.to_string()), None, None);
+            *slot = Some(synthetic);
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -2781,6 +2849,26 @@ pub fn run_tui(
                 );
                 continue;
             }
+            // Symptom 2 fix (`.dot-agent-deck/agent-card-lifecycle-bugs.md`):
+            // a role whose daemon agent died (most commonly a
+            // `clear = false` role that finishes its workflow and
+            // exits cleanly) is absent from `agent_records()` and
+            // therefore absent from `bucket.role_slots`. Pre-fix the
+            // role just disappeared from the orchestration tab on
+            // reconnect — the user lost the slot entirely. Fill the
+            // remaining `None` slots with synthetic dead-slot pane
+            // ids and seed placeholder sessions so every role in the
+            // config keeps its card on the rebuilt tab, even though
+            // only the live ones have backing PTYs on the right.
+            {
+                let mut st = state.blocking_write();
+                fill_dead_slots_with_placeholders(
+                    &mut role_pane_ids,
+                    &bucket.cwd,
+                    &bucket.orchestration_name,
+                    &mut st,
+                );
+            }
             // Now register the orchestrator pane mapping for any live
             // start role so M5 dispatch keeps routing work-done events
             // back to the right place.
@@ -2798,6 +2886,17 @@ pub fn run_tui(
                     let mut st = state.blocking_write();
                     for (i, role) in orch_config.roles.iter().enumerate() {
                         if let Some(Some(pane_id)) = role_pane_ids.get(i) {
+                            // Symptom 2 fix
+                            // (`.dot-agent-deck/agent-card-lifecycle-bugs.md`):
+                            // dead-slot synthetics are placeholder
+                            // sessions only — there is no daemon-side
+                            // pane to delegate to, so don't pollute
+                            // `pane_role_map` (which `handle_delegate`
+                            // queries to find a target pane) with
+                            // entries pointing at non-existent panes.
+                            if is_dead_slot_pane_id(pane_id) {
+                                continue;
+                            }
                             st.pane_role_map.insert(pane_id.clone(), role.name.clone());
                             st.pane_cwd_map.insert(pane_id.clone(), bucket.cwd.clone());
                             if role.start {
@@ -7615,6 +7714,112 @@ mod tests {
             && s.pane_id == "11"
             && s.role_name.is_empty()
             && !s.is_start_role));
+    }
+
+    // Symptom 2 (`.dot-agent-deck/agent-card-lifecycle-bugs.md`):
+    // when an orchestration role's daemon agent dies (e.g., a
+    // `clear = false` release agent that finishes its workflow and
+    // exits cleanly), the hydration bucket loses that slot. Pre-fix
+    // the role just disappeared from the rebuilt orchestration tab.
+    // `fill_dead_slots_with_placeholders` is the bridge: it stamps a
+    // synthetic id onto every `None` slot and seeds a placeholder
+    // session so every role in the config keeps its dashboard card.
+    #[test]
+    fn fill_dead_slots_replaces_none_with_synthetic_id_and_seeds_placeholder() {
+        use crate::state::AppState;
+
+        let mut state = AppState::default();
+        // 5 roles, only 4 hydrated agents — the LAST role (role_index 4,
+        // the `release`-style slot) is the dead one. This mirrors the
+        // production scenario described in the bug task: the `release`
+        // role is the last in `.dot-agent-deck.toml` and the only one
+        // with `clear = false`, so it's the one most likely to be
+        // missing on reconnect.
+        let mut slots: Vec<Option<String>> = vec![
+            Some("p-orch".to_string()),
+            Some("p-coder".to_string()),
+            Some("p-reviewer".to_string()),
+            Some("p-auditor".to_string()),
+            None,
+        ];
+        fill_dead_slots_with_placeholders(&mut slots, "/work", "tdd-cycle", &mut state);
+
+        assert!(
+            slots.iter().all(Option::is_some),
+            "every slot must be filled"
+        );
+        let dead_id = slots[4].as_deref().unwrap();
+        assert!(
+            is_dead_slot_pane_id(dead_id),
+            "dead slot must carry a synthetic id; got {dead_id:?}"
+        );
+        // Live slots untouched.
+        assert_eq!(slots[0].as_deref(), Some("p-orch"));
+        assert_eq!(slots[1].as_deref(), Some("p-coder"));
+        // Placeholder session exists for the dead slot, with
+        // agent_type=None so it renders as "No agent" in the card grid.
+        let dead_session = state
+            .sessions
+            .values()
+            .find(|s| s.pane_id.as_deref() == Some(dead_id))
+            .expect("dead-slot placeholder session must be seeded");
+        assert_eq!(
+            dead_session.agent_type,
+            AgentType::None,
+            "dead-slot placeholder must render as 'No agent'"
+        );
+        assert_eq!(dead_session.agent_id, None);
+    }
+
+    #[test]
+    fn dead_slot_pane_id_is_deterministic_per_role() {
+        // Same (cwd, name, role_index) must produce the same id so a
+        // reconnect doesn't keep minting fresh placeholder cards on
+        // every reattach.
+        let a = dead_slot_pane_id("/work", "tdd-cycle", 4);
+        let b = dead_slot_pane_id("/work", "tdd-cycle", 4);
+        assert_eq!(a, b);
+        // Different role_index → different id.
+        let c = dead_slot_pane_id("/work", "tdd-cycle", 3);
+        assert_ne!(a, c);
+        // Different orchestration → different id.
+        let d = dead_slot_pane_id("/work", "other-cycle", 4);
+        assert_ne!(a, d);
+        // is_dead_slot_pane_id accepts the synthesized id and rejects
+        // a normal numeric pane id.
+        assert!(is_dead_slot_pane_id(&a));
+        assert!(!is_dead_slot_pane_id("42"));
+    }
+
+    #[test]
+    fn fill_dead_slots_is_idempotent_across_repeat_calls() {
+        // Reconnect runs hydration again — calling
+        // `fill_dead_slots_with_placeholders` on already-filled slots
+        // must not change them and must not double-seed the
+        // placeholder session. (The placeholder helper itself
+        // overwrites the existing entry under the same session id, so
+        // the count stays at 1.)
+        use crate::state::AppState;
+
+        let mut state = AppState::default();
+        let mut slots: Vec<Option<String>> = vec![Some("p-orch".to_string()), None];
+        fill_dead_slots_with_placeholders(&mut slots, "/work", "tdd-cycle", &mut state);
+        let first_dead = slots[1].clone().unwrap();
+        let placeholder_count_first = state
+            .sessions
+            .values()
+            .filter(|s| s.pane_id.as_deref().is_some_and(is_dead_slot_pane_id))
+            .count();
+        // Second pass — same input shape.
+        fill_dead_slots_with_placeholders(&mut slots, "/work", "tdd-cycle", &mut state);
+        let placeholder_count_second = state
+            .sessions
+            .values()
+            .filter(|s| s.pane_id.as_deref().is_some_and(is_dead_slot_pane_id))
+            .count();
+        assert_eq!(slots[1].as_deref(), Some(first_dead.as_str()));
+        assert_eq!(placeholder_count_first, 1);
+        assert_eq!(placeholder_count_second, 1);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1467,8 +1467,20 @@ pub(crate) fn partition_hydrated_panes(hydrated: &[HydratedPane]) -> HydrationPa
 /// the left-side card grid renders 5 cards (one per role) because the
 /// placeholder session sitting on the synthetic id satisfies the
 /// `pane_id ∈ role_pane_ids` filter in [`render_frame`].
+///
+/// Follow-up to 0d5e651 (auditor finding #4): the variable-width
+/// components are length-prefixed so distinct (cwd,
+/// orchestration_name, role_index) tuples can never collide. The
+/// previous `-`-separated form was ambiguous whenever cwd or
+/// orchestration_name contained hyphens: e.g. (cwd="/a", name="b-c",
+/// idx=1) and (cwd="/a-b", name="c", idx=1) both produced
+/// `__dead-slot__-/a-b-c-1`.
 pub fn dead_slot_pane_id(cwd: &str, orchestration_name: &str, role_index: usize) -> String {
-    format!("{DEAD_SLOT_PREFIX}{cwd}-{orchestration_name}-{role_index}")
+    format!(
+        "{DEAD_SLOT_PREFIX}{cwd_len}-{cwd}-{name_len}-{orchestration_name}-{role_index}",
+        cwd_len = cwd.len(),
+        name_len = orchestration_name.len(),
+    )
 }
 
 /// Reserved prefix for synthetic dead-slot pane ids produced by
@@ -1500,8 +1512,10 @@ pub fn is_dead_slot_pane_id(pane_id: &str) -> bool {
 /// `agent_type = None` placeholder session keyed on it (so the dead
 /// slot renders as "No agent" in the card grid), and returns the
 /// fully-populated `role_pane_ids` to the caller. The synthetic id is
-/// NOT a managed pane — `register_pane` is deliberately skipped so
-/// `apply_event` won't accept hook events forged against it.
+/// NOT a managed pane — `register_pane` is deliberately skipped, and
+/// `apply_event` additionally rejects synthetic ids from its
+/// auto-register branch so a forged hook event cannot promote one
+/// into `managed_pane_ids`.
 pub fn fill_dead_slots_with_placeholders(
     role_pane_ids: &mut [Option<String>],
     cwd: &str,
@@ -3459,9 +3473,19 @@ pub fn run_tui(
         let filtered: Vec<(&String, &SessionState)> = match tab_manager.active_tab() {
             Tab::Dashboard => {
                 let exclude = tab_manager.all_managed_pane_ids();
+                // Follow-up to 0d5e651 (auditor finding #2): synthetic
+                // dead-slot placeholders live on the orchestration tab
+                // only. `all_managed_pane_ids` deliberately skips them
+                // (close_tab can't `close_pane` a synthetic id), so we
+                // must filter them out here too — otherwise the
+                // "No agent" ghost card leaks onto the Dashboard.
                 all_filtered
                     .into_iter()
-                    .filter(|(_, s)| s.pane_id.as_ref().is_none_or(|pid| !exclude.contains(pid)))
+                    .filter(|(_, s)| {
+                        s.pane_id
+                            .as_ref()
+                            .is_none_or(|pid| !exclude.contains(pid) && !is_dead_slot_pane_id(pid))
+                    })
                     .collect()
             }
             Tab::Orchestration { role_pane_ids, .. } => {
@@ -7791,14 +7815,40 @@ mod tests {
         assert!(!is_dead_slot_pane_id("42"));
     }
 
+    // Follow-up to 0d5e651 (auditor finding #4): the old format
+    // `__dead-slot__-{cwd}-{name}-{idx}` was ambiguous whenever cwd
+    // or orchestration_name contained hyphens. Two distinct tuples
+    // could produce the same synthetic id, which would then alias
+    // their placeholder sessions. Pin that the length-prefixed format
+    // disambiguates the textbook collision case.
+    #[test]
+    fn dead_slot_pane_id_disambiguates_hyphenated_inputs() {
+        // Under the old `-`-separated form both inputs formatted to
+        // `__dead-slot__-/a-b-c-1`. Under the length-prefixed form
+        // they are guaranteed distinct.
+        let a = dead_slot_pane_id("/a", "b-c", 1);
+        let b = dead_slot_pane_id("/a-b", "c", 1);
+        assert_ne!(
+            a, b,
+            "differently-hyphenated (cwd, orchestration_name) tuples \
+             must produce distinct synthetic ids"
+        );
+    }
+
     #[test]
     fn fill_dead_slots_is_idempotent_across_repeat_calls() {
         // Reconnect runs hydration again — calling
         // `fill_dead_slots_with_placeholders` on already-filled slots
         // must not change them and must not double-seed the
-        // placeholder session. (The placeholder helper itself
-        // overwrites the existing entry under the same session id, so
-        // the count stays at 1.)
+        // placeholder session.
+        //
+        // Follow-up to 0d5e651 (reviewer finding #7): the original
+        // comment claimed the helper "overwrites the existing entry
+        // under the same session id" on the second pass. That's
+        // wrong — the helper's body SKIPS slots where `slot.is_some()`,
+        // so `insert_placeholder_session` is never re-invoked. The
+        // count stays at 1 because the synthetic slot is already
+        // filled on the second pass.
         use crate::state::AppState;
 
         let mut state = AppState::default();
@@ -7810,7 +7860,8 @@ mod tests {
             .values()
             .filter(|s| s.pane_id.as_deref().is_some_and(is_dead_slot_pane_id))
             .count();
-        // Second pass — same input shape.
+        // Second pass — same input shape (slots are already filled,
+        // so the helper short-circuits on each iteration).
         fill_dead_slots_with_placeholders(&mut slots, "/work", "tdd-cycle", &mut state);
         let placeholder_count_second = state
             .sessions
@@ -7820,6 +7871,141 @@ mod tests {
         assert_eq!(slots[1].as_deref(), Some(first_dead.as_str()));
         assert_eq!(placeholder_count_first, 1);
         assert_eq!(placeholder_count_second, 1);
+    }
+
+    // Follow-up to 0d5e651 (reviewer finding #7): a more realistic
+    // idempotency scenario than the one above. A real
+    // disconnect/reconnect loop rebuilds `role_pane_ids` from scratch
+    // every time `hydrate_from_daemon` runs — the slot for a dead
+    // role is `None` again, not pre-filled. Verify that running the
+    // helper twice in a row (with the slot reset between calls)
+    // produces the SAME synthetic id (because `dead_slot_pane_id` is
+    // deterministic in `(cwd, name, role_index)`) and that
+    // `insert_placeholder_session` reuses the same `pane-{synthetic}`
+    // session key so only one placeholder ever exists for the slot.
+    #[test]
+    fn fill_dead_slots_produces_stable_id_across_reconnect_rebuilds() {
+        use crate::state::AppState;
+
+        let mut state = AppState::default();
+        let cwd = "/work";
+        let orchestration_name = "tdd-cycle";
+
+        // First reconnect: dead role at index 1.
+        let mut slots: Vec<Option<String>> = vec![Some("p-orch".to_string()), None];
+        fill_dead_slots_with_placeholders(&mut slots, cwd, orchestration_name, &mut state);
+        let first_dead = slots[1].clone().unwrap();
+
+        // Second reconnect: hydration rebuilt `role_pane_ids` from
+        // scratch — the dead role's slot is `None` again. Run the
+        // helper a second time.
+        let mut slots: Vec<Option<String>> = vec![Some("p-orch".to_string()), None];
+        fill_dead_slots_with_placeholders(&mut slots, cwd, orchestration_name, &mut state);
+        let second_dead = slots[1].clone().unwrap();
+
+        // The synthetic id is deterministic, so both reconnect
+        // attempts produce the same id …
+        assert_eq!(first_dead, second_dead);
+        // … and the placeholder session is keyed on
+        // `pane-{synthetic}`, so a second `insert_placeholder_session`
+        // call reuses the existing entry rather than spawning a
+        // sibling. Exactly one dead-slot session must exist.
+        let dead_session_count = state
+            .sessions
+            .values()
+            .filter(|s| s.pane_id.as_deref().is_some_and(is_dead_slot_pane_id))
+            .count();
+        assert_eq!(
+            dead_session_count, 1,
+            "repeated reconnect loops must not accumulate dead-slot \
+             placeholder sessions; got {dead_session_count}"
+        );
+    }
+
+    // Follow-up to 0d5e651 (auditor finding #2): dead-slot placeholder
+    // sessions belong to the orchestration tab only. The dashboard
+    // scoping uses `all_managed_pane_ids` as an EXCLUDE filter, but
+    // that set now skips synthetic ids (otherwise `close_tab` would
+    // try to `close_pane` them). Without an explicit `is_dead_slot`
+    // filter on the dashboard side, the placeholder "No agent" card
+    // leaks onto the Dashboard tab as a ghost. Pin the exclusion.
+    #[test]
+    fn dashboard_filter_excludes_dead_slot_placeholder_sessions() {
+        use crate::state::AppState;
+
+        let mut state = AppState::default();
+
+        // A real session on a real pane that DOES belong to an
+        // orchestration tab (so it's in `exclude`) — this models the
+        // existing behaviour that orchestration-tab sessions are
+        // hidden from the dashboard.
+        let real_pane = "p-orchestrator".to_string();
+        state.register_pane(real_pane.clone());
+        state.insert_placeholder_session(
+            real_pane.clone(),
+            Some("/work".to_string()),
+            Some(AgentType::ClaudeCode),
+            Some("agent-A".to_string()),
+        );
+
+        // A dead-slot placeholder seeded by `fill_dead_slots_with_placeholders`.
+        let mut slots: Vec<Option<String>> = vec![Some(real_pane.clone()), None];
+        fill_dead_slots_with_placeholders(&mut slots, "/work", "tdd-cycle", &mut state);
+        let dead_pane = slots[1].clone().unwrap();
+
+        // A separate session that lives only on the dashboard (not in
+        // any orchestration tab) — this is what should survive the
+        // filter.
+        let dashboard_pane = "p-dashboard-only".to_string();
+        state.register_pane(dashboard_pane.clone());
+        state.insert_placeholder_session(
+            dashboard_pane.clone(),
+            Some("/work".to_string()),
+            Some(AgentType::ClaudeCode),
+            Some("agent-B".to_string()),
+        );
+
+        // Build the exclude set the way `TabManager::all_managed_pane_ids`
+        // does for an orchestration tab: include the real pane, skip
+        // the synthetic dead-slot id.
+        let exclude: Vec<String> = slots
+            .iter()
+            .filter_map(|s| s.as_ref())
+            .filter(|id| !is_dead_slot_pane_id(id))
+            .cloned()
+            .collect();
+        assert!(
+            !exclude.contains(&dead_pane),
+            "test precondition: synthetic id must NOT be in the exclude set"
+        );
+
+        // Replicate the dashboard scoping filter at
+        // `render_frame`'s Tab::Dashboard branch.
+        let visible_on_dashboard: Vec<String> = state
+            .sessions
+            .values()
+            .filter(|s| {
+                s.pane_id
+                    .as_ref()
+                    .is_none_or(|pid| !exclude.contains(pid) && !is_dead_slot_pane_id(pid))
+            })
+            .filter_map(|s| s.pane_id.clone())
+            .collect();
+
+        assert!(
+            !visible_on_dashboard.contains(&dead_pane),
+            "dead-slot placeholder must NOT appear on the Dashboard; \
+             got {visible_on_dashboard:?}"
+        );
+        assert!(
+            !visible_on_dashboard.contains(&real_pane),
+            "real orchestration-tab pane must continue to be excluded \
+             from the Dashboard via the existing path"
+        );
+        assert!(
+            visible_on_dashboard.contains(&dashboard_pane),
+            "dashboard-only session must remain visible; got {visible_on_dashboard:?}"
+        );
     }
 
     #[test]

--- a/tests/orchestration_delegate.rs
+++ b/tests/orchestration_delegate.rs
@@ -3196,4 +3196,33 @@ command = "cat -u"
         Some(coder_new.as_str()),
         "new session card must carry the NEW (post-respawn) agent_id"
     );
+
+    // Symptom 1 regression guard: the OLD card (still bound to the
+    // pre-respawn agent_id) must have been retired by `apply_event`
+    // when the NEW SessionStart arrived. Pre-fix the dashboard ended
+    // up with TWO coder cards on `coder-pane` — the live new card and
+    // the stale old card the daemon couldn't kill cleanly (F9 sends
+    // SIGKILL, so no graceful SessionEnd ever fires).
+    let coder_pane_cards: Vec<(&String, Option<&str>)> = st
+        .sessions
+        .iter()
+        .filter(|(_, s)| s.pane_id.as_deref() == Some("coder-pane"))
+        .map(|(id, s)| (id, s.agent_id.as_deref()))
+        .collect();
+    assert_eq!(
+        coder_pane_cards.len(),
+        1,
+        "F9 clear=true respawn must leave exactly one card on coder-pane; \
+         got {coder_pane_cards:?}"
+    );
+    assert_eq!(
+        coder_pane_cards[0].1,
+        Some(coder_new.as_str()),
+        "the surviving coder-pane card must belong to the post-respawn agent"
+    );
+    assert!(
+        !st.sessions.contains_key(&initial_session_id),
+        "the pre-respawn (agent-A) session card must be retired; \
+         it lingered as session_id={initial_session_id}"
+    );
 }

--- a/tests/rehydration.rs
+++ b/tests/rehydration.rs
@@ -28,7 +28,7 @@ use tempfile::TempDir;
 use tokio::net::{UnixListener, UnixStream};
 use tokio::task::JoinHandle;
 
-use dot_agent_deck::agent_pty::AgentPtyRegistry;
+use dot_agent_deck::agent_pty::{AgentPtyRegistry, TabMembership};
 use dot_agent_deck::daemon_client::{DaemonClient, StartAgentOptions};
 use dot_agent_deck::daemon_protocol::{
     AttachRequest, AttachResponse, KIND_REQ, KIND_RESP, bind_attach_listener, read_frame,
@@ -37,6 +37,9 @@ use dot_agent_deck::daemon_protocol::{
 use dot_agent_deck::embedded_pane::EmbeddedPaneController;
 use dot_agent_deck::event::AgentType;
 use dot_agent_deck::state::AppState;
+use dot_agent_deck::ui::{
+    dead_slot_pane_id, fill_dead_slots_with_placeholders, is_dead_slot_pane_id,
+};
 
 // `bind_attach_listener` flips the process-global umask while binding; share
 // the lock with the other M-series tests so concurrent tempdir creation
@@ -898,4 +901,176 @@ async fn hydrate_preserves_agent_type_end_to_end_opencode() {
 
     drop(ctrl);
     let _ = server.registry.close_agent(&agent_id);
+}
+
+/// Symptom 2 regression
+/// (`.dot-agent-deck/agent-card-lifecycle-bugs.md`): a role whose daemon
+/// agent has died (e.g., a `clear = false` `release` agent that runs
+/// through its workflow and exits cleanly) is absent from
+/// `agent_records()` on reconnect. The TUI's hydration partition
+/// therefore receives sparse role slots — the bucket has one fewer
+/// entry than the orchestration config declares. Pre-fix the missing
+/// role's slot disappeared from the rebuilt orchestration tab
+/// entirely.
+///
+/// This test pins the fix end-to-end at the integration boundary the
+/// real reconnect path uses:
+///   1. Spawn 5 orchestration role agents through `DaemonClient`,
+///      mirroring the production `.dot-agent-deck.toml` layout
+///      (orchestrator + coder + reviewer + auditor + release).
+///   2. Kill the LAST agent (`release`-equivalent) the same way a
+///      `clear = false` agent exiting cleanly would die — its
+///      registry entry is pruned, `list_agents` no longer reports
+///      it.
+///   3. Hydrate. Verify `hydrate_from_daemon` returns 4 panes (the
+///      live ones) — that's the underlying state the fix has to cope
+///      with.
+///   4. Build a `Vec<Option<String>>` of length 5 the way the
+///      hydration loop in `ui.rs` does (one `Some(pane_id)` per
+///      hydrated role slot, the dead role's slot is `None`).
+///   5. Call `fill_dead_slots_with_placeholders` and assert every
+///      slot now carries a non-empty id, the dead one is the
+///      deterministic synthetic id, and a placeholder session has
+///      been seeded so the orchestration tab's card filter
+///      (`pane_id ∈ role_pane_ids`) finds it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dead_role_stays_visible_on_reconnect_as_placeholder_card() {
+    let server = start_real_server().await;
+    let client = DaemonClient::new(server.path.clone());
+
+    let orchestration_name = "tdd-cycle";
+    let cwd = server._dir.path().to_string_lossy().into_owned();
+    let role_names = ["orchestrator", "coder", "reviewer", "auditor", "release"];
+    let mut spawned_ids: Vec<String> = Vec::new();
+    for (role_index, role_name) in role_names.iter().enumerate() {
+        let pane_env = format!("pane-{role_name}");
+        let id = client
+            .start_agent(StartAgentOptions {
+                command: Some("sh -c 'sleep 30'".to_string()),
+                cwd: Some(cwd.clone()),
+                display_name: Some((*role_name).to_string()),
+                env: vec![("DOT_AGENT_DECK_PANE_ID".to_string(), pane_env)],
+                tab_membership: Some(TabMembership::Orchestration {
+                    name: orchestration_name.to_string(),
+                    role_index,
+                    role_name: (*role_name).to_string(),
+                    is_start_role: role_index == 0,
+                    orchestration_cwd: Some(cwd.clone()),
+                }),
+                ..Default::default()
+            })
+            .await
+            .expect("start_agent should succeed");
+        spawned_ids.push(id);
+    }
+
+    // Kill the LAST role (`release`-equivalent). Matches the
+    // production failure mode: an agent that exits cleanly (or that
+    // the user explicitly closed) is pruned from `agent_records()`
+    // and disappears from `list_agents`.
+    let release_id = spawned_ids.last().unwrap().clone();
+    server
+        .registry
+        .close_agent(&release_id)
+        .expect("close_agent for release should succeed");
+
+    // Hydrate. Confirms the precondition the fix has to cope with:
+    // only 4 panes are returned even though the orchestration
+    // declares 5.
+    let ctrl = Arc::new(EmbeddedPaneController::new(
+        server.path.clone(),
+        tokio::runtime::Handle::current(),
+    ));
+    let hydrated = {
+        let ctrl = ctrl.clone();
+        tokio::task::spawn_blocking(move || ctrl.hydrate_from_daemon())
+            .await
+            .unwrap()
+    };
+    assert_eq!(
+        hydrated.len(),
+        4,
+        "release agent was closed, so only 4 of 5 should hydrate; \
+         got {hydrated:?}"
+    );
+
+    // Build `role_pane_ids` the way the hydration loop does. We map
+    // each surviving role into its slot by role_index.
+    let mut role_pane_ids: Vec<Option<String>> = vec![None; role_names.len()];
+    for h in &hydrated {
+        if let Some(TabMembership::Orchestration { role_index, .. }) = &h.tab_membership {
+            role_pane_ids[*role_index] = Some(h.pane_id.clone());
+        }
+    }
+    assert!(
+        role_pane_ids[4].is_none(),
+        "role_index 4 must be the dead slot"
+    );
+
+    // Apply the fix: every dead slot gets a synthetic id and a
+    // placeholder session is seeded so the orchestration tab keeps
+    // the role's card visible.
+    let mut state = AppState::default();
+    // Seed placeholders for the live hydrated panes too — mirrors the
+    // hydration loop's normal path so the post-fix AppState looks like
+    // the real run_tui's would.
+    for h in &hydrated {
+        state.register_pane(h.pane_id.clone());
+        state.insert_placeholder_session(
+            h.pane_id.clone(),
+            h.cwd.clone(),
+            h.agent_type.clone(),
+            Some(h.agent_id.clone()),
+        );
+    }
+    fill_dead_slots_with_placeholders(&mut role_pane_ids, &cwd, orchestration_name, &mut state);
+
+    // Every role slot is now filled.
+    assert!(
+        role_pane_ids.iter().all(Option::is_some),
+        "all 5 role slots must have a pane id after the dead-slot fill; \
+         got {role_pane_ids:?}"
+    );
+    let dead_id = role_pane_ids[4].as_deref().unwrap();
+    assert_eq!(
+        dead_id,
+        dead_slot_pane_id(&cwd, orchestration_name, 4),
+        "dead slot id must be the deterministic synthetic"
+    );
+    assert!(is_dead_slot_pane_id(dead_id));
+
+    // The placeholder session backing the dead slot exists, has the
+    // 'No agent' shape, and would be picked up by the orchestration
+    // tab's card-filter (`pane_id ∈ role_pane_ids`).
+    let dead_session = state
+        .sessions
+        .values()
+        .find(|s| s.pane_id.as_deref() == Some(dead_id))
+        .expect("dead-slot placeholder session must exist in AppState");
+    assert_eq!(dead_session.agent_type, AgentType::None);
+
+    // And we end up with one session per role — five total, not
+    // four. Pre-fix this would have been four.
+    let cards_per_pane: Vec<&str> = role_pane_ids
+        .iter()
+        .filter_map(|p| p.as_deref())
+        .filter(|pid| {
+            state
+                .sessions
+                .values()
+                .any(|s| s.pane_id.as_deref() == Some(*pid))
+        })
+        .collect();
+    assert_eq!(
+        cards_per_pane.len(),
+        5,
+        "exactly one card must exist per role slot; got {cards_per_pane:?}"
+    );
+
+    drop(ctrl);
+    // Clean up surviving agents so the test doesn't leak the `sleep 30`
+    // children.
+    for id in &spawned_ids[..spawned_ids.len() - 1] {
+        let _ = server.registry.close_agent(id);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes two follow-on symptoms discovered during testing of PRD #110's session-reuse vs F9-respawn fix, plus addresses all reviewer and auditor findings from the initial fix commit.

## Background

PRD #110 ([prds/done/110-fix-session-reuse-vs-f9-respawn.md](prds/done/110-fix-session-reuse-vs-f9-respawn.md)) shipped a fix so that an F9 respawn (clear=true delegate) correctly creates a NEW session card instead of being silently remapped onto the old one. Two follow-on bugs remained.

## Symptoms Fixed (commit 0d5e651 / 74b7034)

1. **Duplicate role card after F9 clear=true respawn** — when a fresh session card was created for a role/pane, the prior session card for the same role was not retired. Result: two cards for the same role visible simultaneously in the orchestration tab.

2. **Configured role disappears from orchestration tab on reconnect** — the duplicate card occupied a slot, pushing one of the configured roles off the visible deck. The missing-role symptom was a direct consequence of the duplicate-card bug.

## Reviewer + Auditor Findings Addressed (commit 08b8de6 / 6cf1f86)

1. **Synthetic-id auto-register guard** — added  to the  auto-register branch so a forged hook event cannot bring a synthetic id into existence. Corrected the  docstring to match the real invariant.

2. **Dashboard ghost-card scoping** — dead-slot placeholder sessions are now excluded from the Dashboard tab (scoped to orchestration tab only). The Dashboard exclude-filter already skipped synthetic ids via ; the placeholder sessions themselves are now also explicitly excluded.

3. **Pre-F9 backward-compat retire skip** — the retire-stale-sibling block now skips when , preserving backward compatibility with pre-F9 hook scripts that do not set .

4. **Collision-safe synthetic id encoding** —  format changed from  separator (collidable across tuples) to  separator, ensuring a one-to-one mapping from (cwd, name, idx) to synthetic id.

5. **Failed role status for dead slots** —  now resolves dead-slot synthetic ids to  (not ), preserving correct semantic signal for future features.

6. ** filter** — applied the same  guard for consistency with , , and .

7. **Idempotency test comment fix** — corrected the comment in  and added a more realistic reconnect-loop scenario.

## Auditor Note

's synthetic-id reject also changes close-tab behaviour for placeholder-card actions — if a close-tab action is invoked against a dead-slot placeholder, it will now return  instead of a real tab index. This is an **intentional improvement** (close-tab on a placeholder card was a footgun), but reviewers should be aware the behaviour changed.

## Testing

All changes are covered by regression tests. CI must pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent lifecycle handling to prevent duplicate orchestration cards when agents are replaced or respawned.
  * Enhanced session management to properly retire stale sessions when agents are swapped on the same role slot.
  * Fixed an issue where orchestration role slots could appear as actionable panes despite having no active agent.

* **Tests**
  * Expanded test coverage for agent replacement and reconnection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vfarcic/dot-agent-deck/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->