### PR TITLE
docs: add changelog fragment for #118

### DIFF
--- a/changelog.d/118.bugfix.md
+++ b/changelog.d/118.bugfix.md
@@ -1,0 +1,3 @@
+## Orchestration Role Cards Stay Consistent Across Respawn and Reconnect
+
+Two follow-on symptoms from the orchestration GA release are fixed. After an F9 delegate respawn (`clear = true`), the orchestration tab no longer shows a duplicate card for the same role — the stale card from the previous agent is now retired when the fresh one starts. And after reconnecting to a daemon with a role whose worker had already exited (typically a `clear = false` agent that finished its workflow), the configured role no longer briefly disappears from the orchestration tab; every role in the config keeps a placeholder card on hydration so the tab layout matches `.dot-agent-deck.toml`.


### PR DESCRIPTION
## Summary
- Adds `changelog.d/118.bugfix.md` for the agent-card lifecycle fixes shipped in PR #118 (commit 57791ab).
- The `/prd-done` flow was adapted for #118 (no PRD), and the changelog-fragment step got skipped — without this fragment the fix would be invisible in the next release notes assembled by the tag-release skill.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)