### PR TITLE
fix(prd-100): Enter in orchestrator pane now reliably submits — atomic WriteAndSubmit RPC

### DIFF
--- a/changelog.d/100.bugfix.md
+++ b/changelog.d/100.bugfix.md
@@ -1,0 +1,9 @@
+## Enter Key in Orchestrator Pane Now Reliably Submits the Prompt
+
+Pressing Enter to dispatch a prompt to the orchestrator agent no longer intermittently inserts a newline into the input box instead of submitting. Previously, a 150 ms gap in the client write path freed the per-agent writer mutex between the payload write and the trailing CR; concurrent daemon-initiated writes (work-done feedback, respawn notices) could land in that gap, causing the daemon's CR to submit a fused canonical line while the user's CR arrived on an already-empty box — silently swallowing the submission.
+
+The fix routes all `write_to_pane` calls through a new `WriteAndSubmit` daemon RPC that holds the per-agent writer mutex across the full payload + submit delay + CR sequence — the same atomic contract established in PRD #93 round-8 for orchestration dispatch writes. No separate PRD #93 carry-forward is needed; this PR reuses that contract and extends it to every client-initiated pane write.
+
+The fix is not orchestrator-only: every `PaneController::write_to_pane` caller (send-prompt dialog, spawn-time init commands, start-pane prompt, permission y/n forwarding, mode-manager init/command writes, renew-after-respawn) now goes through the same atomic RPC. The orchestrator pane was the only pane that exhibited the symptom because it is the only pane simultaneously receiving daemon-initiated writes and originating user prompts.
+
+`PROTOCOL_VERSION` is bumped from 2 to 3; mismatched daemon/client pairs produce a clear `ProtocolMismatch` error at connection time.

--- a/prds/100-fix-orchestrator-enter-key-newline.md
+++ b/prds/100-fix-orchestrator-enter-key-newline.md
@@ -56,6 +56,26 @@ These are hypotheses, not conclusions. Investigation in Phase 1 nails down which
 - `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass. `cargo test` passes.
 - Manual smoke: a long-form orchestrator prompt sent through the daemon submits on first Enter, 10 consecutive times.
 
+## Root cause
+
+Phase 1 ruled out the three leading hypotheses in their original framing and surfaced a fourth, which the evidence and the regression test in `tests/client_write_to_pane_atomic.rs` confirm. Summary:
+
+- **PRD #93 Phase 2 collapsed the local/daemon split.** The in-process pane backend was deleted; every pane is now a `StreamBackend` routed through the daemon's attach socket (`src/embedded_pane.rs:74-78`). M1.3 ("does the bug exist on the local path?") is therefore moot — there is no longer a separate local path to compare against.
+- **Two write surfaces remain, both daemon-mediated.** (a) Client-initiated via `EmbeddedPaneController::write_to_pane` (`src/embedded_pane.rs:1754` pre-fix) → STREAM_IN frames → daemon's `handle_attach_stream` input loop (`src/daemon_protocol.rs:1148`) → per-agent PTY writer. (b) Daemon-initiated (orchestration dispatch) via `AgentPtyRegistry::write_to_pane_and_submit` (`src/agent_pty.rs:1466`) → directly into the per-agent PTY writer.
+- **The daemon-initiated path is atomic; the client-initiated path was not.** PRD #93 round-8 made `write_to_pane_and_submit` hold the per-agent writer mutex across the full payload + `SUBMIT_DELAY` + CR sequence (`src/agent_pty.rs:1455-1465`). The client-initiated path queued *two* STREAM_IN frames separated by a 150 ms `std::thread::sleep` (the pre-fix `src/embedded_pane.rs:1771-1773`), and the daemon's input loop took the writer mutex briefly per frame. So during the 150 ms gap the writer mutex was **free** on the daemon side.
+- **A concurrent daemon-initiated write landed in that gap.** If a `write_to_pane_and_submit` (work-done feedback) or `write_to_pane_notice` (respawn notice) fired against the orchestrator pane while the user's send-prompt was mid-flight, the byte order written to the PTY master was `[user payload][daemon payload][daemon \r][user \r]`. After ICRNL and canonical line buffering the slave received one fused line; the daemon's CR submitted the combined `user-prompt + daemon-bytes` to the receiving agent, and the user's trailing CR was a no-op on an empty input box. To the user this manifested as "Enter inserted a newline into the orchestrator's input instead of submitting" — the PRD #100 symptom.
+- **The orchestrator pane is uniquely affected** because it is the only pane that simultaneously *receives* daemon-initiated writes (work-done feedback, respawn notices) and *originates* user prompts. Other role panes only receive daemon writes; the dashboard's pure-user-input panes only originate writes. Neither shape produces concurrent same-pane writers.
+
+The regression test toggle in Phase 2 confirmed the byte surface: with the pre-fix `write_to_pane` body, the scrollback shows `USERMSG-PAYLOADBGWRITER-MSG\r\n` (one fused canonical line); with the post-fix RPC body, two distinct `USERMSG-PAYLOAD\r\n` and `BGWRITER-MSG\r\n` lines surface. The fused line is exactly the bug shape the user observes in production.
+
+## Fix scope
+
+The fix routes all client-initiated send-prompt writes through a new `WriteAndSubmit` daemon RPC (`AttachRequest::WriteAndSubmit { pane_id, text }` in `src/daemon_protocol.rs`). On the daemon side the RPC handler calls `AgentPtyRegistry::write_to_pane_and_submit`, which holds the per-agent writer mutex across the entire payload + `SUBMIT_DELAY` + CR sequence — the same atomic contract orchestration dispatch already had since PRD #93 round-8.
+
+This is **not** orchestrator-only. Every caller of `PaneController::write_to_pane` now benefits — the deck's send-prompt dialog (`src/ui.rs:1603`), the spawn-time init-command writes (`src/ui.rs:3264-3267`, `5070-5076`), the start-pane prompt (`src/ui.rs:3703`), the permission y/n forwarding (`src/ui.rs:4750`), the mode-manager init/command writes (`src/mode_manager.rs:308-322`), and the renew-after-respawn path (`src/mode_manager.rs:421-422`) all go through the same atomic RPC. The orchestrator-only symptom in the PRD was an *observation*, not a constraint — it surfaced there because the orchestrator pane is the only pane with concurrent daemon-initiated writes.
+
+`PROTOCOL_VERSION` bumped from 2 to 3 (`src/daemon_protocol.rs:146`). The version handshake in `src/connect.rs` already rejects mismatched daemons with a clear error, so the upgrade boundary is honest.
+
 ## Milestones
 
 ### Phase 1: Investigation and reproducer

--- a/prds/100-fix-orchestrator-enter-key-newline.md
+++ b/prds/100-fix-orchestrator-enter-key-newline.md
@@ -80,19 +80,19 @@ This is **not** orchestrator-only. Every caller of `PaneController::write_to_pan
 
 ### Phase 1: Investigation and reproducer
 
-- [ ] **M1.1** — Instrument the daemon's pane-write path to log every byte sent to a pane, with a feature flag or `RUST_LOG=trace` gate so the instrumentation can stay in tree. Confirm whether bracketed-paste sequences (`\e[200~ ... \e[201~`) are present and whether the trailing byte is `\n` (10), `\r` (13), or both.
-- [ ] **M1.2** — Build a deterministic reproducer. Try the obvious axes first: very long messages, messages with embedded newlines, rapid back-to-back sends, sends immediately after the orchestrator pane mounts, sends while another role pane is animating. Document what triggers the bug.
-- [ ] **M1.3** — Determine whether the bug exists in the local (in-process) path or only the daemon path. This is one data point that helps localize the cause and informs PRD #93's regression surface.
+- [x] **M1.1** — Instrument the daemon's pane-write path to log every byte sent to a pane, with a feature flag or `RUST_LOG=trace` gate so the instrumentation can stay in tree. Confirm whether bracketed-paste sequences (`\e[200~ ... \e[201~`) are present and whether the trailing byte is `\n` (10), `\r` (13), or both.
+- [x] **M1.2** — Build a deterministic reproducer. Try the obvious axes first: very long messages, messages with embedded newlines, rapid back-to-back sends, sends immediately after the orchestrator pane mounts, sends while another role pane is animating. Document what triggers the bug.
+- [x] **M1.3** — Determine whether the bug exists in the local (in-process) path or only the daemon path. This is one data point that helps localize the cause and informs PRD #93's regression surface. *(N/A — PRD #93 Phase 2 deleted the local pane backend; all writes are daemon-mediated. Documented in Root cause.)*
 
 ### Phase 2: Root cause and fix
 
-- [ ] **M2.1** — Document the root cause in this PRD (add a "Root cause" section). Cite the evidence from M1.
-- [ ] **M2.2** — Implement the fix at the smallest layer that resolves it. Likely one of: daemon write path normalization, orchestrator UI input-mode guard, or removing bracketed-paste framing on the send-prompt path.
-- [ ] **M2.3** — Decide and document the fix's scope: orchestrator-only, all-agents, or a layer that incidentally fixes both.
+- [x] **M2.1** — Document the root cause in this PRD (add a "Root cause" section). Cite the evidence from M1.
+- [x] **M2.2** — Implement the fix at the smallest layer that resolves it. Likely one of: daemon write path normalization, orchestrator UI input-mode guard, or removing bracketed-paste framing on the send-prompt path.
+- [x] **M2.3** — Decide and document the fix's scope: orchestrator-only, all-agents, or a layer that incidentally fixes both.
 
 ### Phase 3: Tests and validation
 
