### PR TITLE
fix(ui): dashboard j/k/Up/Down card navigation (PRD #68)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,7 +65,7 @@ About 30 seconds after both the TUI and every managed agent are gone, the daemon
 1. Launch the dashboard with `dot-agent-deck`
 2. Press `Ctrl+n` to open a new pane — pick a directory, give the pane a name, and enter the command to run (typically `claude` or `opencode`)
 3. Watch the agent's status, tool calls, and prompts update on the dashboard in real-time
-4. To type into an agent, move keyboard focus into its pane: press `Ctrl+d` to enter command mode, then `1`–`9` to jump to that card's pane
+4. To type into an agent, move keyboard focus into its pane: press `Ctrl+d` to enter command mode, then either `j`/`k` (or `Down`/`Up`) to cycle through cards or `1`–`9` to jump directly to a card
 5. To close the pane you're currently working in, press `Ctrl+w` — it closes the selected card and its pane, even while you're still typing in it. The dashboard tab itself can't be closed.
 
 > **Tip:** The command can be any shell command, but real-time status, tool, and prompt tracking on the dashboard only work for `claude` and `opencode` (the agents Agent Deck installs hooks for).

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -47,6 +47,8 @@ These shortcuts work in **command mode**. If you're typing in an agent pane, pre
 
 | Key | Action |
 |---|---|
+| `j` / `Down` | Select next card (wraps at end) |
+| `k` / `Up` | Select previous card (wraps at start) |
 | `1`–`9` | Jump to card N and focus its pane |
 | `/` | Filter sessions (opens filter input — see [Dialogs](#dialogs)) |
 | `r` | Rename selected session (opens rename input — see [Dialogs](#dialogs)) |
@@ -54,8 +56,6 @@ These shortcuts work in **command mode**. If you're typing in an agent pane, pre
 | `?` | Toggle help overlay |
 | `y` / `n` | Approve / deny a pending permission request (only when an agent is waiting) |
 | `Esc` | Clear active filter |
-
-> **Note:** `j`/`k` and `Up`/`Down` for cycling selection through cards are documented in the in-app help but are currently not working — see [#68](https://github.com/vfarcic/dot-agent-deck/issues/68). Use `1`–`9` to jump directly to a card.
 
 ## Directory Picker
 

--- a/prds/done/68-fix-card-navigation-keys.md
+++ b/prds/done/68-fix-card-navigation-keys.md
@@ -1,8 +1,9 @@
 # PRD #68: Fix Dashboard Card Navigation Keys
 
-**Status**: Draft
+**Status**: Complete
 **Priority**: Medium
 **Created**: 2026-04-28
+**Completed**: 2026-05-25
 
 ## Problem
 
@@ -33,12 +34,12 @@ Fix so that pressing `j`/`k`/`Up`/`Down` while the dashboard has keyboard focus 
 
 ## Acceptance Criteria
 
-- [ ] From a freshly launched dashboard with multiple session cards, pressing `j` or `Down` advances the selection to the next card; the previously-selected card is no longer highlighted.
-- [ ] Pressing `k` or `Up` moves the selection back.
-- [ ] Selection wraps at the end / start of the list (matches existing `(selected_index + 1) % total` logic).
-- [ ] After fix, restore `j`/`k` / `Up`/`Down` rows in:
+- [x] From a freshly launched dashboard with multiple session cards, pressing `j` or `Down` advances the selection to the next card; the previously-selected card is no longer highlighted.
+- [x] Pressing `k` or `Up` moves the selection back.
+- [x] Selection wraps at the end / start of the list (matches existing `(selected_index + 1) % total` logic).
+- [x] After fix, restore `j`/`k` / `Up`/`Down` rows in:
   - `docs/keyboard-shortcuts.md` Dashboard table
-  - `docs/getting-started.mdx` Basic Workflow step on focusing a pane
+  - `docs/getting-started.md` Basic Workflow step on focusing a pane
   - `src/ui.rs` help overlay text
 
 ## Out of Scope

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2157,6 +2157,28 @@ fn focus_deck(
     true
 }
 
+/// PRD #68: mirror a selection move made by `handle_normal_key`
+/// (j/k/Up/Down) into the embedded controller's focus. The per-frame
+/// "sync `ui.selected_index` ← focused pane" block at the top of the
+/// outer event loop would otherwise roll the move back on the next
+/// iteration. The digit-jump path (`Ctrl+d` → `1`-`9`) already pairs
+/// selection with focus via [`focus_deck`]; this helper is its
+/// counterpart for the cycling keys. No-op when the index didn't
+/// change or the new selection lacks a `pane_id`.
+fn mirror_selection_into_focus(
+    prev_selected_index: usize,
+    ui: &UiState,
+    filtered: &[(&String, &SessionState)],
+    pane: &dyn PaneController,
+) {
+    if ui.selected_index != prev_selected_index
+        && let Some((_, session)) = filtered.get(ui.selected_index)
+        && let Some(pane_id) = session.pane_id.as_ref()
+    {
+        let _ = pane.focus_pane(pane_id);
+    }
+}
+
 fn handle_normal_key(
     key: KeyEvent,
     ui: &mut UiState,
@@ -4510,22 +4532,7 @@ pub fn run_tui(
                             .map(|session| session.status.clone());
                         let prev_selected_index = ui.selected_index;
                         let r = handle_normal_key(key, &mut ui, total, selected_status);
-                        // PRD #68: j/k/Up/Down update `ui.selected_index`,
-                        // but the per-frame "sync selected_index ← focused
-                        // pane" block at the top of this outer loop
-                        // resets the index back to whatever pane is
-                        // currently focused — so plain selection moves
-                        // never visibly land. Mirror the selection into
-                        // focus here so the next iteration's sync agrees
-                        // with the user's move. This matches what
-                        // `focus_deck` (Ctrl+d → 1-9) already does for
-                        // the digit-jump path.
-                        if ui.selected_index != prev_selected_index
-                            && let Some((_, session)) = filtered.get(ui.selected_index)
-                            && let Some(pane_id) = session.pane_id.as_ref()
-                        {
-                            let _ = pane.focus_pane(pane_id);
-                        }
+                        mirror_selection_into_focus(prev_selected_index, &ui, &filtered, &*pane);
                         r
                     }
                     UiMode::Filter => handle_filter_key(key, &mut ui),
@@ -8060,7 +8067,7 @@ mod tests {
             }
         }
 
-        let mut state = AppState::default();
+        let state = AppState::default();
         let cfg = OrchestrationConfig {
             name: "tdd-cycle".into(),
             roles: vec![
@@ -10197,12 +10204,14 @@ mod tests {
         );
     }
 
-    /// Companion to the focus_deck test: simulate the j/k dispatch
-    /// loop fix end-to-end. `handle_normal_key` is the entry point the
-    /// fix wraps; the dispatch loop's post-handler hook then calls
-    /// `focus_pane` on the new selection. Pin both halves together so
-    /// a future refactor can't silently delete the focus mirror and
-    /// re-introduce PRD #68.
+    /// Companion to the focus_deck test: pin the dispatch-loop's
+    /// "after `handle_normal_key`, mirror the new selection into
+    /// focus" step. The production loop calls
+    /// `mirror_selection_into_focus`; this test calls the SAME
+    /// helper, so a future refactor that deletes the production call
+    /// site re-introduces PRD #68 even if the helper still exists,
+    /// and a refactor that deletes the helper breaks this test
+    /// outright.
     #[test]
     fn jk_navigation_mirrors_selection_into_focus() {
         let mut snapshot = AppState::default();
@@ -10222,31 +10231,31 @@ mod tests {
         let mut ui = default_ui();
         ui.selected_index = 0;
 
-        // Inline the dispatch-loop fix shape so a future refactor that
-        // drops the mirror trips the test (the production loop lives
-        // inside `run_ui`, which is too heavy to spin up here).
-        let move_with_focus = |ui: &mut UiState, key: KeyEvent| {
+        // Drive the production code path: `handle_normal_key` plus
+        // the dispatch-loop hook `mirror_selection_into_focus`. If
+        // either is deleted from `run_tui`, this test still exercises
+        // both — but the production bug returns silently because the
+        // outer loop's per-frame sync is what relies on the helper
+        // being called. The companion code-review check is "every
+        // `handle_normal_key` callsite in `run_tui` Normal mode pairs
+        // with `mirror_selection_into_focus`."
+        let press = |ui: &mut UiState, key: KeyEvent| {
             let prev = ui.selected_index;
             let _ = handle_normal_key(key, ui, total, None);
-            if ui.selected_index != prev
-                && let Some((_, session)) = filtered.get(ui.selected_index)
-                && let Some(pid) = session.pane_id.as_ref()
-            {
-                let _ = crate::pane::PaneController::focus_pane(&pc, pid);
-            }
+            mirror_selection_into_focus(prev, ui, &filtered, &pc);
         };
 
         // j: 0 → 1, focus mirrored to p1.
-        move_with_focus(
+        press(
             &mut ui,
             KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
         );
         assert_eq!(ui.selected_index, 1);
         // Down: 1 → 2, focus mirrored to p2.
-        move_with_focus(&mut ui, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        press(&mut ui, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         assert_eq!(ui.selected_index, 2);
         // k: 2 → 1, focus mirrored to p1.
-        move_with_focus(
+        press(
             &mut ui,
             KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
         );

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2179,6 +2179,29 @@ fn mirror_selection_into_focus(
     }
 }
 
+/// PRD #68 / PR #123 Greptile follow-up: one full Normal-mode key
+/// dispatch — `handle_normal_key` plus the focus-mirror that makes
+/// j/k/Up/Down actually land. `run_tui`'s `UiMode::Normal` arm and
+/// `jk_navigation_mirrors_selection_into_focus` both call this
+/// helper, so the test exercises the exact production path; deleting
+/// the mirror line from this function would fail the test instead of
+/// silently regressing the feature. Inlining either step back into
+/// `run_tui` would defeat that — keep the call site in `run_tui` a
+/// one-liner to this helper.
+fn dispatch_normal_mode_key(
+    key: KeyEvent,
+    ui: &mut UiState,
+    total: usize,
+    selected_status: Option<SessionStatus>,
+    filtered: &[(&String, &SessionState)],
+    pane: &dyn PaneController,
+) -> KeyResult {
+    let prev_selected_index = ui.selected_index;
+    let result = handle_normal_key(key, ui, total, selected_status);
+    mirror_selection_into_focus(prev_selected_index, ui, filtered, pane);
+    result
+}
+
 fn handle_normal_key(
     key: KeyEvent,
     ui: &mut UiState,
@@ -4530,10 +4553,14 @@ pub fn run_tui(
                             .as_ref()
                             .and_then(|sid| snapshot.sessions.get(sid))
                             .map(|session| session.status.clone());
-                        let prev_selected_index = ui.selected_index;
-                        let r = handle_normal_key(key, &mut ui, total, selected_status);
-                        mirror_selection_into_focus(prev_selected_index, &ui, &filtered, &*pane);
-                        r
+                        dispatch_normal_mode_key(
+                            key,
+                            &mut ui,
+                            total,
+                            selected_status,
+                            &filtered,
+                            &*pane,
+                        )
                     }
                     UiMode::Filter => handle_filter_key(key, &mut ui),
                     UiMode::Help => handle_help_key(key, &mut ui),
@@ -10205,13 +10232,13 @@ mod tests {
     }
 
     /// Companion to the focus_deck test: pin the dispatch-loop's
-    /// "after `handle_normal_key`, mirror the new selection into
-    /// focus" step. The production loop calls
-    /// `mirror_selection_into_focus`; this test calls the SAME
-    /// helper, so a future refactor that deletes the production call
-    /// site re-introduces PRD #68 even if the helper still exists,
-    /// and a refactor that deletes the helper breaks this test
-    /// outright.
+    /// Normal-mode step end-to-end by driving the SAME helper that
+    /// `run_tui` calls — `dispatch_normal_mode_key`. Deleting the
+    /// `mirror_selection_into_focus` line from that helper would
+    /// regress PRD #68 in production AND fail this test, closing the
+    /// Greptile-flagged gap where calling `mirror_selection_into_focus`
+    /// directly from the test would silently pass when someone
+    /// removed the production call site.
     #[test]
     fn jk_navigation_mirrors_selection_into_focus() {
         let mut snapshot = AppState::default();
@@ -10231,18 +10258,8 @@ mod tests {
         let mut ui = default_ui();
         ui.selected_index = 0;
 
-        // Drive the production code path: `handle_normal_key` plus
-        // the dispatch-loop hook `mirror_selection_into_focus`. If
-        // either is deleted from `run_tui`, this test still exercises
-        // both — but the production bug returns silently because the
-        // outer loop's per-frame sync is what relies on the helper
-        // being called. The companion code-review check is "every
-        // `handle_normal_key` callsite in `run_tui` Normal mode pairs
-        // with `mirror_selection_into_focus`."
         let press = |ui: &mut UiState, key: KeyEvent| {
-            let prev = ui.selected_index;
-            let _ = handle_normal_key(key, ui, total, None);
-            mirror_selection_into_focus(prev, ui, &filtered, &pc);
+            dispatch_normal_mode_key(key, ui, total, None, &filtered, &pc);
         };
 
         // j: 0 → 1, focus mirrored to p1.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4508,7 +4508,25 @@ pub fn run_tui(
                             .as_ref()
                             .and_then(|sid| snapshot.sessions.get(sid))
                             .map(|session| session.status.clone());
-                        handle_normal_key(key, &mut ui, total, selected_status)
+                        let prev_selected_index = ui.selected_index;
+                        let r = handle_normal_key(key, &mut ui, total, selected_status);
+                        // PRD #68: j/k/Up/Down update `ui.selected_index`,
+                        // but the per-frame "sync selected_index ← focused
+                        // pane" block at the top of this outer loop
+                        // resets the index back to whatever pane is
+                        // currently focused — so plain selection moves
+                        // never visibly land. Mirror the selection into
+                        // focus here so the next iteration's sync agrees
+                        // with the user's move. This matches what
+                        // `focus_deck` (Ctrl+d → 1-9) already does for
+                        // the digit-jump path.
+                        if ui.selected_index != prev_selected_index
+                            && let Some((_, session)) = filtered.get(ui.selected_index)
+                            && let Some(pane_id) = session.pane_id.as_ref()
+                        {
+                            let _ = pane.focus_pane(pane_id);
+                        }
+                        r
                     }
                     UiMode::Filter => handle_filter_key(key, &mut ui),
                     UiMode::Help => handle_help_key(key, &mut ui),
@@ -6327,6 +6345,8 @@ fn render_help_overlay(frame: &mut Frame, active_mode_name: Option<&str>, palett
         Line::from(""),
         Line::styled("  Dashboard (command mode)", cyan),
         Line::from(""),
+        Line::from("  j / Down        Select next card"),
+        Line::from("  k / Up          Select previous card"),
         Line::from("  1-9             Jump to pane N"),
         Line::from("  Enter           Focus selected pane"),
         Line::from("  /               Filter sessions"),
@@ -9978,6 +9998,266 @@ mod tests {
             None,
         );
         assert!(matches!(result_y_no_status, KeyResult::Continue));
+    }
+
+    // -----------------------------------------------------------------------
+    // PRD #68 — dashboard card navigation (j/k/Up/Down)
+    //
+    // Two layers are pinned here:
+    //
+    // 1. `handle_normal_key` updates `ui.selected_index` with wrap-around
+    //    for j/k/Up/Down. This is the documented contract of the key
+    //    handler (help overlay + docs/keyboard-shortcuts.md).
+    //
+    // 2. `focus_deck` (the Ctrl+d → 1-9 path) still flips the embedded
+    //    controller's focus AND `ui.selected_index` — this is the
+    //    risk-mitigation regression test the PRD asks for. The fix in
+    //    the dispatch loop mirrors `focus_deck`'s "selection + focus"
+    //    pattern after `handle_normal_key`, so the per-frame
+    //    "selected_index ← focused pane" sync no longer rolls back the
+    //    user's j/k move.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn handle_normal_key_j_and_down_advance_with_wrap() {
+        let mut ui = default_ui();
+        ui.selected_index = 0;
+
+        // j advances 0 → 1
+        let r = handle_normal_key(
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+            &mut ui,
+            3,
+            None,
+        );
+        assert!(matches!(r, KeyResult::Continue));
+        assert_eq!(ui.selected_index, 1);
+
+        // Down advances 1 → 2
+        let r = handle_normal_key(
+            KeyEvent::new(KeyCode::Down, KeyModifiers::NONE),
+            &mut ui,
+            3,
+            None,
+        );
+        assert!(matches!(r, KeyResult::Continue));
+        assert_eq!(ui.selected_index, 2);
+
+        // wraps 2 → 0
+        let r = handle_normal_key(
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+            &mut ui,
+            3,
+            None,
+        );
+        assert!(matches!(r, KeyResult::Continue));
+        assert_eq!(ui.selected_index, 0);
+    }
+
+    #[test]
+    fn handle_normal_key_k_and_up_retreat_with_wrap() {
+        let mut ui = default_ui();
+        ui.selected_index = 0;
+
+        // k from 0 wraps to total - 1
+        let r = handle_normal_key(
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+            &mut ui,
+            3,
+            None,
+        );
+        assert!(matches!(r, KeyResult::Continue));
+        assert_eq!(ui.selected_index, 2);
+
+        // Up retreats 2 → 1
+        let r = handle_normal_key(
+            KeyEvent::new(KeyCode::Up, KeyModifiers::NONE),
+            &mut ui,
+            3,
+            None,
+        );
+        assert!(matches!(r, KeyResult::Continue));
+        assert_eq!(ui.selected_index, 1);
+    }
+
+    #[test]
+    fn handle_normal_key_jk_no_op_when_no_cards() {
+        // `total == 0` (empty dashboard): j/k/Up/Down must not panic
+        // and must not move `selected_index` off zero.
+        let mut ui = default_ui();
+        for code in [
+            KeyCode::Char('j'),
+            KeyCode::Char('k'),
+            KeyCode::Down,
+            KeyCode::Up,
+        ] {
+            let r = handle_normal_key(KeyEvent::new(code, KeyModifiers::NONE), &mut ui, 0, None);
+            assert!(matches!(r, KeyResult::Continue));
+            assert_eq!(ui.selected_index, 0);
+        }
+    }
+
+    /// Pane controller that records every `focus_pane` call. Used by the
+    /// `focus_deck` regression test below — the production embedded
+    /// controller is too heavy to spin up in a unit test, but the
+    /// contract `focus_deck` cares about is "the controller's
+    /// `focus_pane` got called with the right id".
+    struct RecordingFocusPC {
+        focused: std::sync::Mutex<Vec<String>>,
+    }
+    impl crate::pane::PaneController for RecordingFocusPC {
+        fn create_pane(
+            &self,
+            _cmd: Option<&str>,
+            _cwd: Option<&str>,
+        ) -> Result<String, crate::pane::PaneError> {
+            Ok(String::new())
+        }
+        fn write_to_pane(&self, _id: &str, _text: &str) -> Result<(), crate::pane::PaneError> {
+            Ok(())
+        }
+        fn close_pane(&self, _id: &str) -> Result<(), crate::pane::PaneError> {
+            Ok(())
+        }
+        fn rename_pane(
+            &self,
+            _id: &str,
+            name: &str,
+        ) -> Result<crate::pane::RenameOutcome, crate::pane::PaneError> {
+            Ok(crate::pane::RenameOutcome::applied(name))
+        }
+        fn focus_pane(&self, id: &str) -> Result<(), crate::pane::PaneError> {
+            self.focused.lock().unwrap().push(id.to_string());
+            Ok(())
+        }
+        fn list_panes(&self) -> Result<Vec<crate::pane::PaneInfo>, crate::pane::PaneError> {
+            Ok(Vec::new())
+        }
+        fn resize_pane(
+            &self,
+            _id: &str,
+            _direction: crate::pane::PaneDirection,
+            _amount: u16,
+        ) -> Result<(), crate::pane::PaneError> {
+            Ok(())
+        }
+        fn toggle_layout(&self) -> Result<(), crate::pane::PaneError> {
+            Ok(())
+        }
+        fn name(&self) -> &str {
+            "recording"
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    /// PRD #68 risk-mitigation: pin that the digit-jump path
+    /// (`Ctrl+d` → `1`-`9` → `focus_deck`) still focuses the right
+    /// pane AND sets `ui.selected_index` after the j/k fix lands in
+    /// the dispatch loop. The fix mirrors `focus_deck`'s pattern, so
+    /// breaking the digit path would mean both paths regressed.
+    #[test]
+    fn focus_deck_focuses_target_pane_and_updates_selected_index() {
+        use tokio::sync::RwLock;
+        let mut snapshot = AppState::default();
+        // Three sessions with concrete pane_ids so `focus_deck` has
+        // something to focus on.
+        for (sid, pid) in [("s0", "p0"), ("s1", "p1"), ("s2", "p2")] {
+            let mut sess = make_session(SessionStatus::Idle);
+            sess.session_id = sid.to_string();
+            sess.pane_id = Some(pid.to_string());
+            snapshot.sessions.insert(sid.to_string(), sess);
+        }
+        let state: SharedState = Arc::new(RwLock::new(snapshot.clone()));
+        let pc = RecordingFocusPC {
+            focused: std::sync::Mutex::new(Vec::new()),
+        };
+
+        // Build the `filtered` view focus_deck expects.
+        let ids: Vec<(&String, &SessionState)> = snapshot.sessions.iter().collect();
+        // Sort for stable order across HashMap iteration.
+        let mut ids = ids;
+        ids.sort_by(|a, b| a.0.cmp(b.0));
+
+        let mut ui = default_ui();
+        let ok = focus_deck(1, &mut ui, &ids, &snapshot, &state, &pc);
+        assert!(ok, "focus_deck must accept an in-range idx");
+        assert_eq!(ui.selected_index, 1);
+        // PaneInput transition is also part of the Ctrl+d → 1-9 contract.
+        assert_eq!(ui.mode, UiMode::PaneInput);
+        let calls = pc.focused.lock().unwrap();
+        assert_eq!(
+            calls.as_slice(),
+            &["p1".to_string()],
+            "focus_deck must call focus_pane on the targeted card's pane"
+        );
+    }
+
+    /// Companion to the focus_deck test: simulate the j/k dispatch
+    /// loop fix end-to-end. `handle_normal_key` is the entry point the
+    /// fix wraps; the dispatch loop's post-handler hook then calls
+    /// `focus_pane` on the new selection. Pin both halves together so
+    /// a future refactor can't silently delete the focus mirror and
+    /// re-introduce PRD #68.
+    #[test]
+    fn jk_navigation_mirrors_selection_into_focus() {
+        let mut snapshot = AppState::default();
+        for (sid, pid) in [("s0", "p0"), ("s1", "p1"), ("s2", "p2")] {
+            let mut sess = make_session(SessionStatus::Idle);
+            sess.session_id = sid.to_string();
+            sess.pane_id = Some(pid.to_string());
+            snapshot.sessions.insert(sid.to_string(), sess);
+        }
+        let pc = RecordingFocusPC {
+            focused: std::sync::Mutex::new(Vec::new()),
+        };
+        let mut filtered: Vec<(&String, &SessionState)> = snapshot.sessions.iter().collect();
+        filtered.sort_by(|a, b| a.0.cmp(b.0));
+        let total = filtered.len();
+
+        let mut ui = default_ui();
+        ui.selected_index = 0;
+
+        // Inline the dispatch-loop fix shape so a future refactor that
+        // drops the mirror trips the test (the production loop lives
+        // inside `run_ui`, which is too heavy to spin up here).
+        let move_with_focus = |ui: &mut UiState, key: KeyEvent| {
+            let prev = ui.selected_index;
+            let _ = handle_normal_key(key, ui, total, None);
+            if ui.selected_index != prev
+                && let Some((_, session)) = filtered.get(ui.selected_index)
+                && let Some(pid) = session.pane_id.as_ref()
+            {
+                let _ = crate::pane::PaneController::focus_pane(&pc, pid);
+            }
+        };
+
+        // j: 0 → 1, focus mirrored to p1.
+        move_with_focus(
+            &mut ui,
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+        );
+        assert_eq!(ui.selected_index, 1);
+        // Down: 1 → 2, focus mirrored to p2.
+        move_with_focus(&mut ui, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(ui.selected_index, 2);
+        // k: 2 → 1, focus mirrored to p1.
+        move_with_focus(
+            &mut ui,
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
+        );
+        assert_eq!(ui.selected_index, 1);
+
+        let calls = pc.focused.lock().unwrap();
+        assert_eq!(
+            calls.as_slice(),
+            &["p1".to_string(), "p2".to_string(), "p1".to_string()],
+            "every j/k/Up/Down move must mirror the new selection into focus"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fix dashboard card navigation so that pressing `j`/`k`/`Up`/`Down` in Normal mode visibly cycles the selected card, matching what the help overlay and docs already advertised.

Closes #68.

## Root Cause

A focus-sync loop at `src/ui.rs:3578-3588` unconditionally re-synced `ui.selected_index` to the focused pane's index on every TUI iteration. This snapped any selection change made by `j`/`k`/`Up`/`Down` (via `handle_normal_key`) back to the original value before the next render, making navigation appear broken.

**Fix**: after `handle_normal_key` runs and the selected index has changed, mirror the new `selected_index` back into `pane.focus_pane()` so the sync loop finds the focused pane already consistent and becomes a no-op.

## Notable Side Effect

The fix incidentally also repairs `j`/`k` navigation on the **Orchestration tab**, since that tab shares the same dispatch path (`UiMode::Normal → handle_normal_key`).

## Cleanup

A pre-existing `unused_mut` clippy warning at `src/ui.rs:8063` (introduced in commit 57791ab for PRD #110) was cleaned up in this PR to keep `cargo clippy --all-targets` green.

## Changes

- **`src/ui.rs`**: 
  - Fix: mirror `selected_index` into `pane.focus_pane()` after key handling when index changed
  - Extracted helper `mirror_selection_into_focus` (lines 2160-2179) — shared between dispatch loop and test
  - Fixed pre-existing `unused_mut` at line 8063
  - Restored `j`/`k`/`Up`/`Down` rows in the help overlay
  - Added 5 tests:
    - `handle_normal_key_j_and_down_advance_with_wrap`
    - `handle_normal_key_k_and_up_retreat_with_wrap`
    - `handle_normal_key_jk_no_op_when_no_cards`
    - `focus_deck_focuses_target_pane_and_updates_selected_index`
    - `jk_navigation_mirrors_selection_into_focus`
- **`docs/keyboard-shortcuts.md`**: Restored `j`/`k`/`Up`/`Down` rows in the Dashboard table; removed "currently not working" footnote
- **`docs/getting-started.md`**: Restored `j`/`k` step in the Basic Workflow section
- **`prds/done/68-fix-card-navigation-keys.md`**: Archived PRD as complete

## Test Plan

- [x] `j` / `Down` advances selection to next card, with wrap at end of list
- [x] `k` / `Up` retreats selection to previous card, with wrap at start of list
- [x] `Ctrl+d` → `1`–`9` direct jump still works (regression test included)
- [x] Docs restored in 3 places: `docs/keyboard-shortcuts.md`, `docs/getting-started.md`, `src/ui.rs` help overlay
- [x] 699 lib tests + all integration suites pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed card navigation: selecting cards with j/k and arrow keys now properly synchronizes with the embedded pane controller.

* **Documentation**
  * Updated getting-started guide to document j/k and arrow key navigation for cycling through cards.
  * Updated keyboard shortcuts reference with j/k and arrow key bindings for card selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vfarcic/dot-agent-deck/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->