### PR TITLE
fix(prd-100): route orchestrator spawn-time write through atomic WriteAndSubmit RPC

### DIFF
--- a/changelog.d/100.fix.md
+++ b/changelog.d/100.fix.md
@@ -1,0 +1,7 @@
+## Fix Orchestrator Spawn-Time Role Prompt Not Submitting
+
+When orchestration starts, the deck automatically injects the initial role prompt into the orchestrator agent's input. The trailing Enter sometimes did not trigger submission — instead, the cursor dropped to a new line inside the input box with the prompt text un-submitted.
+
+Root cause: the TUI client's spawn-time write used two `KIND_STREAM_IN` frames separated by a 150ms sleep. The daemon's per-agent writer mutex was released between frames, leaving a window during which a concurrent daemon-initiated write (e.g. a sibling worker's work-done feedback) could interleave, fusing its payload and CR into the gap. The orchestrator agent then saw the daemon's CR first — submitting the fused line — and the user's trailing CR landed in an empty input box and was rendered as a newline.
+
+Fix: a new `WriteAndSubmit` RPC routes the spawn-time injection through the daemon's existing `write_to_pane_and_submit` primitive, which holds the per-agent writer mutex across the full `payload → SUBMIT_DELAY → CR` sequence — the same atomic contract used by the daemon-initiated orchestration-delegate path, which has always worked correctly.

--- a/prds/100-fix-orchestrator-enter-key-newline.md
+++ b/prds/100-fix-orchestrator-enter-key-newline.md
@@ -1,6 +1,6 @@
 # PRD #100: Fix Orchestrator Spawn-Time Role Prompt Sometimes Not Submitting
 
-**Status**: Planning (second attempt — see "Prior attempt" section)
+**Status**: Implementation complete (second attempt) — pending release
 **Priority**: High
 **Created**: 2026-05-21
 **Updated**: 2026-05-25
@@ -82,22 +82,36 @@ Lessons for the next attempt:
 
 ### Phase 1: Investigation (byte traces first)
 
-- [ ] **M1.1** — Re-add minimal `RUST_LOG=trace`-gated instrumentation on the pane write path if not already present. PR #122's branch has a working version under `target: "pane_write"` that can be cherry-picked.
-- [ ] **M1.2** — Capture a byte-level trace of a failing spawn-time client → orchestrator submit. Repeat orchestration starts as needed until a failure is captured.
-- [ ] **M1.3** — Capture a byte-level trace of a working orchestrator → worker delegation submit for comparison.
-- [ ] **M1.4** — Diff the two traces. Document the byte-level difference. That difference IS the bug.
+- [~] **M1.1** — Re-add minimal `RUST_LOG=trace`-gated instrumentation on the pane write path. **Skipped by user decision** — added in commit e244dfc, then reverted before any user-facing change. See "Implementation decisions" below.
+- [~] **M1.2** — Capture a byte-level trace of a failing spawn-time submit. **Skipped by user decision** — see "Implementation decisions" below.
+- [~] **M1.3** — Capture a byte-level trace of a working delegation submit. **Skipped by user decision** — but the regression test's toggle-verify produced an equivalent synthetic snapshot (fused payload pattern `ROLE-PROMPT-MARKERDAEMON-FEEDBACK-MARKER\r\n...`) confirming the interleave hypothesis.
+- [~] **M1.4** — Diff the two traces. **Skipped by user decision** — bridged structurally instead: the failing path is the TUI-client's two-frame STREAM_IN pattern; the working path is the daemon-side `AgentPtyRegistry::write_to_pane_and_submit` atomic primitive. The fix routes the failing call site to the same primitive.
 
 ### Phase 2: Minimal fix
 
-- [ ] **M2.1** — Implement the smallest change at the spawn-time call site that makes its byte stream match the working delegation path's. No protocol bumps, no new validation, no cross-cutting behavior changes.
-- [ ] **M2.2** — Add a regression test that exercises the spawn-time path specifically. Test must fail before M2.1's change and pass after — toggle-verify.
+- [x] **M2.1** — Implemented in commit `1129c024` (`fix(prd-100): route orchestrator spawn-time write through atomic WriteAndSubmit RPC`). New `AttachRequest::WriteAndSubmit { pane_id, text }` variant + handler arm in `src/daemon_protocol.rs`; trait method `write_and_submit_to_pane` with default impl in `src/pane.rs`; `EmbeddedPaneController` override in `src/embedded_pane.rs`; client one-shot RPC in `src/daemon_client.rs`; single call-site swap at `src/ui.rs:3733`. **PROTOCOL_VERSION 2 → 3 deliberately bumped — see "Implementation decisions" below.** Seven other `write_to_pane` callers (`ui.rs:1630, 3294, 3297, 4177, 4509, 4780, 5100, 5106, 5156`) intentionally left unchanged — out of scope.
+- [x] **M2.2** — Regression test at `tests/spawn_time_role_prompt_atomic.rs::spawn_time_role_prompt_is_atomic_against_concurrent_daemon_write`. Toggle-verified PASS-PASS — with the fix, test passes; with the swap reverted to legacy `write_to_pane`, test fails with the fused-payload snapshot above.
 
 ### Phase 3: Validation and release
 
-- [ ] **M3.1** — Manual smoke: 10 consecutive orchestration starts, each role prompt arrives and submits on its own. Document the pass.
-- [ ] **M3.2** — Run the existing test suite (`cargo test`); confirm no regression for other agents (Claude Code, OpenCode) or other pane write paths.
-- [ ] **M3.3** — Changelog fragment via `dot-ai-changelog-fragment`. Frame as a bug fix.
+- [~] **M3.1** — 10-start manual smoke. **Skipped by user decision** — post-merge validation preferred. See "Implementation decisions" below.
+- [x] **M3.2** — Full `cargo test` green: 896 passed / 0 failed (including the new regression test). `cargo fmt --check` clean. `cargo clippy --all-targets -- -D warnings` clean.
+- [ ] **M3.3** — Changelog fragment via `dot-ai-changelog-fragment` (release flow).
 - [ ] **M3.4** — PR, review, audit, merge, close.
+
+## Implementation decisions
+
+Recorded for the audit trail — these are deliberate departures from the PRD as written, made explicitly during the implementation conversation.
+
+1. **Skip Phase 1 trace investigation (M1.1–M1.4).** The PRD mandates capturing byte-level traces of a failing vs. working submit before writing the fix, as the antidote to PR #122's hypothesis-without-evidence failure mode. The user opted to skip this — viewing trace instrumentation as unnecessary diagnostic scaffolding — and proceed with a minimal hypothesis-based fix validated post-merge. Risk accepted: if the interleave hypothesis is wrong, the fix won't resolve the bug and we'll discover that empirically rather than via trace evidence. Partial mitigation: the regression test's toggle-verify produced a synthetic fused-payload snapshot consistent with the interleave hypothesis (not a true byte trace from a live failure, but the same predicted byte pattern).
+
+2. **Bump `PROTOCOL_VERSION` 2 → 3.** PRD "Out of Scope" forbids this. Override approved after coder's structural analysis showed no v2-compatible path is also minimal ("tens of lines"): the TUI client's only byte-write surface is `KIND_STREAM_IN` frames, the daemon's writer-mutex semantics are per-frame, and the agent (Claude Code) won't submit a fused payload+CR — so the atomic contract requires *some* new mechanism for the client to invoke `write_to_pane_and_submit` on the daemon. The PRD's no-bump rule was a guardrail against PR #122's cross-cutting scope creep, not a structural taboo against any protocol change. Applied narrowly here: one variant, one handler, one client method, one call-site swap. None of PR #122's scope creep (1 MiB cap, `is_valid_pane_id_env` validation, `encode_pane_payload` error-semantics change, PII tracing, fan-out across other callers) is included.
+
+3. **Skip M3.1 pre-merge 10-start smoke.** User will validate empirically after the PR merges, per their stated preference.
+
+4. **Hold the fix to the orchestrator spawn-time call site only.** Seven other `write_to_pane` callers (send-prompt dialog, agent init commands, mode-manager shell setup, permission y/n forwarding, orchestration restoration) retain the legacy two-STREAM_IN-frames-with-gap pattern and may have the same latent race. PRD #100's scope is strictly the user-reported orchestrator symptom. A future "finish PRD #93 — move remaining TUI writes daemon-side" PRD is the right vehicle for the broader cleanup; not relevant to this fix.
+
+5. **Reviewer suggestion declined: comment at `ui.rs:3733`.** Reviewer suggested adding a comment referencing the regression test to make accidental swap-back harder. Declined per CLAUDE.md guidance to avoid task-/PR-reference comments that rot; the method name (`write_and_submit_to_pane`) plus the regression test are the defense.
 
 ## Key Files (preliminary — confirm during M1)
 

--- a/prds/done/100-fix-orchestrator-enter-key-newline.md
+++ b/prds/done/100-fix-orchestrator-enter-key-newline.md
@@ -1,6 +1,6 @@
 # PRD #100: Fix Orchestrator Spawn-Time Role Prompt Sometimes Not Submitting
 
-**Status**: Implementation complete (second attempt) — pending release
+**Status**: Complete — merged 2026-05-25
 **Priority**: High
 **Created**: 2026-05-21
 **Updated**: 2026-05-25

--- a/src/daemon_client.rs
+++ b/src/daemon_client.rs
@@ -260,6 +260,34 @@ impl DaemonClient {
             .ok_or_else(|| ClientError::Malformed("start-agent ok but no id in response".into()))
     }
 
+    /// PRD #100: route a pane write through the daemon's atomic
+    /// `write_to_pane_and_submit` primitive instead of the
+    /// two-`STREAM_IN`-frames-with-gap pattern. Same one-shot connection
+    /// shape as `resize_agent` / `stop_agent`. The daemon holds the
+    /// per-agent writer mutex across `payload → SUBMIT_DELAY → CR`, so a
+    /// concurrent daemon-initiated write (work-done feedback, respawn
+    /// notice) cannot interleave between the payload and the submit CR.
+    pub async fn write_and_submit(&self, pane_id: &str, text: &str) -> Result<(), ClientError> {
+        let stream = self.connect().await?;
+        let (mut rd, mut wr) = stream.into_split();
+        let resp = issue_command(
+            &mut rd,
+            &mut wr,
+            &AttachRequest::WriteAndSubmit {
+                pane_id: pane_id.to_string(),
+                text: text.to_string(),
+            },
+        )
+        .await?;
+        if !resp.ok {
+            return Err(ClientError::Server(
+                resp.error
+                    .unwrap_or_else(|| "write-and-submit failed".into()),
+            ));
+        }
+        Ok(())
+    }
+
     /// Push a TUI pane resize through to the daemon's PTY. Idempotent on the
     /// wire: each call opens a fresh short-lived connection (matching the
     /// pattern used for `stop_agent` / `list_agents`). Callers that fire

--- a/src/daemon_protocol.rs
+++ b/src/daemon_protocol.rs
@@ -142,7 +142,7 @@ pub const KIND_SHUTDOWN_ACK: u8 = 0x16;
 /// Additive `#[serde(default, skip_serializing_if = "Option::is_none")]`
 /// fields do NOT require a bump — they're forward-compatible by design. See
 /// the module-level "Protocol versioning" section for the full bump policy.
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 
 /// Hard cap on a single frame's payload length. Defends against a malicious
 /// or buggy peer trying to allocate gigabytes off a forged length prefix.
@@ -313,6 +313,24 @@ pub enum AttachRequest {
         display_name: Option<String>,
         #[serde(default)]
         cwd: Option<String>,
+    },
+    /// PRD #100: atomic write-and-submit RPC. Routes the client's
+    /// `pane_id` + `text` straight to
+    /// [`crate::agent_pty::AgentPtyRegistry::write_to_pane_and_submit`]
+    /// on the daemon side, which holds the per-agent writer mutex across
+    /// the full `payload → SUBMIT_DELAY → CR` sequence (PRD #93 round-8
+    /// atomic contract). Lets a TUI client trigger the same atomic
+    /// byte stream the daemon-initiated orchestration-delegate path
+    /// already produces — without the two-`STREAM_IN`-frames-with-150ms-gap
+    /// pattern, whose mid-sequence mutex release lets a concurrent
+    /// daemon-initiated write interleave and fuse a daemon-side CR onto
+    /// the user's payload, submitting it prematurely. The user's
+    /// trailing CR then lands in an empty input box and is rendered as
+    /// a newline — PRD #100's "Enter inserted a newline instead of
+    /// submitting" symptom.
+    WriteAndSubmit {
+        pane_id: String,
+        text: String,
     },
     /// PRD #76 M2.17: long-lived subscription to the daemon's
     /// `AgentEvent` broadcast. Server replies with an OK `RESP` then
@@ -927,6 +945,12 @@ async fn handle_connection(
             Ok(()) => write_resp(&mut stream, &AttachResponse::ok()).await?,
             Err(e) => write_resp(&mut stream, &AttachResponse::err(e.to_string())).await?,
         },
+        AttachRequest::WriteAndSubmit { pane_id, text } => {
+            match registry.write_to_pane_and_submit(&pane_id, &text).await {
+                Ok(()) => write_resp(&mut stream, &AttachResponse::ok()).await?,
+                Err(e) => write_resp(&mut stream, &AttachResponse::err(e.to_string())).await?,
+            }
+        }
         AttachRequest::SubscribeEvents => {
             handle_subscribe_events(stream, event_tx).await?;
         }

--- a/src/embedded_pane.rs
+++ b/src/embedded_pane.rs
@@ -1774,6 +1774,24 @@ impl PaneController for EmbeddedPaneController {
         Ok(())
     }
 
+    /// PRD #100: atomic counterpart of [`Self::write_to_pane`]. Routes
+    /// through the new `WriteAndSubmit` RPC so the daemon holds its
+    /// per-agent writer mutex across `payload → SUBMIT_DELAY → CR`,
+    /// matching the daemon-initiated `write_to_pane_and_submit` contract.
+    /// Used at the orchestrator spawn-time role-prompt injection site
+    /// in `ui.rs`, where a concurrent daemon-initiated write (e.g.
+    /// work-done feedback for a sibling worker) could otherwise
+    /// interleave into the legacy two-frame path's mid-sequence gap and
+    /// submit the user's prompt with daemon bytes fused in.
+    fn write_and_submit_to_pane(&self, pane_id: &str, text: &str) -> Result<(), PaneError> {
+        let client = self.client.clone();
+        let pane_id = pane_id.to_string();
+        let text = text.to_string();
+        self.runtime
+            .block_on(async move { client.write_and_submit(&pane_id, &text).await })
+            .map_err(|e| PaneError::CommandFailed(format!("write_and_submit: {e}")))
+    }
+
     fn name(&self) -> &str {
         "embedded"
     }

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -332,6 +332,22 @@ pub trait PaneController: Send + Sync {
     fn rename_pane(&self, pane_id: &str, name: &str) -> Result<RenameOutcome, PaneError>;
     fn toggle_layout(&self) -> Result<(), PaneError>;
     fn write_to_pane(&self, pane_id: &str, text: &str) -> Result<(), PaneError>;
+    /// PRD #100: write `text` to `pane_id` and submit atomically — the
+    /// daemon side holds its per-agent writer mutex across the full
+    /// `payload → SUBMIT_DELAY → CR` sequence, matching the contract
+    /// `AgentPtyRegistry::write_to_pane_and_submit` provides to
+    /// daemon-initiated callers (orchestration delegate / work-done
+    /// feedback). The default impl forwards to [`Self::write_to_pane`],
+    /// which is the historical two-`STREAM_IN`-frames-with-gap pattern
+    /// — fine for test mocks and any caller whose pane has no
+    /// concurrent same-pane writer in production. The
+    /// `EmbeddedPaneController` impl overrides this with the atomic
+    /// `WriteAndSubmit` RPC; the orchestrator spawn-time role-prompt
+    /// injection in `ui.rs` uses the override because it shares its
+    /// pane with daemon-initiated writes.
+    fn write_and_submit_to_pane(&self, pane_id: &str, text: &str) -> Result<(), PaneError> {
+        self.write_to_pane(pane_id, text)
+    }
     fn name(&self) -> &str;
     fn is_available(&self) -> bool;
     fn as_any(&self) -> &dyn Any;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3730,7 +3730,7 @@ pub fn run_tui(
                         .is_some_and(|t| t.elapsed() > std::time::Duration::from_secs(10));
                 if agent_ready || timeout_ready {
                     if let Some(prompt) = orchestrator_prompt.take() {
-                        let _ = pane.write_to_pane(start_pane_id, &prompt);
+                        let _ = pane.write_and_submit_to_pane(start_pane_id, &prompt);
                     }
                     role_statuses[*start_role_index] = OrchestrationRoleStatus::Working;
                     ui.orchestration_prompted.insert(*id);

--- a/tests/spawn_time_role_prompt_atomic.rs
+++ b/tests/spawn_time_role_prompt_atomic.rs
@@ -1,0 +1,266 @@
+//! PRD #100 regression: the orchestrator spawn-time role-prompt
+//! injection (`ui.rs::pane.write_and_submit_to_pane(start_pane_id, &prompt)`)
+//! must produce the same atomic byte stream as the working
+//! daemon-initiated orchestration-delegate path
+//! (`AgentPtyRegistry::write_to_pane_and_submit`).
+//!
+//! The bug: the legacy `PaneController::write_to_pane` queued two
+//! `KIND_STREAM_IN` frames (payload, then `\r`) separated by a
+//! `std::thread::sleep(SUBMIT_DELAY)`. The daemon's per-agent writer
+//! mutex was released between the frames, so a concurrent
+//! daemon-initiated `write_to_pane_and_submit` on the same pane
+//! (e.g. a sibling worker's work-done feedback firing while the
+//! orchestrator's role prompt was still in flight) could land its
+//! full payload + CR sequence into the gap. The receiving agent then
+//! saw `[user payload][daemon payload][daemon \r][user \r]` — the
+//! daemon's CR submitted the fused line; the user's trailing CR
+//! landed in an empty input box and was rendered as a newline. This
+//! is the "Enter inserted a newline into the orchestrator's input
+//! instead of submitting" symptom the PRD #100 issue reports.
+//!
+//! This test pins the contract at the controller layer (one level
+//! below the `ui.rs:3733` call site, which is buried in a render
+//! loop and not directly drivable from an integration test). It
+//! drives a concurrent two-writer race against a `cat -u` PTY:
+//!
+//! - Task A: `EmbeddedPaneController::write_and_submit_to_pane`
+//!   (the new atomic RPC path — `WriteAndSubmit` over the wire,
+//!   handled in-process by `AgentPtyRegistry::write_to_pane_and_submit`).
+//! - Task B: `AgentPtyRegistry::write_to_pane_and_submit` direct
+//!   in-process call (matches the daemon-initiated work-done
+//!   feedback path at `state.rs::handle_work_done`).
+//!
+//! With the fix, both writers' payload+CR sequences serialize on the
+//! per-agent writer mutex — neither fuses into the other. `cat -u`
+//! echoes both as CLEAN separate lines.
+//!
+//! Toggle-verify: temporarily swap task A's `write_and_submit_to_pane`
+//! call to `write_to_pane` (the legacy two-frames-with-gap path) and
+//! the `ROLE-PROMPT-MARKER\r\n` contiguous-bytes assertion below
+//! fails — the daemon-initiated CR submits the fused line, so
+//! `ROLE-PROMPT-MARKER` is followed by `DAEMON-FEEDBACK-MARKER`
+//! rather than `\r\n`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+
+use dot_agent_deck::agent_pty::AgentPtyRegistry;
+use dot_agent_deck::daemon::{Daemon, run_daemon_with};
+use dot_agent_deck::embedded_pane::EmbeddedPaneController;
+use dot_agent_deck::pane::{AgentSpawnOptions, PaneController};
+use dot_agent_deck::state::{AppState, SharedState};
+
+mod common;
+
+static HARNESS_BIND_LOCK: Mutex<()> = Mutex::new(());
+
+struct DaemonHandle {
+    _dir: TempDir,
+    attach_path: PathBuf,
+    pty_registry: Arc<AgentPtyRegistry>,
+    handle: JoinHandle<()>,
+}
+
+impl Drop for DaemonHandle {
+    fn drop(&mut self) {
+        self.handle.abort();
+        self.pty_registry.shutdown_all();
+    }
+}
+
+async fn spawn_daemon() -> DaemonHandle {
+    common::init_test_env();
+    let (dir, hook_path, attach_path) = {
+        let _g = HARNESS_BIND_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = common::race_safe_tempdir();
+        let hook = dir.path().join("hook.sock");
+        let attach = dir.path().join("attach.sock");
+        (dir, hook, attach)
+    };
+
+    let state: SharedState = Arc::new(RwLock::new(AppState::default()));
+    let daemon = Daemon::with_attach(state, attach_path.clone())
+        .with_idle_shutdown(None)
+        .with_lock_dir_override(common::lock_dir_path());
+    let pty_registry = daemon.pty_registry.clone();
+
+    let hook_for_daemon = hook_path.clone();
+    let handle = tokio::spawn(async move {
+        let _ = run_daemon_with(&hook_for_daemon, daemon).await;
+    });
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline {
+        if attach_path.exists() && UnixStream::connect(&attach_path).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        attach_path.exists(),
+        "attach socket did not appear within 5s"
+    );
+
+    DaemonHandle {
+        _dir: dir,
+        attach_path,
+        pty_registry,
+        handle,
+    }
+}
+
+async fn wait_for_bytes_in_snapshot(
+    registry: &AgentPtyRegistry,
+    agent_id: &str,
+    needle: &[u8],
+    timeout: Duration,
+) -> Vec<u8> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if let Ok(snap) = registry.snapshot(agent_id)
+            && snap.windows(needle.len()).any(|w| w == needle)
+        {
+            return snap;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    registry.snapshot(agent_id).unwrap_or_default()
+}
+
+/// PRD #100 regression: concurrent client-initiated atomic write and
+/// daemon-initiated `write_to_pane_and_submit` against the same pane
+/// must serialize — neither writer's payload may fuse with the other
+/// across the legacy two-`STREAM_IN`-frame gap.
+///
+/// Sequence:
+///   1. Spawn a `cat -u` agent via the controller (so the pane is
+///      registered on both the local controller AND the daemon).
+///   2. Spawn task A: `EmbeddedPaneController::write_and_submit_to_pane`
+///      with "ROLE-PROMPT-MARKER". (Routes through the new atomic
+///      `WriteAndSubmit` RPC.)
+///   3. After a short delay (designed to land inside the legacy
+///      path's mid-sequence mutex gap — for the OLD `write_to_pane`),
+///      kick off task B: `AgentPtyRegistry::write_to_pane_and_submit`
+///      with "DAEMON-FEEDBACK-MARKER". (Matches `handle_work_done`'s
+///      direct in-process call.)
+///   4. Wait for both to complete and assert `cat -u`'s scrollback
+///      contains `ROLE-PROMPT-MARKER\r\n` as a CONTIGUOUS byte
+///      sequence — proves the atomic boundary held and no daemon
+///      bytes were spliced into the user payload before the submit CR.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn spawn_time_role_prompt_is_atomic_against_concurrent_daemon_write() {
+    let daemon = spawn_daemon().await;
+
+    let controller = Arc::new(EmbeddedPaneController::new(
+        daemon.attach_path.clone(),
+        tokio::runtime::Handle::current(),
+    ));
+
+    // Spawn via the controller so the pane is registered on BOTH the
+    // local controller (`self.panes`) AND the daemon registry. This
+    // mirrors the production spawn-time setup and makes the legacy
+    // `write_to_pane` path (used in the toggle-verify edit) reachable
+    // — without local registration, `queue_stream_input` would fail
+    // with "pane not found" before the atomicity assertion runs.
+    let controller_for_spawn = controller.clone();
+    let (pane_id, _resolved) = tokio::task::spawn_blocking(move || {
+        controller_for_spawn
+            .create_pane_with_options(Some("cat -u"), None, AgentSpawnOptions::default())
+            .expect("create_pane_with_options")
+    })
+    .await
+    .expect("join spawn task");
+
+    // Look up the daemon-side agent id by matching pane_id_env. The
+    // controller-spawned agent's pane_id_env equals the locally
+    // allocated `pane_id` (see `create_stream_pane`).
+    let agent_id = {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            let records = daemon.pty_registry.agent_records();
+            if let Some(rec) = records
+                .iter()
+                .find(|r| r.pane_id_env.as_deref() == Some(pane_id.as_str()))
+            {
+                break rec.id.clone();
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!("daemon registry never surfaced agent for pane_id {pane_id}");
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    };
+
+    let role_prompt = "ROLE-PROMPT-MARKER";
+    let daemon_feedback = "DAEMON-FEEDBACK-MARKER";
+
+    let controller_for_task_a = controller.clone();
+    let pane_for_task_a = pane_id.clone();
+    let role_prompt_for_task_a = role_prompt.to_string();
+    let task_a = tokio::task::spawn_blocking(move || {
+        controller_for_task_a
+            .write_and_submit_to_pane(&pane_for_task_a, &role_prompt_for_task_a)
+            .expect("write_and_submit_to_pane on task A")
+    });
+
+    // Kick task B partway into task A's expected write window. For
+    // the OLD `write_to_pane` (toggle-verify), task A holds no mutex
+    // between its two `STREAM_IN` frames and its `std::thread::sleep`
+    // is 150 ms — 40 ms lands the daemon-initiated write deep inside
+    // that gap. For the new atomic RPC, the daemon holds the writer
+    // mutex end-to-end, so task B blocks until task A releases.
+    tokio::time::sleep(Duration::from_millis(40)).await;
+
+    let registry_for_task_b = daemon.pty_registry.clone();
+    let pane_for_task_b = pane_id.clone();
+    let daemon_feedback_for_task_b = daemon_feedback.to_string();
+    let task_b = tokio::spawn(async move {
+        registry_for_task_b
+            .write_to_pane_and_submit(&pane_for_task_b, &daemon_feedback_for_task_b)
+            .await
+            .expect("write_to_pane_and_submit on task B")
+    });
+
+    task_a.await.expect("join task A");
+    task_b.await.expect("join task B");
+
+    // Both writers' payloads must echo cleanly back through cat -u's
+    // stdout. The crucial assertion is that `ROLE-PROMPT-MARKER\r\n`
+    // appears as a CONTIGUOUS byte sequence — a fused failure mode
+    // would have `ROLE-PROMPT-MARKERDAEMON-FEEDBACK-MARKER` between
+    // the marker and the CRLF.
+    // Wait for the LATER of the two echoes — task B runs after task
+    // A, so `DAEMON-FEEDBACK-MARKER\r\n` is the trailing event. Once
+    // its echo lands the scrollback is guaranteed to contain the full
+    // serialized output of both writers (whatever order they fused
+    // in).
+    let snap = wait_for_bytes_in_snapshot(
+        &daemon.pty_registry,
+        &agent_id,
+        b"DAEMON-FEEDBACK-MARKER\r\n",
+        Duration::from_secs(5),
+    )
+    .await;
+    assert!(
+        snap.windows(b"ROLE-PROMPT-MARKER\r\n".len())
+            .any(|w| w == b"ROLE-PROMPT-MARKER\r\n"),
+        "atomic contract violated: ROLE-PROMPT-MARKER\\r\\n must appear as a contiguous \
+         sequence in the cat -u echo, proving no daemon bytes were spliced into the user \
+         payload before the submit CR. snapshot = {:?}",
+        String::from_utf8_lossy(&snap)
+    );
+    assert!(
+        snap.windows(b"DAEMON-FEEDBACK-MARKER\r\n".len())
+            .any(|w| w == b"DAEMON-FEEDBACK-MARKER\r\n"),
+        "daemon-initiated write must also surface its own clean echo line; \
+         absence indicates the two writes never serialized. snapshot = {:?}",
+        String::from_utf8_lossy(&snap)
+    );
+}


### PR DESCRIPTION
## Description

Second attempt at [#100](https://github.com/vfarcic/dot-agent-deck/issues/100) — Fix Orchestrator Spawn-Time Role Prompt Sometimes Not Submitting. The first attempt (PR #122) was closed for scope creep; this PR is deliberately narrow and addresses only the confirmed failing call site.

## Root Cause

The TUI client's spawn-time orchestrator role-prompt injection (`ui.rs:3733`) used to call `PaneController::write_to_pane`, which queued two `KIND_STREAM_IN` frames separated by a `std::thread::sleep(SUBMIT_DELAY)`. The daemon's per-agent writer mutex was released between frames, leaving a ~150ms window during which a concurrent daemon-initiated write (e.g. a sibling worker's work-done feedback arriving on the same pane) could interleave. The orchestrator agent would see `[user payload][daemon payload][daemon \r][user \r]` — the daemon's CR submitted the fused line; the user's trailing CR landed in an empty input box and rendered as a newline. That is PRD #100's reported symptom.

## Fix

A new `AttachRequest::WriteAndSubmit` RPC variant routes the spawn-time injection through the daemon's existing `AgentPtyRegistry::write_to_pane_and_submit` primitive, which holds the per-agent writer mutex across the full `payload → SUBMIT_DELAY → CR` sequence. This is the same atomic contract already used by the daemon-initiated orchestration-delegate path — the path that has always worked correctly.

**Changed files:**
- `src/daemon_protocol.rs` — new `WriteAndSubmit { pane_id, text }` variant + handler arm
- `src/pane.rs` — `write_and_submit_to_pane` trait method with default fallback
- `src/embedded_pane.rs` — `EmbeddedPaneController` override calling the new RPC
- `src/daemon_client.rs` — one-shot RPC client method
- `src/ui.rs` — **single call-site swap** at line 3733 (spawn-time role-prompt write)
- `tests/spawn_time_role_prompt_atomic.rs` — regression test (toggle-verified PASS-PASS)

## Deliberate PROTOCOL_VERSION 2 → 3 bump

PRD #100 originally said "no PROTOCOL_VERSION bump." That rule was a guardrail against PR #122's cross-cutting scope creep. This PR includes **none** of PR #122's scope:
- No 1 MiB payload cap
- No `is_valid_pane_id_env` validation
- No `encode_pane_payload` error-semantics change
- No PII-aware tracing across four files
- No fan-out to other `write_to_pane` callers

The bump to v3 is a deliberate, user-approved scoped override. The structural reason: `STREAM_IN`'s per-frame mutex semantics are fundamentally incompatible with an atomic `payload+SUBMIT_DELAY+CR` contract initiated from the client side; no v2-compatible path exists at the "tens of lines" scale the PRD also requires.

## Scope cap — 7 other callers intentionally NOT migrated

The following `write_to_pane` callers in `ui.rs` retain the legacy two-frame pattern:
- `ui.rs:1630, 3294, 3297, 4177, 4509, 4780, 5100, 5106, 5156`
(send-prompt dialog, agent init commands, mode-manager shell setup, permission y/n forwarding, orchestration restoration)

These are out of PRD #100's scope. A future "finish PRD #93" PRD is the right vehicle for the broader cleanup.

## Regression test

`tests/spawn_time_role_prompt_atomic.rs` drives a concurrent two-writer race against a `cat -u` PTY. Task A goes through `write_and_submit_to_pane` (the new path); Task B is a direct in-process `registry.write_to_pane_and_submit` (mirrors the daemon-side work-done feedback path). The assertion is that the role-prompt marker appears as a contiguous byte sequence in the PTY echo, proving no daemon bytes were spliced in.

**Toggle-verified:** swapping Task A's call from `write_and_submit_to_pane` → `write_to_pane` reproduces the fused-payload snapshot and fails the test; restoring the call passes.

## Test plan

- Automated regression test: passes (toggle-verified)
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: 896 passed / 0 failed
- Manual smoke (post-merge): user will start orchestration 10× and confirm role prompt submits on its own every time

Closes #100

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed orchestrator spawn-time role prompt submission reliability issue caused by frame interleaving; implemented atomic write-and-submit mechanism to ensure reliable delivery.

* **Tests**
  * Added regression test to verify spawn-time role prompt atomicity under concurrent daemon operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vfarcic/dot-agent-deck/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->