-- [ ] **M3.1** — Add an automated regression test that exercises the daemon write path and asserts the submit actually fires (i.e. the orchestrator processed the message, not just that bytes were written). Test must fail before the fix.
+- [x] **M3.1** — Add an automated regression test that exercises the daemon write path and asserts the submit actually fires (i.e. the orchestrator processed the message, not just that bytes were written). Test must fail before the fix.
 - [ ] **M3.2** — Run the M1.2 reproducer 100 consecutive times against the fixed build; confirm zero failures.
 - [ ] **M3.3** — Verify no regression for other agents (Claude Code, OpenCode) — run the existing send-prompt tests and a manual smoke through each agent type.
 

--- a/prds/done/100-fix-orchestrator-enter-key-newline.md
+++ b/prds/done/100-fix-orchestrator-enter-key-newline.md
@@ -1,6 +1,6 @@
 # PRD #100: Fix Enter-Key Intermittently Inserting Newline Instead of Submitting to Orchestrator
 
-**Status**: Planning
+**Status**: Complete (2026-05-25)
 **Priority**: High
 **Created**: 2026-05-21
 **GitHub Issue**: [#100](https://github.com/vfarcic/dot-agent-deck/issues/100)
@@ -98,9 +98,9 @@ This is **not** orchestrator-only. Every caller of `PaneController::write_to_pan
 
 ### Phase 4: Docs and release
 
-- [ ] **M4.1** — Changelog fragment via `dot-ai-changelog-fragment`. Frame as a bug fix — "fix Enter sometimes inserting newline instead of submitting in the orchestrator pane".
-- [ ] **M4.2** — Note in the PRD #93 dependency graph if any of this work should be folded into the unification, or if the fix lands on both paths cleanly.
-- [ ] **M4.3** — PR, review, audit, merge, close.
+- [x] **M4.1** — Changelog fragment via `dot-ai-changelog-fragment`. Frame as a bug fix — "fix Enter sometimes inserting newline instead of submitting in the orchestrator pane".
+- [x] **M4.2** — PRD #93 carry-forward: no separate action needed. This fix reuses PRD #93 round-8's per-agent-writer-mutex-held-across-CR atomic contract (`write_to_pane_and_submit`). The new `WriteAndSubmit` RPC extends the same contract to client-initiated writes. Both paths now serialise through the same per-agent writer mutex, so the PRD #93 unification does not need to re-introduce atomicity — it already has it.
+- [x] **M4.3** — PR created (pending manual smoke: M3.2 100-run validation and M3.3 Claude Code / OpenCode regression smoke before merge and issue close).
 
 ## Key Files (preliminary — confirm during M1)
 

--- a/src/agent_pty.rs
+++ b/src/agent_pty.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 use tokio::sync::{Mutex as AsyncMutex, Notify, broadcast};
 
 use crate::event::AgentType;
-use crate::pane_input::{PaneInputError, SUBMIT_DELAY, encode_pane_payload};
+use crate::pane_input::{PaneInputError, SUBMIT_DELAY, encode_pane_payload, escape_bytes_for_log};
 
 /// Trigger flag the deck client honors to mean "the daemon is already
 /// running; attach over its stream socket instead of spawning one." The
@@ -346,6 +346,16 @@ pub enum AgentPtyError {
     /// wrapper and leak the tail as raw keystrokes inside the agent TUI.
     #[error("Invalid pane payload: {0}")]
     InvalidPayload(#[from] PaneInputError),
+    /// PRD #100 audit #2: a caller-supplied `text` to the `WriteAndSubmit`
+    /// RPC exceeded the configured per-call cap. The wire-level frame cap
+    /// (`MAX_FRAME_LEN` in `daemon_protocol.rs`) is 16 MiB — enough room
+    /// for an accidental TUI bug to flood the writer mutex with a
+    /// multi-megabyte payload that wedges the pane for seconds. The
+    /// per-call cap (default `WRITE_AND_SUBMIT_MAX_TEXT` = 1 MiB) catches
+    /// those well before they hit the PTY. Surfaces to the caller via
+    /// `AttachResponse::err` → `ClientError::Server` → `PaneError::CommandFailed`.
+    #[error("Pane payload too large: {len} bytes (cap {cap})")]
+    PayloadTooLarge { len: usize, cap: usize },
     /// A spawn carried a `DOT_AGENT_DECK_PANE_ID` env value that already
     /// names another live agent in this registry. The `write_to_pane_*`
     /// entrypoints key off `pane_id_env`, so accepting a second agent with the same id
@@ -1093,6 +1103,7 @@ struct RegistryInner {
 /// private because the public API exposes the two named methods
 /// directly — see [`AgentPtyRegistry::write_to_pane_and_submit`] and
 /// [`AgentPtyRegistry::write_to_pane_notice`].
+#[derive(Debug)]
 enum SubmitMode {
     Submit,
     Notice,
@@ -1534,12 +1545,57 @@ impl AgentPtyRegistry {
         use std::io::Write as _;
         let payload = encode_pane_payload(text)?;
         let mut w = writer.lock().await;
+        // PRD #100 M1.1: byte-level trace of every daemon-initiated PTY
+        // write. Gated by `RUST_LOG=trace` (or
+        // `dot_agent_deck::agent_pty=trace`). Logs both the payload and
+        // the trailing submit byte separately so an operator can see
+        // whether bracketed-paste framing (`\x1b[200~...\x1b[201~`) is
+        // present and whether the terminator is `\r` (13), `\n` (10),
+        // or absent. Mirrors the trace in
+        // `EmbeddedPaneController::write_to_pane` so the client-initiated
+        // path and the daemon-initiated path are distinguishable but
+        // share the same byte-escape format.
+        //
+        // PRD #100 reviewer #8: emitted INSIDE the writer mutex
+        // critical section so trace-log order matches actual write
+        // order. Emitting before `writer.lock().await` would let two
+        // concurrent writers log their payloads in one order and
+        // write them in the opposite order — a misleading footgun
+        // for anyone debugging a race from the log alone.
+        //
+        // PRD #100 audit #5: **PII WARNING.** `payload` is the user's
+        // prompt body (or orchestration feedback text) byte-for-byte.
+        // For interactive panes that includes anything the user
+        // pastes into the orchestrator — credentials, API tokens,
+        // PII. Trace-level gating + the `pane_write` target keep
+        // this off in production (default log level is info), but an
+        // operator running `RUST_LOG=trace dot-agent-deck` (or
+        // `RUST_LOG=pane_write=trace`) with `DOT_AGENT_DECK_LOG=/path`
+        // captures user prompt content verbatim to disk. To suppress
+        // selectively while keeping other trace output:
+        // `RUST_LOG=trace,pane_write=warn`.
+        tracing::trace!(
+            target: "pane_write",
+            source = "daemon",
+            mode = ?mode,
+            pane_id = %pane_id,
+            payload_len = payload.len(),
+            payload = %escape_bytes_for_log(&payload),
+            "daemon write_to_pane: payload bytes"
+        );
         w.write_all(&payload)
             .map_err(|e| AgentPtyError::Writer(e.to_string()))?;
         let _ = w.flush();
         match mode {
             SubmitMode::Submit => {
                 tokio::time::sleep(SUBMIT_DELAY).await;
+                tracing::trace!(
+                    target: "pane_write",
+                    source = "daemon",
+                    pane_id = %pane_id,
+                    terminator = %escape_bytes_for_log(b"\r"),
+                    "daemon write_to_pane: submit terminator"
+                );
                 w.write_all(b"\r")
                     .map_err(|e| AgentPtyError::Writer(e.to_string()))?;
                 let _ = w.flush();
@@ -1552,6 +1608,13 @@ impl AgentPtyRegistry {
                 // `encode_pane_payload` strips trailing whitespace so a
                 // caller-provided `\n` would have been swallowed; the
                 // single byte is written here unambiguously.
+                tracing::trace!(
+                    target: "pane_write",
+                    source = "daemon",
+                    pane_id = %pane_id,
+                    terminator = %escape_bytes_for_log(b"\n"),
+                    "daemon write_to_pane: notice terminator"
+                );
                 w.write_all(b"\n")
                     .map_err(|e| AgentPtyError::Writer(e.to_string()))?;
                 let _ = w.flush();

--- a/src/daemon_client.rs
+++ b/src/daemon_client.rs
@@ -337,6 +337,42 @@ impl DaemonClient {
         Ok(())
     }
 
+    /// PRD #100 M2.2: atomic "write payload + submit CR" against a
+    /// pane addressed by its `DOT_AGENT_DECK_PANE_ID`. The daemon
+    /// holds the per-agent writer mutex across the full payload +
+    /// SUBMIT_DELAY + CR sequence, so no other writer (orchestration
+    /// dispatch, work-done feedback, respawn notice) can interleave
+    /// bytes between the user's payload and the user's CR.
+    ///
+    /// Replaces the deck's older two-STREAM_IN-frames send-prompt path
+    /// (payload, then `\r` after a 150 ms client-side sleep), which
+    /// released the writer mutex between the two frames and let a
+    /// daemon-initiated write land in the gap — the PRD #100 symptom.
+    pub async fn write_to_pane_and_submit(
+        &self,
+        pane_id: &str,
+        text: &str,
+    ) -> Result<(), ClientError> {
+        let stream = self.connect().await?;
+        let (mut rd, mut wr) = stream.into_split();
+        let resp = issue_command(
+            &mut rd,
+            &mut wr,
+            &AttachRequest::WriteAndSubmit {
+                pane_id: pane_id.to_string(),
+                text: text.to_string(),
+            },
+        )
+        .await?;
+        if !resp.ok {
+            return Err(ClientError::Server(
+                resp.error
+                    .unwrap_or_else(|| "write-and-submit failed".into()),
+            ));
+        }
+        Ok(())
+    }
+
     /// PRD #76 M2.17: open a long-lived `SubscribeEvents` connection.
     /// Returns once the daemon has confirmed the subscription with a
     /// successful RESP — subsequent frames on the wire are `KIND_EVENT`

--- a/src/daemon_protocol.rs
+++ b/src/daemon_protocol.rs
@@ -90,6 +90,7 @@ pub use crate::agent_pty::TabMembership;
 use crate::agent_pty::{AgentPtyRegistry, AgentRecord, SpawnOptions};
 use crate::agent_pty::{DOT_AGENT_DECK_PANE_ID, is_valid_pane_id_env};
 use crate::event::{AgentType, BroadcastMsg};
+use crate::pane_input::escape_bytes_for_log;
 use crate::state::SharedState;
 
 // ---------------------------------------------------------------------------
@@ -142,12 +143,24 @@ pub const KIND_SHUTDOWN_ACK: u8 = 0x16;
 /// Additive `#[serde(default, skip_serializing_if = "Option::is_none")]`
 /// fields do NOT require a bump — they're forward-compatible by design. See
 /// the module-level "Protocol versioning" section for the full bump policy.
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// Hard cap on a single frame's payload length. Defends against a malicious
 /// or buggy peer trying to allocate gigabytes off a forged length prefix.
 /// 16 MiB is well above any reasonable PTY chunk or scrollback snapshot.
 const MAX_FRAME_LEN: usize = 16 * 1024 * 1024;
+
+/// PRD #100 audit #2: per-call cap on the `text` field of
+/// [`AttachRequest::WriteAndSubmit`]. Sized at 1 MiB — large enough to
+/// accommodate the longest realistic user prompt or pasted document
+/// (a 1 MiB plain-text file is roughly 200k words / 600 pages of
+/// novel-length prose) while small enough that an accidental TUI bug
+/// or hostile same-UID caller can't park the per-agent writer mutex
+/// for seconds at a time. Smaller than `MAX_FRAME_LEN` (16 MiB) so
+/// callers see a typed
+/// [`crate::agent_pty::AgentPtyError::PayloadTooLarge`] before the
+/// wire framing rejects the request.
+pub const WRITE_AND_SUBMIT_MAX_TEXT: usize = 1024 * 1024;
 
 /// Bounded timeout for a single STREAM_OUT/STREAM_END write to a client. If
 /// a client stops draining its socket, the OS send buffer fills and our
@@ -338,6 +351,45 @@ pub enum AttachRequest {
         client_version: u32,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         client_build_version: Option<String>,
+    },
+    /// PRD #100 M2.2: atomic "write payload then submit CR" against a
+    /// pane addressed by its `DOT_AGENT_DECK_PANE_ID`. The daemon
+    /// runs the full sequence under the per-agent writer mutex — the
+    /// same atomic contract `AgentPtyRegistry::write_to_pane_and_submit`
+    /// already gives orchestration dispatch — so a concurrent
+    /// daemon-initiated write (work-done feedback, respawn notice)
+    /// cannot interleave between the user's payload and the user's
+    /// submit CR. Without this RPC the TUI's send-prompt path queued
+    /// two STREAM_IN frames separated by a 150 ms client-side sleep,
+    /// during which the writer mutex was free and another writer
+    /// could land its own payload + LF/CR between the user's bytes
+    /// — manifesting at the receiving agent as "Enter inserted a
+    /// newline instead of submitting" (PRD #100 symptom).
+    ///
+    /// `pane_id` is the agent's `DOT_AGENT_DECK_PANE_ID` env value,
+    /// not the daemon-side registry id — same convention as the
+    /// daemon-initiated write path. The daemon resolves it to the
+    /// agent's writer mutex internally.
+    ///
+    /// **Trust model.** Same-UID owns the registry — identical
+    /// addressing scope to the internal orchestration-dispatch path
+    /// in `AgentPtyRegistry::write_to_pane_and_submit`. NOT bound to
+    /// a per-connection attach the way [`AttachRequest::AttachStream`]
+    /// plus STREAM_IN bytes are: a single connected client can
+    /// target any live `pane_id` per call. Authorization is
+    /// unchanged (still 0o600 socket plus same-UID = full daemon
+    /// access); if that boundary ever tightens (multi-user daemon,
+    /// broker), this RPC needs a per-pane caller→agent binding,
+    /// whereas STREAM_IN already has it.
+    ///
+    /// `text` is capped at [`WRITE_AND_SUBMIT_MAX_TEXT`] (1 MiB) per
+    /// call so a buggy or hostile same-UID caller can't park the
+    /// per-agent writer mutex for seconds at a time on a
+    /// multi-megabyte payload. Oversize requests surface as
+    /// `AgentPtyError::PayloadTooLarge` → `ClientError::Server`.
+    WriteAndSubmit {
+        pane_id: String,
+        text: String,
     },
 }
 
@@ -927,6 +979,68 @@ async fn handle_connection(
             Ok(()) => write_resp(&mut stream, &AttachResponse::ok()).await?,
             Err(e) => write_resp(&mut stream, &AttachResponse::err(e.to_string())).await?,
         },
+        AttachRequest::WriteAndSubmit { pane_id, text } => {
+            // PRD #100 M2.2: atomic payload + submit CR under the
+            // per-agent writer mutex. The receiving side is the same
+            // `write_to_pane_and_submit` orchestration dispatch uses;
+            // calling it here gives client-initiated writes the same
+            // "no other writer can interleave between payload and CR"
+            // contract.
+            //
+            // PRD #100 audit #4: pre-validate `pane_id` so a malformed
+            // env value fails fast with a typed error instead of
+            // dropping into the `HashMap::values().find(...)` lookup —
+            // mirrors the existing validation at spawn/hydrate time
+            // (`is_valid_pane_id_env`).
+            if !is_valid_pane_id_env(&pane_id) {
+                let resp = AttachResponse::err(format!(
+                    "write-and-submit: invalid pane_id (must match \
+                     the env-var grammar): {pane_id:?}"
+                ));
+                write_resp(&mut stream, &resp).await?;
+                return Ok(());
+            }
+            // PRD #100 audit #2: cap `text` at
+            // [`WRITE_AND_SUBMIT_MAX_TEXT`] bytes BEFORE acquiring
+            // any registry lock. The wire-level `MAX_FRAME_LEN` cap
+            // (16 MiB) leaves room for an accidental TUI bug to
+            // flood the writer mutex with a multi-megabyte payload
+            // that wedges the pane for seconds while
+            // `encode_pane_payload` allocates and the writer drains;
+            // this cap catches those well before they hit the PTY.
+            if text.len() > WRITE_AND_SUBMIT_MAX_TEXT {
+                let err = crate::agent_pty::AgentPtyError::PayloadTooLarge {
+                    len: text.len(),
+                    cap: WRITE_AND_SUBMIT_MAX_TEXT,
+                };
+                tracing::warn!(
+                    pane_id = %pane_id,
+                    error = %err,
+                    "write-and-submit: rejecting oversize text"
+                );
+                write_resp(&mut stream, &AttachResponse::err(err.to_string())).await?;
+                return Ok(());
+            }
+            match registry.write_to_pane_and_submit(&pane_id, &text).await {
+                Ok(()) => write_resp(&mut stream, &AttachResponse::ok()).await?,
+                Err(e) => {
+                    // PRD #100 audit nit: surface failures so an
+                    // operator tailing daemon logs can correlate a
+                    // failed RPC with the cause (NotFound, encode
+                    // rejection, writer I/O error). Existing
+                    // StopAgent / SetAgentLabel handlers also don't
+                    // log on Err, but this RPC is on the hot
+                    // user-prompt path — a silent failure here is a
+                    // dropped user prompt.
+                    tracing::warn!(
+                        pane_id = %pane_id,
+                        error = %e,
+                        "write-and-submit: failed to write to pane"
+                    );
+                    write_resp(&mut stream, &AttachResponse::err(e.to_string())).await?
+                }
+            }
+        }
         AttachRequest::SubscribeEvents => {
             handle_subscribe_events(stream, event_tx).await?;
         }
@@ -1148,6 +1262,36 @@ async fn handle_attach_stream(
             Ok(Some((KIND_STREAM_IN, bytes))) => {
                 use std::io::Write;
                 let mut w = writer.lock().await;
+                // PRD #100 M1.1: byte-level trace of STREAM_IN frames
+                // forwarded to the per-agent PTY writer. This is the
+                // daemon-side counterpart to the client-side trace in
+                // `EmbeddedPaneController::write_to_pane`. Useful for
+                // confirming that the bytes the TUI queued (payload, then
+                // `\r`) arrived as two distinct frames and that no other
+                // path interleaved a write on the same writer mutex
+                // between them. Gated by `RUST_LOG=trace` (or
+                // `dot_agent_deck::daemon_protocol=trace`). Emitted
+                // INSIDE the writer mutex (PRD #100 reviewer #8) so
+                // trace order matches actual write order.
+                //
+                // PRD #100 audit #5: **PII WARNING.** STREAM_IN bytes
+                // are user keystrokes — including anything pasted
+                // into the pane and the user's typed prompts. Trace
+                // gating + the `pane_write` target keep this off in
+                // production; an operator running
+                // `RUST_LOG=trace dot-agent-deck` (or
+                // `RUST_LOG=pane_write=trace`) with `DOT_AGENT_DECK_LOG`
+                // pointed at a file captures user input verbatim to
+                // disk. To suppress selectively while keeping other
+                // trace output: `RUST_LOG=trace,pane_write=warn`.
+                tracing::trace!(
+                    target: "pane_write",
+                    source = "stream_in",
+                    agent_id = %id,
+                    payload_len = bytes.len(),
+                    payload = %escape_bytes_for_log(&bytes),
+                    "STREAM_IN forwarded to PTY writer"
+                );
                 if w.write_all(&bytes).is_err() {
                     break;
                 }

--- a/src/embedded_pane.rs
+++ b/src/embedded_pane.rs
@@ -171,7 +171,16 @@ struct Pane {
 /// Thread-safe pane registry.
 type PaneRegistry = Arc<Mutex<HashMap<String, Pane>>>;
 
-use crate::pane_input::{SUBMIT_DELAY, encode_pane_payload};
+// Send-prompt encoding (`encode_pane_payload`, `SUBMIT_DELAY`) lives
+// entirely on the daemon side now — the TUI hands raw `text` to the
+// `WriteAndSubmit` RPC and the daemon does the framing under the
+// per-agent writer mutex (PRD #100 M2.2). `escape_bytes_for_log` is
+// still imported because the TUI-side trace logs the raw text with
+// the same byte-escape format the daemon-side trace uses (PRD #100
+// reviewer trace-symmetry alignment).
+// See `crate::daemon_protocol::AttachRequest::WriteAndSubmit` and
+// `crate::agent_pty::AgentPtyRegistry::write_to_pane_and_submit`.
+use crate::pane_input::escape_bytes_for_log;
 
 /// Embedded terminal pane controller. Spawns agents on the daemon at
 /// [`Self::client`]'s socket path and renders their PTY output through a
@@ -366,23 +375,6 @@ impl EmbeddedPaneController {
         let current = *id;
         *id += 1;
         current.to_string()
-    }
-
-    /// Enqueue `payload` for the pane's I/O task to forward as one
-    /// `KIND_STREAM_IN` frame. Held under the `panes` mutex only long
-    /// enough to look up the sender — the actual write happens on the
-    /// I/O task. A closed channel means the I/O task has already exited
-    /// (e.g. socket close); surface that as `CommandFailed` so callers
-    /// can decide whether to retry.
-    fn queue_stream_input(&self, pane_id: &str, payload: Vec<u8>) -> Result<(), PaneError> {
-        let panes = self.panes.lock().unwrap();
-        let pane = panes
-            .get(pane_id)
-            .ok_or_else(|| PaneError::CommandFailed(format!("Pane {pane_id} not found")))?;
-        pane.backend
-            .input_tx
-            .send(StreamCmd::Input(payload))
-            .map_err(|_| PaneError::CommandFailed(format!("Pane {pane_id} stream I/O task ended")))
     }
 
     /// Build a stream-backed pane against the daemon. The PTY lives in
@@ -1740,38 +1732,103 @@ impl PaneController for EmbeddedPaneController {
         Ok(())
     }
 
-    /// Concurrency contract: callers must not invoke `write_to_pane` concurrently
-    /// for the same `pane_id`. The pane lock is released around `SUBMIT_DELAY` so
-    /// other panes can be drawn — but interleaved writes for the *same* pane would
-    /// produce `payload_A + payload_B + CR + CR`, fusing two prompts. The current
-    /// architecture is single-threaded for pane I/O, so this is a latent constraint
-    /// rather than an active hazard; a per-pane submit mutex would enforce it if
-    /// concurrent callers are ever introduced.
+    /// PRD #100 M2.2: the send-prompt path now issues a single
+    /// `WriteAndSubmit` RPC instead of queuing two STREAM_IN frames
+    /// (payload, then `\r` after a 150 ms client-side sleep). The
+    /// daemon's [`crate::agent_pty::AgentPtyRegistry::write_to_pane_and_submit`]
+    /// holds the per-agent writer mutex across the full payload +
+    /// `SUBMIT_DELAY` + CR sequence — the same atomic contract
+    /// orchestration dispatch already had (PRD #93 round-8). No other
+    /// writer (orchestration delegate, work-done feedback, respawn
+    /// notice) can interleave bytes between the user's payload and
+    /// the user's CR, which closed the PRD #100 bug surface.
     ///
-    /// PRD #93 round-8: an embedded bracketed-paste marker in a multi-line
-    /// `text` causes [`encode_pane_payload`] to return Err — log at warn
-    /// and drop the write, same handling as a missing pane below.
+    /// The old two-frame approach had a 150 ms window during which the
+    /// writer mutex was released; a daemon-initiated write landing in
+    /// the gap produced byte streams like
+    /// `[user payload][daemon notice][\n][user \r]`, which the
+    /// receiving agent rendered as "Enter inserted a newline instead
+    /// of submitting".
+    ///
+    /// Concurrency: the daemon's per-agent writer mutex serializes
+    /// concurrent callers for the same pane, so the historical
+    /// single-threaded-pane-I/O constraint is no longer required to
+    /// avoid `payload_A + payload_B + CR + CR` fusion.
+    ///
+    /// **Runtime requirement.** This impl drives the RPC via
+    /// `self.runtime.block_on(...)`. `Handle::block_on` on a
+    /// `current_thread` runtime would deadlock the single worker, so
+    /// the TUI must run on a multi-thread runtime. In production this
+    /// is guaranteed by `#[tokio::main]` in `src/main.rs` (which
+    /// defaults to multi-thread) plus the TUI loop running inside
+    /// `tokio::task::spawn_blocking`. A future refactor that moves
+    /// the TUI onto a `flavor = "current_thread"` runtime would have
+    /// to either keep this RPC on the runtime side or use
+    /// `tokio::task::block_in_place` — both `write_to_pane` and the
+    /// existing `block_on` sites in `create_pane` / `close_pane` /
+    /// `hydrate_from_daemon` share this constraint.
+    ///
+    /// **Error semantics — behavior change from pre-fix path
+    /// (PRD #100 audit #3, reviewer MEDIUM).** The pre-fix body
+    /// converted [`crate::pane_input::PaneInputError`] (embedded
+    /// `\x1b[200~` / `\x1b[201~` in a multi-line payload) into
+    /// `tracing::warn!` + `Ok(())` — silent to the caller. The new
+    /// path runs `encode_pane_payload` daemon-side inside
+    /// `write_to_pane_and_submit`; a rejection there becomes
+    /// `AgentPtyError::InvalidPayload` → `AttachResponse::err` →
+    /// `ClientError::Server` → `PaneError::CommandFailed`. The
+    /// daemon still logs `warn` at the encode site, but this method
+    /// now also returns `Err` to the caller. Callers using
+    /// `let _ = pane.write_to_pane(...)` (the majority) see no
+    /// difference; `ui.rs:5126` (`KeyResult::SendConfigGenPrompt`)
+    /// and `ui.rs:4750` (permission y/n) match the `Result` and
+    /// will now surface
+    /// `"Failed to send config prompt: write_to_pane: WriteAndSubmit
+    /// RPC failed: …"` in the status bar where the embedded-marker
+    /// case was previously silent. This is the desired direction —
+    /// a dropped user prompt should be observable, not silent.
     fn write_to_pane(&self, pane_id: &str, text: &str) -> Result<(), PaneError> {
-        let payload = match encode_pane_payload(text) {
-            Ok(payload) => payload,
-            Err(e) => {
-                tracing::warn!(
-                    pane_id = %pane_id,
-                    error = %e,
-                    "write_to_pane: dropping write — encode_pane_payload rejected the input"
-                );
-                return Ok(());
+        // PRD #100 reviewer trace-symmetry: TUI-side trace now logs
+        // the full payload (escaped) too, matching the daemon-side
+        // trace in `agent_pty::write_to_pane_internal` and the
+        // STREAM_IN handler. The asymmetry the reviewer flagged was
+        // unintentional — operators investigating a byte-stream
+        // race want both sides at the same fidelity. Same
+        // `pane_write` target so a single RUST_LOG switch captures
+        // both. **PII WARNING** (PRD #100 audit #5): `text` is the
+        // user's prompt body byte-for-byte and may include pasted
+        // credentials. Trace gating + `pane_write` target keep this
+        // off in production (default log level is info), but
+        // `RUST_LOG=trace dot-agent-deck` (or `RUST_LOG=pane_write=trace`)
+        // with `DOT_AGENT_DECK_LOG=/path` captures user prompts to
+        // disk. Filter selectively with
+        // `RUST_LOG=trace,pane_write=warn`.
+        tracing::trace!(
+            target: "pane_write",
+            source = "tui",
+            pane_id = %pane_id,
+            payload_len = text.len(),
+            payload = %escape_bytes_for_log(text.as_bytes()),
+            "tui write_to_pane: issuing WriteAndSubmit RPC"
+        );
+        let client = self.client.clone();
+        let pane_id = pane_id.to_string();
+        let text = text.to_string();
+        self.runtime.block_on(async move {
+            match client.write_to_pane_and_submit(&pane_id, &text).await {
+                Ok(()) => Ok(()),
+                Err(e) => {
+                    tracing::warn!(
+                        pane_id = %pane_id,
+                        error = %e,
+                        "write_to_pane: daemon WriteAndSubmit RPC failed"
+                    );
+                    Err(PaneError::CommandFailed(format!(
+                        "write_to_pane: WriteAndSubmit RPC failed: {e}"
+                    )))
+                }
             }
-        };
-        // Write the payload (content, optionally bracketed-paste-wrapped), flush, then
-        // pause briefly before sending the submit CR. Agent TUIs like claude treat a
-        // CR that arrives fused to the preceding text as newline-in-input; only a CR
-        // that arrives as a separate event after a pause is honored as Enter. The
-        // pane lock is released during the sleep so the UI thread can keep drawing.
-        self.queue_stream_input(pane_id, payload)?;
-        std::thread::sleep(SUBMIT_DELAY);
-        self.queue_stream_input(pane_id, b"\r".to_vec())?;
-        Ok(())
+        })
     }
 
     fn name(&self) -> &str {

--- a/src/pane_input.rs
+++ b/src/pane_input.rs
@@ -81,6 +81,28 @@ fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
 /// close marker. 150ms tuned empirically.
 pub const SUBMIT_DELAY: std::time::Duration = std::time::Duration::from_millis(150);
 
+/// Render bytes for trace logging in a human-scannable form: printable
+/// ASCII as-is, everything else as `\xNN`. The common framing bytes
+/// (`\x1b[200~`, `\x1b[201~`, `\r`, `\n`) thus surface as
+/// `\x1b[200~`, `\r`, `\n` rather than raw control codes that
+/// terminals would interpret on rendering.
+///
+/// PRD #100 M1.1: bracketed-paste framing and `\r` vs `\n` are the two
+/// leading hypotheses for the orchestrator Enter-submit bug, so the
+/// pane-write trace must let an operator distinguish them at a glance.
+/// Gated behind `RUST_LOG=trace` (or per-target `dot_agent_deck::pane_input=trace`)
+/// — the helper itself does no logging; callers emit `tracing::trace!`.
+pub fn escape_bytes_for_log(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len());
+    for &b in bytes {
+        match b {
+            0x20..=0x7e => out.push(b as char),
+            _ => out.push_str(&format!("\\x{b:02x}")),
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -150,5 +172,23 @@ mod tests {
         let input = "hello \x1b[201~ world";
         let out = encode_pane_payload(input).unwrap();
         assert_eq!(out, input.as_bytes());
+    }
+
+    /// PRD #100 M1.1: the trace-log helper must render bracketed-paste
+    /// markers, CR, and LF unambiguously so an operator can tell at a
+    /// glance whether the daemon emitted `\x1b[200~...\x1b[201~` framing
+    /// and whether the submit terminator was `\r` (13), `\n` (10), or
+    /// both.
+    #[test]
+    fn escape_bytes_for_log_renders_paste_framing_and_terminators() {
+        let bytes = b"\x1b[200~hello\nworld\x1b[201~\r";
+        assert_eq!(
+            escape_bytes_for_log(bytes),
+            "\\x1b[200~hello\\x0aworld\\x1b[201~\\x0d"
+        );
+        assert_eq!(escape_bytes_for_log(b""), "");
+        assert_eq!(escape_bytes_for_log(b"ls -la"), "ls -la");
+        assert_eq!(escape_bytes_for_log(b"\n"), "\\x0a");
+        assert_eq!(escape_bytes_for_log(b"\r"), "\\x0d");
     }
 }

--- a/tests/client_write_to_pane_atomic.rs
+++ b/tests/client_write_to_pane_atomic.rs
@@ -1,0 +1,439 @@
+//! PRD #100 M3.1 — regression test for the client-initiated send-prompt
+//! atomicity contract.
+//!
+//! Before the fix (PRD #100 Phase 2), the TUI's
+//! `EmbeddedPaneController::write_to_pane` queued two STREAM_IN frames
+//! for the per-pane I/O task — the payload, then `\r` after a 150 ms
+//! client-side `std::thread::sleep`. The per-agent writer mutex on the
+//! daemon side was released between those two frames, so a concurrent
+//! daemon-initiated write (orchestration delegate / work-done feedback
+//! / respawn notice) could land its own payload + CR in the 150 ms gap.
+//! Master byte order in that case:
+//!   `[user payload][daemon payload][daemon \r][user \r]`
+//! After ICRNL on input and canonical line buffering, the slave saw
+//! one fused line `user-payload + daemon-payload\n` plus a trailing
+//! empty line. Cat then emitted a single combined `<fused>\r\n` on its
+//! stdout — exactly the "Enter inserted a newline" bug surface.
+//!
+//! After the fix, `EmbeddedPaneController::write_to_pane` issues a
+//! single `WriteAndSubmit` RPC. The daemon runs the full payload +
+//! `SUBMIT_DELAY` + CR sequence under the per-agent writer mutex —
+//! the same atomic contract orchestration dispatch already had (PRD
+//! #93 round-8). Concurrent daemon-initiated writes block on the
+//! same mutex; the slave receives each canonical line cleanly and
+//! cat emits two distinct `<payload>\r\n` substrings.
+//!
+//! Assertion mirrors `write_to_pane_and_submit_serializes_concurrent_writes_per_pane`
+//! in `tests/orchestration_delegate.rs`: each payload's `\r\n`-suffixed
+//! form must appear in the scrollback as a contiguous substring. A
+//! fused write at the PTY-master level would collapse both payloads
+//! into one canonical line and neither `<payload>\r\n` would
+//! individually appear. The PTY's local echo can still interleave
+//! payload bytes on the master independently of cat's stdout writes;
+//! anchoring on cat's `<payload>\r\n` writes is the only assertion
+//! that's robust to that master-side rendering race.
+//!
+//! Verified by toggling: temporarily restoring the old
+//! `EmbeddedPaneController::write_to_pane` body (queue STREAM_IN
+//! payload, `std::thread::sleep(SUBMIT_DELAY)`, queue STREAM_IN `\r`)
+//! makes this test fail with `USERMSG-PAYLOAD\r\n missing from
+//! scrollback`. Restoring the RPC path makes it pass.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use tokio::task::JoinHandle;
+
+use dot_agent_deck::agent_pty::{
+    AgentPtyRegistry, DOT_AGENT_DECK_PANE_ID, TabMembership, is_valid_pane_id_env,
+};
+use dot_agent_deck::daemon_client::{DaemonClient, StartAgentOptions};
+use dot_agent_deck::daemon_protocol::{bind_attach_listener, serve_attach};
+use dot_agent_deck::embedded_pane::EmbeddedPaneController;
+use dot_agent_deck::pane::PaneController;
+
+static HARNESS_BIND_LOCK: Mutex<()> = Mutex::new(());
+
+struct Server {
+    _dir: TempDir,
+    path: PathBuf,
+    registry: Arc<AgentPtyRegistry>,
+    handle: JoinHandle<()>,
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        self.handle.abort();
+        self.registry.shutdown_all();
+    }
+}
+
+async fn start_server() -> Server {
+    let registry = Arc::new(AgentPtyRegistry::new());
+
+    let (dir, path, listener) = {
+        let _g = HARNESS_BIND_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("attach.sock");
+        let listener = bind_attach_listener(&path).expect("bind attach listener");
+        (dir, path, listener)
+    };
+
+    let registry_for_task = registry.clone();
+    let (event_tx, _) = tokio::sync::broadcast::channel(16);
+    let handle = tokio::spawn(async move {
+        let _ = serve_attach(listener, registry_for_task, event_tx).await;
+    });
+
+    Server {
+        _dir: dir,
+        path,
+        registry,
+        handle,
+    }
+}
+
+async fn start_cat_pane(server: &Server, pane_id: &str) -> String {
+    assert!(is_valid_pane_id_env(pane_id));
+    let client = DaemonClient::new(server.path.clone());
+    let cwd = std::env::temp_dir().to_string_lossy().into_owned();
+    client
+        .start_agent(StartAgentOptions {
+            command: Some("cat -u".to_string()),
+            cwd: Some(cwd),
+            display_name: Some(pane_id.to_string()),
+            rows: 24,
+            cols: 80,
+            env: vec![(DOT_AGENT_DECK_PANE_ID.to_string(), pane_id.to_string())],
+            tab_membership: Some(TabMembership::Orchestration {
+                name: "atomic".to_string(),
+                role_index: 0,
+                role_name: pane_id.to_string(),
+                is_start_role: false,
+                orchestration_cwd: None,
+            }),
+            agent_type: None,
+        })
+        .await
+        .expect("start_agent")
+}
+
+async fn wait_for_in_snapshot(
+    registry: &AgentPtyRegistry,
+    agent_id: &str,
+    needle: &[u8],
+    timeout: Duration,
+) -> Option<Vec<u8>> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(snap) = registry.snapshot(agent_id)
+            && snap.windows(needle.len()).any(|w| w == needle)
+        {
+            return Some(snap);
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    None
+}
+
+/// Race `EmbeddedPaneController::write_to_pane` (the user-facing
+/// send-prompt path) against a concurrent `AgentPtyRegistry::write_to_pane_and_submit`
+/// scheduled to land in the user write's 150 ms `SUBMIT_DELAY` window.
+/// With the pre-fix controller (two STREAM_IN frames + client-side
+/// sleep) the daemon-initiated write lands between the user's payload
+/// and CR; the slave sees one fused canonical line and cat emits a
+/// single combined `<fused>\r\n`. With the post-fix controller
+/// (single `WriteAndSubmit` RPC routed through the same per-agent
+/// writer mutex orchestration dispatch uses) the user's payload+CR is
+/// atomic; the daemon-initiated write waits its turn and cat emits
+/// two distinct `<payload>\r\n` substrings.
+///
+/// Multi-thread runtime: the controller's `write_to_pane` is sync and
+/// uses `runtime.block_on(...)` to drive the `WriteAndSubmit` RPC. On
+/// a current-thread runtime that `block_on` would deadlock the test's
+/// only worker.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn controller_write_to_pane_is_atomic_against_concurrent_daemon_write() {
+    let server = start_server().await;
+    let agent_id = start_cat_pane(&server, "atomic-pane").await;
+
+    let ctrl = Arc::new(EmbeddedPaneController::new(
+        server.path.clone(),
+        tokio::runtime::Handle::current(),
+    ));
+
+    // Register the daemon-started agent in the controller's pane map
+    // via hydrate. Without this the pre-fix `write_to_pane` body —
+    // which looks the pane up under the registry's `panes` mutex —
+    // would error with "Pane not found" before the race could play
+    // out and the toggle-verification step would fail trivially.
+    // Hydrate reuses the agent's `pane_id_env` as the local pane id
+    // when valid (so "atomic-pane" is the same on both sides), so
+    // the test's `write_to_pane("atomic-pane", ...)` calls land on
+    // the same agent that `registry.write_to_pane_and_submit` does.
+    let ctrl_for_hydrate = ctrl.clone();
+    let hydrated = tokio::task::spawn_blocking(move || ctrl_for_hydrate.hydrate_from_daemon())
+        .await
+        .unwrap();
+    assert_eq!(
+        hydrated.len(),
+        1,
+        "expected one hydrated pane; got {hydrated:?}"
+    );
+    assert_eq!(
+        hydrated[0].pane_id, "atomic-pane",
+        "hydration should reuse the agent's pane_id_env as the local pane id"
+    );
+
+    // Order matters for reproducing the PRD #100 race against the
+    // *pre-fix* controller: the user write must reach the writer
+    // mutex FIRST so its payload lands while the mutex is briefly
+    // released; then the daemon-initiated write fires during the
+    // user's 150 ms client-side sleep gap. With the *post-fix*
+    // controller the user's call goes through a single RPC that
+    // holds the mutex across payload + sleep + CR, so the
+    // daemon-initiated write blocks on the mutex instead of
+    // interleaving.
+    let ctrl_for_user = ctrl.clone();
+    let user_task = tokio::task::spawn_blocking(move || {
+        ctrl_for_user.write_to_pane("atomic-pane", "USERMSG-PAYLOAD")
+    });
+
+    // Brief delay to nudge the daemon-initiated write into the
+    // user's `SUBMIT_DELAY` window. The pre-fix controller's
+    // STREAM_IN(payload) frame arrives ~immediately at the daemon,
+    // releases the mutex, and starts sleeping; this delay puts the
+    // daemon-initiated `write_to_pane_and_submit` squarely inside
+    // that sleep.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let registry_for_task = server.registry.clone();
+    let daemon_task = tokio::spawn(async move {
+        registry_for_task
+            .write_to_pane_and_submit("atomic-pane", "BGWRITER-MSG")
+            .await
+    });
+
+    user_task.await.unwrap().expect("controller write");
+    daemon_task.await.unwrap().unwrap();
+
+    // Atomicity invariant: cat -u outputs each canonical line as one
+    // atomic `<payload>\r\n` write. If the per-pane writer mutex
+    // serialized the two writes correctly, the slave saw two
+    // distinct canonical lines and cat emitted two distinct
+    // `<payload>\r\n` substrings. A fused master-side byte stream
+    // (PRD #100 bug surface — `user_payload + bg_payload\r`) would
+    // collapse into ONE combined canonical line, and neither
+    // `USERMSG-PAYLOAD\r\n` nor `BGWRITER-MSG\r\n` would appear on
+    // its own.
+    let user_needle: &[u8] = b"USERMSG-PAYLOAD\r\n";
+    let bg_needle: &[u8] = b"BGWRITER-MSG\r\n";
+
+    let snap = wait_for_in_snapshot(
+        &server.registry,
+        &agent_id,
+        user_needle,
+        Duration::from_secs(5),
+    )
+    .await
+    .unwrap_or_else(|| {
+        let last = server.registry.snapshot(&agent_id).unwrap_or_default();
+        panic!(
+            "PRD #100 regression: USERMSG-PAYLOAD\\r\\n missing from \
+                 scrollback — the user's payload and CR were not atomic, \
+                 so the slave fused them with BGWRITER-MSG into one \
+                 canonical line. Last snapshot: {:?}",
+            String::from_utf8_lossy(&last)
+        )
+    });
+    assert!(
+        snap.windows(bg_needle.len()).any(|w| w == bg_needle)
+            || wait_for_in_snapshot(
+                &server.registry,
+                &agent_id,
+                bg_needle,
+                Duration::from_secs(5)
+            )
+            .await
+            .is_some(),
+        "PRD #100 regression: BGWRITER-MSG\\r\\n missing from scrollback \
+         — the orchestration-side write was not atomic against the \
+         concurrent user write. Last snapshot: {:?}",
+        String::from_utf8_lossy(&snap)
+    );
+
+    drop(ctrl);
+    let _ = server.registry.close_agent(&agent_id);
+}
+
+/// PRD #100 audit #6: race ≥2 parallel `EmbeddedPaneController::write_to_pane`
+/// calls (each going through the new `WriteAndSubmit` RPC) against
+/// the same pane. The original M3.1 test pinned client-vs-daemon
+/// serialization through the writer mutex; this test pins
+/// client-vs-client serialization through the SAME mutex. Asymmetry
+/// between the two surfaces would mean the RPC handler unlocked
+/// something it shouldn't have, so even though the mechanism is
+/// shared (`AgentPtyRegistry::write_to_pane_and_submit`), the
+/// RPC-only path deserves its own coverage.
+///
+/// Assertion: each of the three concurrent payloads must surface as
+/// its own `<payload>\r\n` substring in cat's scrollback. Fused
+/// writes at the PTY master would collapse two or more payloads
+/// into a single canonical line and cat would emit one combined
+/// `<a><b>\r\n` instead of two distinct `<a>\r\n` + `<b>\r\n`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_controller_write_to_pane_serializes_per_pane() {
+    let server = start_server().await;
+    let agent_id = start_cat_pane(&server, "multi-client-pane").await;
+
+    let ctrl = Arc::new(EmbeddedPaneController::new(
+        server.path.clone(),
+        tokio::runtime::Handle::current(),
+    ));
+
+    let ctrl_for_hydrate = ctrl.clone();
+    let hydrated = tokio::task::spawn_blocking(move || ctrl_for_hydrate.hydrate_from_daemon())
+        .await
+        .unwrap();
+    assert_eq!(hydrated.len(), 1);
+    assert_eq!(hydrated[0].pane_id, "multi-client-pane");
+
+    let payloads = ["CLIENTA-MSG", "CLIENTB-MSG", "CLIENTC-MSG"];
+    let mut joins = Vec::new();
+    for payload in payloads {
+        let ctrl = ctrl.clone();
+        joins.push(tokio::task::spawn_blocking(move || {
+            ctrl.write_to_pane("multi-client-pane", payload)
+        }));
+    }
+    for j in joins {
+        j.await.unwrap().expect("controller write");
+    }
+
+    // Every payload must surface as its own `<payload>\r\n` chunk
+    // from cat. Same atomicity-via-canonical-line shape as the
+    // existing `write_to_pane_and_submit_serializes_concurrent_writes_per_pane`
+    // in `tests/orchestration_delegate.rs`.
+    for payload in payloads {
+        let needle: Vec<u8> = format!("{payload}\r\n").into_bytes();
+        let snap =
+            wait_for_in_snapshot(&server.registry, &agent_id, &needle, Duration::from_secs(5))
+                .await
+                .unwrap_or_else(|| {
+                    let last = server.registry.snapshot(&agent_id).unwrap_or_default();
+                    panic!(
+                        "concurrent-write regression: {payload}\\r\\n missing \
+                     from scrollback — the RPC path fused writes from \
+                     multiple clients into a single canonical line. \
+                     Snapshot: {:?}",
+                        String::from_utf8_lossy(&last)
+                    )
+                });
+        assert!(
+            snap.windows(needle.len()).any(|w| w == needle.as_slice()),
+            "expected {payload}\\r\\n in scrollback: {:?}",
+            String::from_utf8_lossy(&snap)
+        );
+    }
+
+    drop(ctrl);
+    let _ = server.registry.close_agent(&agent_id);
+}
+
+/// PRD #100 reviewer 'minor gap': mirror of the headline atomicity
+/// test, but the concurrent daemon-initiated writer is a
+/// `write_to_pane_notice` (LF terminator, no submit) instead of a
+/// `write_to_pane_and_submit` (CR terminator). Both go through
+/// `write_to_pane_internal` and the same per-agent writer mutex, so
+/// the serialization invariant holds — but the LF-terminator path is
+/// what hypothesis #2 of the original PRD specifically called out as
+/// the bug surface, and it's worth pinning that the notice path also
+/// can't sneak its LF in between the user's payload and CR.
+///
+/// Assertion: the user's `USERMSG-PAYLOAD\r\n` survives as a contiguous
+/// substring even with a concurrent notice landing during the user
+/// write's `SUBMIT_DELAY` window. A pre-fix-style notice landing in
+/// the gap would let the slave see `user-payload + notice\n` followed
+/// by the user's CR, collapsing them into one canonical line —
+/// `USERMSG-PAYLOAD\r\n` would not appear.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn controller_write_to_pane_is_atomic_against_concurrent_notice() {
+    let server = start_server().await;
+    let agent_id = start_cat_pane(&server, "notice-race-pane").await;
+
+    let ctrl = Arc::new(EmbeddedPaneController::new(
+        server.path.clone(),
+        tokio::runtime::Handle::current(),
+    ));
+
+    let ctrl_for_hydrate = ctrl.clone();
+    let hydrated = tokio::task::spawn_blocking(move || ctrl_for_hydrate.hydrate_from_daemon())
+        .await
+        .unwrap();
+    assert_eq!(hydrated.len(), 1);
+    assert_eq!(hydrated[0].pane_id, "notice-race-pane");
+
+    let ctrl_for_user = ctrl.clone();
+    let user_task = tokio::task::spawn_blocking(move || {
+        ctrl_for_user.write_to_pane("notice-race-pane", "USERMSG-PAYLOAD")
+    });
+
+    // 50 ms head start on the user write puts the notice squarely
+    // inside the user write's `SUBMIT_DELAY` window — the original
+    // bug scenario for hypothesis #2.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let registry_for_task = server.registry.clone();
+    let notice_task = tokio::spawn(async move {
+        registry_for_task
+            .write_to_pane_notice("notice-race-pane", "NOTICE-MARKER")
+            .await
+    });
+
+    user_task.await.unwrap().expect("controller write");
+    notice_task.await.unwrap().unwrap();
+
+    // The user's payload must surface as `USERMSG-PAYLOAD\r\n` — its
+    // own canonical line, not fused with the notice. The notice
+    // terminator is LF (no CR), so the notice text itself doesn't
+    // close a canonical line on its own; what we're guarding against
+    // is the notice's bytes landing between the user's payload and
+    // the user's CR.
+    let user_needle: &[u8] = b"USERMSG-PAYLOAD\r\n";
+    wait_for_in_snapshot(
+        &server.registry,
+        &agent_id,
+        user_needle,
+        Duration::from_secs(5),
+    )
+    .await
+    .unwrap_or_else(|| {
+        let last = server.registry.snapshot(&agent_id).unwrap_or_default();
+        panic!(
+            "notice-race regression: USERMSG-PAYLOAD\\r\\n missing — \
+                 the notice's LF landed between the user's payload and \
+                 the user's CR, fusing them into a single canonical \
+                 line. Snapshot: {:?}",
+            String::from_utf8_lossy(&last)
+        )
+    });
+
+    // The notice text must surface too (PTY echo gets it; cat won't
+    // emit it as a separate stdout line because the LF terminator
+    // doesn't close a *new* canonical line from cat's perspective
+    // unless the buffer is already empty — but the echo path always
+    // surfaces it).
+    let notice_needle: &[u8] = b"NOTICE-MARKER";
+    wait_for_in_snapshot(
+        &server.registry,
+        &agent_id,
+        notice_needle,
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("notice text must surface in scrollback");
+
+    drop(ctrl);
+    let _ = server.registry.close_agent(&agent_id);
+}

--- a/tests/pane_write_byte_order.rs
+++ b/tests/pane_write_byte_order.rs
@@ -1,0 +1,275 @@
+//! Byte-level reproducer harness for PRD #100 (Enter sometimes inserts a
+//! newline into the orchestrator's input instead of submitting).
+//!
+//! Phase 1 / M1.2 asks for a deterministic reproducer along the PRD's
+//! axes: very long messages, embedded newlines, rapid back-to-back
+//! sends, sends right after orchestrator mount, sends while another
+//! role pane animates. Three of those axes are already pinned in
+//! `tests/orchestration_delegate.rs` (single-line CR, multi-line
+//! bracketed paste, concurrent same-pane serialization). This file
+//! covers the two PRD axes the existing tests don't:
+//!
+//! * **Very long single-line messages** — the size axis. The
+//!   single-line/no-paste contract in `encode_pane_payload` must hold
+//!   regardless of payload size; a regression to "wrap above N bytes"
+//!   would silently introduce hypothesis-#1 surface on long prompts.
+//! * **Notice-then-submit byte order** — the orchestration error path
+//!   writes a notice (`\n` terminator) before a subsequent submit
+//!   (`\r` terminator). The combined byte stream
+//!   `notice\npayload\r` is exactly the surface PRD hypothesis #2
+//!   predicts: claude-style agents read the LF as newline-in-input,
+//!   so the CR submits `notice\npayload` together. We pin the bytes
+//!   here so Phase 2 has a stable before/after.
+//!
+//! The bug itself lives in the receiving agent (Claude Code /
+//! similar) and depends on that agent's bracketed-paste + Enter
+//! interpretation, which we cannot run in CI. What CI *can* pin is
+//! the framing the deck produces — the receiving agent only ever
+//! sees these bytes, so a contract on the framing is a contract on
+//! the bug surface.
+//!
+//! Each agent runs `cat -u`. The host PTY applies line discipline on
+//! the way out: every `\n` written by the daemon-side writer surfaces
+//! in the scrollback as `\r\n` (ONLCR), and each input is echoed
+//! twice (once by the kernel's PTY echo, once by `cat` reading and
+//! writing back). Assertions below avoid raw `\r`/`\n` counting and
+//! instead pin facts that survive line discipline: presence and
+//! relative order of `\x1b[200~` / `\x1b[201~` markers and message
+//! bodies.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+
+use dot_agent_deck::agent_pty::{
+    AgentPtyRegistry, DOT_AGENT_DECK_PANE_ID, TabMembership, is_valid_pane_id_env,
+};
+use dot_agent_deck::daemon::{Daemon, run_daemon_with};
+use dot_agent_deck::daemon_client::{DaemonClient, StartAgentOptions};
+use dot_agent_deck::state::{AppState, SharedState};
+
+mod common;
+
+static HARNESS_BIND_LOCK: Mutex<()> = Mutex::new(());
+
+struct DaemonHandle {
+    _dir: TempDir,
+    #[allow(dead_code)]
+    hook_path: PathBuf,
+    attach_path: PathBuf,
+    #[allow(dead_code)]
+    state: SharedState,
+    pty_registry: Arc<AgentPtyRegistry>,
+    handle: JoinHandle<()>,
+}
+
+impl Drop for DaemonHandle {
+    fn drop(&mut self) {
+        self.handle.abort();
+        self.pty_registry.shutdown_all();
+    }
+}
+
+async fn spawn_daemon() -> DaemonHandle {
+    common::init_test_env();
+    let (dir, hook_path, attach_path) = {
+        let _g = HARNESS_BIND_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = common::race_safe_tempdir();
+        let hook = dir.path().join("hook.sock");
+        let attach = dir.path().join("attach.sock");
+        (dir, hook, attach)
+    };
+
+    let state: SharedState = Arc::new(RwLock::new(AppState::default()));
+    let daemon = Daemon::with_attach(state.clone(), attach_path.clone())
+        .with_idle_shutdown(None)
+        .with_lock_dir_override(common::lock_dir_path());
+    let pty_registry = daemon.pty_registry.clone();
+
+    let hook_for_daemon = hook_path.clone();
+    let handle = tokio::spawn(async move {
+        let _ = run_daemon_with(&hook_for_daemon, daemon).await;
+    });
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline {
+        if attach_path.exists() && UnixStream::connect(&attach_path).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        attach_path.exists(),
+        "attach socket did not appear within 5s"
+    );
+
+    DaemonHandle {
+        _dir: dir,
+        hook_path,
+        attach_path,
+        state,
+        pty_registry,
+        handle,
+    }
+}
+
+async fn start_pane(daemon: &DaemonHandle, pane_id: &str) -> String {
+    assert!(is_valid_pane_id_env(pane_id), "pane_id must be valid");
+    let client = DaemonClient::new(daemon.attach_path.clone());
+    let cwd = std::env::temp_dir().to_string_lossy().into_owned();
+    client
+        .start_agent(StartAgentOptions {
+            command: Some("cat -u".to_string()),
+            cwd: Some(cwd),
+            display_name: Some(pane_id.to_string()),
+            rows: 24,
+            cols: 80,
+            env: vec![(DOT_AGENT_DECK_PANE_ID.to_string(), pane_id.to_string())],
+            tab_membership: Some(TabMembership::Orchestration {
+                name: "byte-order".to_string(),
+                role_index: 0,
+                role_name: pane_id.to_string(),
+                is_start_role: false,
+                orchestration_cwd: None,
+            }),
+            agent_type: None,
+        })
+        .await
+        .expect("start_agent")
+}
+
+/// Poll the agent's scrollback for `needle` and return the snapshot
+/// captured at the moment the needle first appears. Panics on timeout.
+async fn wait_for_in_snapshot(
+    registry: &AgentPtyRegistry,
+    agent_id: &str,
+    needle: &[u8],
+    timeout: Duration,
+) -> Vec<u8> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(snap) = registry.snapshot(agent_id)
+            && snap.windows(needle.len()).any(|w| w == needle)
+        {
+            return snap;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let last = registry.snapshot(agent_id).unwrap_or_default();
+    panic!(
+        "needle {:?} not found in agent {} scrollback within {:?}; \
+         last snapshot: {:?}",
+        String::from_utf8_lossy(needle),
+        agent_id,
+        timeout,
+        String::from_utf8_lossy(&last)
+    );
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+/// PRD axis: very long single-line message. The single-line policy in
+/// `encode_pane_payload` (no bracketed-paste wrap unless the payload
+/// contains an embedded `\n`) must hold regardless of payload size.
+/// A "wrap above N bytes" regression would introduce hypothesis #1
+/// surface — Enter inside the paste read as newline-in-input — for
+/// any user prompt longer than the threshold.
+#[tokio::test]
+async fn daemon_very_long_single_line_message_stays_unwrapped() {
+    let daemon = spawn_daemon().await;
+    let agent_id = start_pane(&daemon, "long-line-pane").await;
+
+    // 8 KB single-line payload (well past typical PTY chunking and
+    // any plausible buffer-size threshold a future regression might
+    // introduce).
+    let big = "x".repeat(8 * 1024);
+    daemon
+        .pty_registry
+        .write_to_pane_and_submit("long-line-pane", &big)
+        .await
+        .expect("write_to_pane_and_submit");
+
+    // Wait for at least the first KB of x's to surface so the write
+    // has certainly flushed.
+    let needle = "x".repeat(1024).into_bytes();
+    let snap = wait_for_in_snapshot(
+        &daemon.pty_registry,
+        &agent_id,
+        &needle,
+        Duration::from_secs(5),
+    )
+    .await;
+    assert!(
+        !contains(&snap, b"\x1b[200~"),
+        "long single-line payload must not be bracketed-paste wrapped"
+    );
+    assert!(
+        !contains(&snap, b"\x1b[201~"),
+        "long single-line payload must not carry a bracketed-paste end marker"
+    );
+}
+
+/// PRD axis: a notice (LF terminator, no submit) followed by a submit
+/// (CR terminator) on the same pane. This is the orchestration error
+/// path: `handle_delegate` writes a respawn-failure notice to the
+/// orchestrator pane via `write_to_pane_notice`, and a subsequent
+/// `handle_work_done` writes feedback via `write_to_pane_and_submit`.
+///
+/// Pin: notice precedes prompt in the byte stream, and neither single-
+/// line payload introduces bracketed-paste framing. Whether the
+/// notice's LF then fuses into the next submit is a property of the
+/// receiving agent's input box — claude-style agents would interpret
+/// `notice\npayload\r` as a two-line input submitted on the CR. We
+/// don't assert that here (no live agent in CI), but the byte order
+/// pinned by this test is the bug surface for PRD hypothesis #2 (LF
+/// vs CR framing inconsistency).
+#[tokio::test]
+async fn daemon_notice_then_submit_preserves_order_and_avoids_paste_framing() {
+    let daemon = spawn_daemon().await;
+    let agent_id = start_pane(&daemon, "notice-then-submit").await;
+
+    daemon
+        .pty_registry
+        .write_to_pane_notice("notice-then-submit", "NOTICE-MARKER")
+        .await
+        .expect("write_to_pane_notice");
+    daemon
+        .pty_registry
+        .write_to_pane_and_submit("notice-then-submit", "USER-PROMPT")
+        .await
+        .expect("write_to_pane_and_submit");
+
+    let snap = wait_for_in_snapshot(
+        &daemon.pty_registry,
+        &agent_id,
+        b"USER-PROMPT",
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let text = String::from_utf8_lossy(&snap);
+    let notice_pos = text.find("NOTICE-MARKER").expect("notice must surface");
+    let prompt_pos = text.find("USER-PROMPT").expect("prompt must surface");
+    assert!(
+        notice_pos < prompt_pos,
+        "notice must precede prompt in the byte stream; got {text:?}"
+    );
+    assert!(
+        !contains(&snap, b"\x1b[200~"),
+        "single-line notice + single-line prompt must not introduce \
+         bracketed-paste framing; got {text:?}"
+    );
+    assert!(
+        !contains(&snap, b"\x1b[201~"),
+        "single-line notice + single-line prompt must not introduce \
+         bracketed-paste framing; got {text:?}"
+    );
+}

--- a/tests/stop_dialog.rs
+++ b/tests/stop_dialog.rs
@@ -239,11 +239,18 @@ mod stub_server {
         F: FnOnce(tokio::net::UnixStream) -> Fut + Send + 'static,
         Fut: std::future::Future<Output = ()> + Send,
     {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("stub.sock");
-        let listener = {
+        // Create the tempdir INSIDE the bind lock so a concurrent
+        // `bind_socket` call (which briefly sets the process umask to
+        // 0o177) cannot strip the execute bit from the directory before
+        // we bind a socket inside it.  See `common::race_safe_tempdir`
+        // for the same fix applied to other harnesses that use
+        // `bind_attach_listener`.
+        let (dir, path, listener) = {
             let _g = HARNESS_BIND_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-            UnixListener::bind(&path).expect("bind stub listener")
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("stub.sock");
+            let listener = UnixListener::bind(&path).expect("bind stub listener");
+            (dir, path, listener)
         };
         let handle = tokio::spawn(async move {
             if let Ok((stream, _)) = listener.accept().await {


### PR DESCRIPTION
## Summary

Fixes [#100](https://github.com/vfarcic/dot-agent-deck/issues/100) — pressing Enter to dispatch a prompt to the orchestrator agent intermittently inserting a newline instead of submitting.

> **⚠️ Do not merge until M3.2 (100-run validation) and M3.3 (Claude Code / OpenCode regression smoke) are confirmed by the user.** These are post-PR / post-CI manual smoke steps, explicitly user-gated per PRD success criteria.

---

## Root Cause

The pre-fix client write path for `write_to_pane` queued two STREAM_IN frames to the daemon separated by a 150 ms `std::thread::sleep` (the old `src/embedded_pane.rs:1771-1773`). The daemon's input loop acquired the per-agent writer mutex briefly per frame, so during the 150 ms gap the mutex was **free**. If a concurrent daemon-initiated write — work-done feedback or a `write_to_pane_notice` (which carries a LF terminator) — fired against the orchestrator pane inside that window, the byte order written to the PTY master became `[user payload][daemon payload][daemon CR][user CR]`. After ICRNL and canonical line buffering, the slave received one fused canonical line; the daemon's CR submitted the combined input and the user's trailing CR was a no-op on an already-empty input box. From the user's perspective: Enter inserted a newline instead of submitting.

The orchestrator pane is uniquely affected because it is the only pane that simultaneously *receives* daemon-initiated writes (work-done feedback, respawn notices) and *originates* user prompts. Other role panes only receive daemon writes; pure-user-input panes only originate writes — neither shape produces concurrent same-pane writers.

---

## Fix

New `AttachRequest::WriteAndSubmit { pane_id, text }` daemon RPC (`src/daemon_protocol.rs`). The handler calls `AgentPtyRegistry::write_to_pane_and_submit`, which holds the per-agent writer mutex across the full payload + `SUBMIT_DELAY` + CR sequence — the same atomic contract PRD #93 round-8 established for orchestration dispatch. Client-initiated and daemon-initiated writes now serialise through the same per-agent writer mutex.

`PROTOCOL_VERSION` bumped **2 → 3**. The version handshake in `src/connect.rs` rejects mismatched daemons with a clear `ProtocolMismatch` error; no silent misbehaviour on skew.

This fix reuses PRD #93 round-8's per-agent-writer-mutex-held-across-CR atomic contract — **no separate PRD #93 carry-forward needed**.

---

## Scope

**Not orchestrator-only.** Every `PaneController::write_to_pane` caller now benefits from the atomic RPC:

- `src/ui.rs:1603` — send-prompt dialog
- `src/ui.rs:3264-3267`, `5070-5076` — spawn-time init-command writes
- `src/ui.rs:3703` — start-pane prompt
- `src/ui.rs:4147` — Ctrl-L reactive-pane clear
- `src/ui.rs:4479` — reactive-pane PROMPT init on focus
- `src/ui.rs:4750` — permission y/n forwarding
- `src/ui.rs:5126` — `KeyResult::SendConfigGenPrompt`
- `src/mode_manager.rs:308-322` — mode-manager init/command writes
- `src/mode_manager.rs:421-422` — renew-after-respawn path

The orchestrator-only symptom in the PRD was an *observation*, not a constraint.

---

## Hardening (from audit + review)

- **1 MiB text cap** — `WRITE_AND_SUBMIT_MAX_TEXT` const; returns `AgentPtyError::PayloadTooLarge` before acquiring the writer mutex. Prevents a buggy/hostile caller from parking the mutex for seconds.
- **`pane_id` validation** — `is_valid_pane_id_env` called before registry lookup; returns typed error on invalid input.
- **Error-semantics behaviour change documented** — pre-fix `write_to_pane` silently returned `Ok(())` on `PaneInputError`; post-fix returns `Err(PaneError::CommandFailed)`, observable at `ui.rs:5126` / `ui.rs:4750` status messages. Docstring updated.
- **PII-aware trace targets** — payload bytes logged at `trace` level under the `pane_write` target only; `RUST_LOG=trace,pane_write=warn` suppresses selectively. Trace moved inside the writer mutex on both paths so log order matches actual write order under concurrent writes.

---

## Tests (4 new)

| File | Test | What it pins |
|------|------|--------------|
| `tests/client_write_to_pane_atomic.rs` | `write_to_pane_submits_without_interleaving_concurrent_daemon_write` (M3.1 regression) | Pre-fix: scrollback shows fused `USERMSG-PAYLOADBGWRITER-MSG\r\n`; post-fix: two distinct lines |
| `tests/client_write_to_pane_atomic.rs` | `controller_write_to_pane_is_atomic_against_concurrent_notice` | Races a `write_to_pane_notice` (LF terminator) — confirms notice path also serialises |
| `tests/client_write_to_pane_atomic.rs` | `concurrent_controller_write_to_pane_serializes_per_pane` | Three parallel RPC clients to the same pane; each `<payload>\r\n` surfaces independently |
| `tests/pane_write_byte_order.rs` | Two tests | Pin the LF-vs-CR byte surface (hypothesis #2) and no-paste-wrap on long single-line |

All 4 are toggle-verified per the coder's report.

---

## Files Changed

- `src/daemon_protocol.rs` — `WriteAndSubmit` RPC variant + handler; `WRITE_AND_SUBMIT_MAX_TEXT` const; `pane_id` validation; trust-model doc; STREAM_IN trace inside mutex + PII warning; `PROTOCOL_VERSION` 2 → 3
- `src/daemon_client.rs` — `DaemonClient::write_to_pane_and_submit` (new client method)
- `src/embedded_pane.rs` — `EmbeddedPaneController::write_to_pane` rewritten to use RPC; runtime + error-semantics doc; client-side trace logs full escaped payload
- `src/agent_pty.rs` — `AgentPtyError::PayloadTooLarge` variant; trace moved inside writer mutex; PII warning
- `tests/client_write_to_pane_atomic.rs` — 3 tests (1 pre-existing M3.1 + 2 new from audit/review)
- `tests/pane_write_byte_order.rs` — 2 byte-order reproducers (new)
- `changelog.d/100.bugfix.md` — release note fragment
- `prds/done/100-fix-orchestrator-enter-key-newline.md` — archived PRD (Complete 2026-05-25)

---

## Outstanding (post-merge, user-gated)

- **M3.2** — 100-run validation: run the send-prompt reproducer 100 consecutive times against the fixed build; confirm zero newline-instead-of-submit failures.
- **M3.3** — Claude Code / OpenCode regression smoke: confirm no regression for other agent types on the existing send-prompt path.

These are explicitly **not** part of this PR's CI gate. User will run them post-merge before closing issue #100.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed intermittent issue where pressing Enter to submit a prompt in the orchestrator pane could insert a newline instead of submitting the prompt.
* Improved serialization of concurrent pane write operations to prevent write interference.
* Protocol version updated; mismatched daemon/client versions will fail at connection with a version mismatch error.

## Tests
* Added regression tests validating atomicity of concurrent pane writes and byte-order preservation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vfarcic/dot-agent-deck/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->