### PR TITLE
fix(test): stop leaked daemons orphaning to PID 1 on abrupt test exit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ cron = "0.16.0"
 tempfile = "3"
 tokio-test = "0.4"
 serial_test = "3"
+# Integration tests don't inherit the package's `[dependencies]`, so the
+# harness/L2 tests need `libc` listed here to call `kill(2)` directly (process-
+# group cleanup on Drop; orphan-exit liveness polling).
+libc = "0.2"
 # PRD #77 Decision 22: insta pinned to a specific version, not `latest`,
 # so a future patch release cannot silently reshape snapshot diffs.
 insta = { version = "=1.47.2", features = ["yaml"] }

--- a/changelog.d/138.misc.md
+++ b/changelog.d/138.misc.md
@@ -1,0 +1,10 @@
+## Test daemons no longer leak to PID 1 on abrupt exit
+
+The integration/E2E harness disables daemon idle-shutdown for determinism and only cleaned daemons up in `Drop`, which never runs on `SIGKILL` / panic-abort / nextest-timeout / `Ctrl-C`. Such daemons orphaned to `init` (PID 1) and kept running for hours after a test run died abruptly.
+
+Two env-gated, test-only daemon self-defense nets now prevent this (both OFF by default, so detached/lazy-spawned production daemons are unaffected):
+
+- `DOT_AGENT_DECK_EXIT_WHEN_ORPHANED` — the daemon captures its parent pid at startup and gracefully shuts down once it is orphaned (parent becomes PID 1 or otherwise changes).
+- `DOT_AGENT_DECK_TEST_MAX_LIFETIME_SECS` — a hard backstop that self-exits after N seconds regardless, covering detached daemons the orphan watchdog can't help.
+
+Harness `Drop` paths additionally reap the whole process group so a daemon's spawned agents go down with it. New L2 test `lifecycle/orphan-exit/001` proves an orphaned, idle-disabled daemon self-exits within seconds.

--- a/src/agent_pty.rs
+++ b/src/agent_pty.rs
@@ -54,6 +54,22 @@ pub const DOT_AGENT_DECK_PANE_ID: &str = "DOT_AGENT_DECK_PANE_ID";
 /// literals can't drift apart.
 pub const DOT_AGENT_DECK_AGENT_ID: &str = "DOT_AGENT_DECK_AGENT_ID";
 
+/// Test-only safety watchdog: when set truthy (`1`/`true`/`yes`/`on`), a
+/// `daemon serve` captures its parent pid at startup and gracefully exits once
+/// it is orphaned (parent becomes `init`/pid 1, or otherwise changes). OFF by
+/// default — production daemons are intentionally detached/lazy-spawned and
+/// would be orphaned from birth, so the watchdog only runs when a test sets
+/// this. Stops idle-disabled test daemons from leaking to PID 1 when the test
+/// process dies without running `Drop` (SIGKILL / panic-abort / nextest
+/// timeout / Ctrl-C).
+pub const DOT_AGENT_DECK_EXIT_WHEN_ORPHANED: &str = "DOT_AGENT_DECK_EXIT_WHEN_ORPHANED";
+
+/// Test-only backstop: when set to a positive integer, a `daemon serve`
+/// gracefully self-exits after that many seconds no matter what. Unset = no cap
+/// (production unaffected). Belt-and-suspenders for anything that slips past the
+/// orphan watchdog (e.g. a detached test daemon whose parent is already PID 1).
+pub const DOT_AGENT_DECK_TEST_MAX_LIFETIME_SECS: &str = "DOT_AGENT_DECK_TEST_MAX_LIFETIME_SECS";
+
 /// Hard upper bound on PTY rows/cols accepted by the daemon. Larger values
 /// are clamped down before reaching `MasterPty::resize`. The cap defends
 /// against a same-uid attach-socket peer perturbing an existing agent's

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10,7 +10,10 @@ use tokio::net::UnixListener;
 use tokio::sync::{Notify, broadcast};
 use tracing::{error, info, warn};
 
-use crate::agent_pty::{AgentPtyRegistry, DOT_AGENT_DECK_IDLE_SHUTDOWN_SECS};
+use crate::agent_pty::{
+    AgentPtyRegistry, DOT_AGENT_DECK_EXIT_WHEN_ORPHANED, DOT_AGENT_DECK_IDLE_SHUTDOWN_SECS,
+    DOT_AGENT_DECK_TEST_MAX_LIFETIME_SECS,
+};
 use crate::error::DaemonError;
 use crate::event::{AgentEvent, BroadcastMsg, DaemonMessage};
 use crate::scheduler::Scheduler;
@@ -38,6 +41,50 @@ pub fn idle_shutdown_from_env() -> Option<Duration> {
     } else {
         Some(Duration::from_secs(secs))
     }
+}
+
+// ---------------------------------------------------------------------------
+// Test-only self-defense: orphan watchdog + max-lifetime backstop.
+//
+// These exist so an idle-disabled TEST daemon (`IDLE_SHUTDOWN_SECS=0`) can't
+// leak to PID 1 when the test process dies without running its cleanup `Drop`
+// (SIGKILL / panic-abort / nextest timeout / Ctrl-C). Both are env-gated and
+// OFF by default, so production detached/lazy-spawned daemons are unaffected.
+// ---------------------------------------------------------------------------
+
+/// Parse a truthy env flag value: `1` / `true` / `yes` / `on`
+/// (case-insensitive, surrounding whitespace ignored). Everything else
+/// (including unset → empty, `0`, `false`) is false.
+pub fn parse_bool_flag(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+/// Parse the max-lifetime backstop: `Some(Duration)` for a positive integer
+/// number of seconds, `None` otherwise (unset, empty, `0`, or unparseable —
+/// meaning "no cap").
+pub fn parse_max_lifetime_secs(value: &str) -> Option<Duration> {
+    match value.trim().parse::<u64>() {
+        Ok(secs) if secs > 0 => Some(Duration::from_secs(secs)),
+        _ => None,
+    }
+}
+
+/// The orphan decision: a daemon should exit when its current parent is `init`
+/// (pid 1 — reparented after the original parent died) OR differs from the
+/// parent captured at startup (covers a sub-reaper that isn't pid 1). Pure so
+/// the policy is unit-testable without a real fork.
+pub fn should_exit_orphaned(original_ppid: i32, current_ppid: i32) -> bool {
+    current_ppid == 1 || current_ppid != original_ppid
+}
+
+/// The calling process's parent pid. Wraps `getppid(2)` (async-signal-safe,
+/// infallible) so the single `unsafe` lives in one place.
+fn current_ppid() -> i32 {
+    // SAFETY: `getppid(2)` has no failure mode and no side effects.
+    unsafe { libc::getppid() }
 }
 
 /// Daemon-wide broadcast capacity for hook-event `BroadcastMsg`s forwarded
@@ -428,6 +475,62 @@ pub async fn run_daemon_with(socket_path: &Path, daemon: Daemon) -> Result<(), D
     // expires, the hook loop's `select!` arm wakes up, and the loop exits.
     let shutdown = Arc::new(Notify::new());
 
+    // Test-only orphan watchdog: when `DOT_AGENT_DECK_EXIT_WHEN_ORPHANED` is
+    // truthy, gracefully shut down (via the SAME `shutdown` signal the idle
+    // monitor uses — so sockets/agents tear down cleanly) once this daemon is
+    // orphaned. OFF by default; production daemons never set the var.
+    let orphan_handle = if std::env::var(DOT_AGENT_DECK_EXIT_WHEN_ORPHANED)
+        .map(|v| parse_bool_flag(&v))
+        .unwrap_or(false)
+    {
+        let original_ppid = current_ppid();
+        let shutdown_signal = shutdown.clone();
+        info!(
+            original_ppid,
+            "exit-when-orphaned watchdog armed (test-only safety net)"
+        );
+        Some(tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                let cur = current_ppid();
+                if should_exit_orphaned(original_ppid, cur) {
+                    warn!(
+                        original_ppid,
+                        current_ppid = cur,
+                        "daemon orphaned (parent died/changed); initiating graceful shutdown"
+                    );
+                    shutdown_signal.notify_one();
+                    break;
+                }
+            }
+        }))
+    } else {
+        None
+    };
+
+    // Test-only max-lifetime backstop: when set, gracefully self-exit after the
+    // configured seconds no matter what (catches anything the orphan watchdog
+    // misses, e.g. a detached daemon whose parent is already PID 1). Unset in
+    // production → no cap.
+    let max_lifetime_handle = std::env::var(DOT_AGENT_DECK_TEST_MAX_LIFETIME_SECS)
+        .ok()
+        .and_then(|v| parse_max_lifetime_secs(&v))
+        .map(|dur| {
+            let shutdown_signal = shutdown.clone();
+            info!(
+                secs = dur.as_secs(),
+                "test max-lifetime backstop armed (test-only safety net)"
+            );
+            tokio::spawn(async move {
+                tokio::time::sleep(dur).await;
+                warn!(
+                    secs = dur.as_secs(),
+                    "daemon test max-lifetime reached; initiating graceful shutdown"
+                );
+                shutdown_signal.notify_one();
+            })
+        });
+
     // Optionally start the M1.2 streaming attach server with the shared
     // client counter. We hold its JoinHandle and abort it on exit so it
     // doesn't outlive the daemon.
@@ -511,6 +614,12 @@ pub async fn run_daemon_with(socket_path: &Path, daemon: Daemon) -> Result<(), D
         h.abort();
     }
     scheduler_handle.abort();
+    if let Some(h) = orphan_handle {
+        h.abort();
+    }
+    if let Some(h) = max_lifetime_handle {
+        h.abort();
+    }
     drop(pty_registry);
 
     result
@@ -773,5 +882,54 @@ async fn run_hook_loop(
             }
             } // end accept_res match
         } // end tokio::select!
+    }
+}
+
+#[cfg(test)]
+mod orphan_watchdog_tests {
+    use super::*;
+
+    #[test]
+    fn parse_bool_flag_accepts_truthy_values() {
+        for v in ["1", "true", "TRUE", "Yes", " on ", "On"] {
+            assert!(parse_bool_flag(v), "{v:?} should be truthy");
+        }
+        for v in ["", "0", "false", "no", "off", "2", "enabled"] {
+            assert!(!parse_bool_flag(v), "{v:?} should be falsey");
+        }
+    }
+
+    #[test]
+    fn parse_max_lifetime_secs_only_positive_ints() {
+        assert_eq!(
+            parse_max_lifetime_secs("300"),
+            Some(Duration::from_secs(300))
+        );
+        assert_eq!(parse_max_lifetime_secs(" 5 "), Some(Duration::from_secs(5)));
+        // Unset/empty/zero/garbage → no cap.
+        assert_eq!(parse_max_lifetime_secs(""), None);
+        assert_eq!(parse_max_lifetime_secs("0"), None);
+        assert_eq!(parse_max_lifetime_secs("-1"), None);
+        assert_eq!(parse_max_lifetime_secs("abc"), None);
+    }
+
+    #[test]
+    fn should_exit_orphaned_when_reparented_to_init_or_changed() {
+        let original = 4242;
+        // Reparented to init (pid 1) → orphaned.
+        assert!(should_exit_orphaned(original, 1));
+        // Parent changed to some other pid (sub-reaper) → orphaned.
+        assert!(should_exit_orphaned(original, 9999));
+        // Same original parent still alive → not orphaned.
+        assert!(!should_exit_orphaned(original, original));
+    }
+
+    #[test]
+    fn should_exit_orphaned_handles_init_originated_daemon() {
+        // A daemon whose original parent was already init (detached) and stays
+        // there: current == original == 1. The `== 1` clause reports orphaned,
+        // which is WHY the watchdog must be left OFF for detached production /
+        // TuiDeck daemons — only the harness's non-detached daemons enable it.
+        assert!(should_exit_orphaned(1, 1));
     }
 }

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -772,6 +772,15 @@ Platform coverage column shorthand: **mac+linux** = macOS and Linux (Windows onc
 - **Does not assert:** any fire behavior of the schedule, nor reuse-tab semantics.
 - **Platform coverage:** mac+linux.
 
+#### lifecycle/orphan-exit
+
+##### lifecycle/orphan-exit/001 — An idle-disabled daemon with `DOT_AGENT_DECK_EXIT_WHEN_ORPHANED=1` self-exits gracefully once its parent dies (orphaned to init), instead of leaking to PID 1.
+- **Layer:** L2.
+- **Agent:** none (the daemon runs under a short-lived intermediate `sh` parent the test can kill without killing itself).
+- **Asserts:** after SIGKILLing the intermediate parent, the daemon process terminates within a few seconds, even though idle shutdown is disabled so only the orphan watchdog can end it.
+- **Does not assert:** the max-lifetime backstop (`DOT_AGENT_DECK_TEST_MAX_LIFETIME_SECS`, covered by the daemon pure-data unit tests) or production daemons (the watchdog is OFF unless the env var is set).
+- **Platform coverage:** mac+linux.
+
 #### lifecycle/handshake
 
 ##### lifecycle/handshake/001 — Build-version match on attach proceeds silently into the dashboard.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -395,6 +395,15 @@ impl TuiDeck {
             // Disable the idle-shutdown so the daemon does not race the
             // test by exiting after a brief detach.
             ("DOT_AGENT_DECK_IDLE_SHUTDOWN_SECS", "0"),
+            // Leaked-daemon safety net: the deck lazy-spawns its daemon
+            // DETACHED (its own session → parent is PID 1 from birth), so the
+            // orphan watchdog can't be enabled here (it would fire instantly).
+            // The max-lifetime backstop is the right net for a detached daemon:
+            // even if a test is SIGKILL'd / panics / times out before `Drop`
+            // runs, the inherited cap makes the daemon self-exit gracefully
+            // within 300s instead of leaking to PID 1 for hours/days. Idle
+            // shutdown stays disabled (above) for determinism.
+            ("DOT_AGENT_DECK_TEST_MAX_LIFETIME_SECS", "300"),
         ];
         // PATH is required for the deck to spawn its own daemon
         // subcommand (it shells out via `current_exe`, but lookups like
@@ -808,6 +817,20 @@ impl Drop for TuiDeck {
         // its tail. Stop the reader instead so the partial buffer
         // already lives in `cast_events`.
         self.reader_stop.store(true, Ordering::Relaxed);
+        // Reap the whole process tree, not just the deck itself. portable-pty
+        // makes the spawned deck a session/process-group leader (pgid == pid),
+        // so a negative-pid `kill` signals every non-detached descendant in its
+        // group (best-effort; ignore errors). Then the normal child kill+wait
+        // as the fallback. (The deck's own lazy-spawned daemon setsid's into a
+        // separate session and escapes this group — its
+        // `DOT_AGENT_DECK_TEST_MAX_LIFETIME_SECS` cap is the net for that.)
+        if let Some(pid) = self.child.process_id() {
+            // SAFETY: kill(2) with a negative pid signals the process group;
+            // SIGKILL has no failure mode beyond ESRCH/EPERM, which we ignore.
+            unsafe {
+                libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+            }
+        }
         let _ = self.child.kill();
         let _ = self.child.wait();
 
@@ -1741,6 +1764,15 @@ pub struct DaemonProc {
 #[allow(dead_code)]
 impl Drop for DaemonProc {
     fn drop(&mut self) {
+        // The daemon was spawned in its own process group (pgid == its pid),
+        // so a negative-pid SIGKILL reaps the whole tree — the daemon and any
+        // agents it spawned — in one shot. Best-effort; ignore ESRCH/EPERM.
+        let pid = self.child.id();
+        // SAFETY: kill(2) with a negative pid signals the process group;
+        // SIGKILL has no failure mode beyond ESRCH/EPERM, which we ignore.
+        unsafe {
+            libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+        }
         let _ = self.child.kill();
         let _ = self.child.wait();
     }
@@ -1808,6 +1840,18 @@ pub fn spawn_daemon_serve_with_env(
         "DOT_AGENT_DECK_IDLE_SHUTDOWN_SECS".into(),
         idle_shutdown_secs.to_string(),
     ));
+    // Leaked-daemon safety net. DaemonProc spawns `daemon serve` as a
+    // NON-detached child (its parent is this test process), so the orphan
+    // watchdog fires correctly when the test dies without running `Drop`
+    // (SIGKILL / panic-abort / nextest timeout / Ctrl-C) — the daemon
+    // gracefully self-exits instead of leaking to PID 1. The max-lifetime cap
+    // is a belt-and-suspenders backstop for anything the watchdog misses.
+    // `IDLE_SHUTDOWN_SECS` is left as the caller passed it (tests rely on `0`
+    // for determinism). These vars are inert for the short-lived `schedule`
+    // CLI subprocesses that also replay this env — only `daemon serve` reads
+    // them.
+    env.push(("DOT_AGENT_DECK_EXIT_WHEN_ORPHANED".into(), "1".into()));
+    env.push(("DOT_AGENT_DECK_TEST_MAX_LIFETIME_SECS".into(), "300".into()));
     for (k, v) in extra_env {
         env.push(((*k).to_string(), (*v).to_string()));
     }
@@ -1826,6 +1870,13 @@ pub fn spawn_daemon_serve_with_env(
     cmd.stdin(std::process::Stdio::null());
     cmd.stdout(std::process::Stdio::null());
     cmd.stderr(std::process::Stdio::from(stderr_file));
+    // Put the daemon in its own process group (pgid == its pid) so `Drop` can
+    // reap the WHOLE tree — the daemon plus any agents it spawned — with one
+    // `kill(-pgid)`, not just the daemon itself.
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
     let child = cmd.spawn().expect("spawn `dot-agent-deck daemon serve`");
 
     let proc = DaemonProc {
@@ -2368,6 +2419,47 @@ fn read_exact_with_deadline(
         }
     }
     Ok(())
+}
+
+/// Poll `cond` until it returns `true` or `timeout` elapses; returns the final
+/// value. Decision 21: bounded polling lives in `common`, never in an
+/// `e2e_*.rs` body (which forbids raw `sleep`).
+#[allow(dead_code)]
+pub fn wait_until<F: Fn() -> bool>(timeout: Duration, cond: F) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if cond() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    cond()
+}
+
+/// Whether `pid` is still a live (non-exited) process. A reaped pid is gone; a
+/// reparented-then-exited pid may briefly be a zombie — treat state `Z` as
+/// exited so the check isn't fooled by an unreaped zombie under a sub-reaper.
+/// Uses `/proc` on Linux and falls back to a `kill(pid, 0)` probe elsewhere.
+#[allow(dead_code)]
+pub fn process_running(pid: i32) -> bool {
+    let stat_path = format!("/proc/{pid}/stat");
+    match std::fs::read_to_string(&stat_path) {
+        Ok(stat) => match stat.rfind(')') {
+            // `/proc/<pid>/stat` is `pid (comm) STATE ...`; comm may contain
+            // spaces/parens, so the state char follows the last ')'.
+            Some(idx) => stat[idx + 1..].trim_start().chars().next() != Some('Z'),
+            None => true,
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            if Path::new("/proc").is_dir() {
+                false // Linux: no /proc entry → the pid is gone.
+            } else {
+                // SAFETY: kill(pid, 0) only probes existence/permission.
+                unsafe { libc::kill(pid, 0) == 0 }
+            }
+        }
+        Err(_) => true,
+    }
 }
 
 #[cfg(test)]

--- a/tests/e2e_daemon_orphan_exit.rs
+++ b/tests/e2e_daemon_orphan_exit.rs
@@ -1,0 +1,117 @@
+#![cfg(feature = "e2e")]
+
+//! L2 lifecycle test for the daemon-side "exit-when-orphaned" watchdog
+//! (PRD #77 catalog `lifecycle/orphan-exit/001`).
+//!
+//! The e2e harness spawns idle-disabled (`DOT_AGENT_DECK_IDLE_SHUTDOWN_SECS=0`)
+//! `daemon serve` processes and only cleans them up in `Drop`, which never runs
+//! on SIGKILL / panic-abort / nextest-timeout / Ctrl-C — so daemons used to
+//! orphan to PID 1 and live for hours. The fix is an env-gated daemon-side
+//! watchdog: with `DOT_AGENT_DECK_EXIT_WHEN_ORPHANED=1` the daemon captures its
+//! parent pid at startup and gracefully exits once it is orphaned. This test
+//! proves it: it runs the daemon under a short-lived intermediate `sh` parent
+//! (so the test can orphan the daemon without killing itself), kills that
+//! parent, and asserts the daemon process terminates within a few seconds —
+//! even though idle shutdown is disabled, so ONLY the watchdog can kill it.
+//!
+//! Decision 21: all bounded polling lives in `common` (`wait_until` /
+//! `process_running`), never as a raw `sleep` in this test body.
+
+mod common;
+
+use std::time::Duration;
+
+use spec::spec;
+
+/// Scenario: Launch `dot-agent-deck daemon serve` (idle shutdown DISABLED) from
+/// a short-lived intermediate `sh` parent that backgrounds it and records its
+/// pid, with `DOT_AGENT_DECK_EXIT_WHEN_ORPHANED=1`. Wait for the daemon to bind
+/// its attach socket (watchdog armed), then SIGKILL the intermediate parent so
+/// the daemon is orphaned to init. Assert the daemon process terminates within
+/// a few seconds — proving the watchdog gracefully shuts an orphaned, otherwise
+/// never-exiting test daemon down instead of leaking it to PID 1.
+#[spec("lifecycle/orphan-exit/001")]
+#[test]
+fn orphan_exit_001_orphaned_daemon_self_exits() {
+    let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
+    let dir = common::race_safe_tempdir();
+    let work = dir.path();
+    let home = work.join("home");
+    std::fs::create_dir_all(&home).expect("create HOME");
+    let attach_socket = work.join("attach.sock");
+    let hook_socket = work.join("hook.sock");
+    let state_dir = work.join("state");
+    let pidfile = work.join("daemon.pid");
+
+    // Intermediate parent: a shell that backgrounds the daemon (so the daemon's
+    // parent is THIS shell, not the test), records the daemon pid, then sleeps.
+    // Killing the shell orphans the daemon without touching the test process.
+    let script = format!(
+        "'{bin}' daemon serve >/dev/null 2>&1 &\necho $! > '{pid}'\nsleep 60\n",
+        bin = bin,
+        pid = pidfile.display(),
+    );
+
+    let path_env = std::env::var("PATH").unwrap_or_default();
+    let mut parent = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(&script)
+        .env_clear()
+        .env("PATH", &path_env)
+        .env("HOME", &home)
+        .env("DOT_AGENT_DECK_SOCKET", &hook_socket)
+        .env("DOT_AGENT_DECK_ATTACH_SOCKET", &attach_socket)
+        .env("DOT_AGENT_DECK_STATE_DIR", &state_dir)
+        // Disable idle shutdown so ONLY the orphan watchdog can end the daemon.
+        .env("DOT_AGENT_DECK_IDLE_SHUTDOWN_SECS", "0")
+        // The behavior under test.
+        .env("DOT_AGENT_DECK_EXIT_WHEN_ORPHANED", "1")
+        .spawn()
+        .expect("spawn intermediate sh parent");
+
+    // Read the daemon pid once the shell has backgrounded it.
+    let read_pid = || -> Option<i32> {
+        std::fs::read_to_string(&pidfile)
+            .ok()
+            .and_then(|s| s.trim().parse::<i32>().ok())
+    };
+    assert!(
+        common::wait_until(Duration::from_secs(10), || read_pid().is_some()),
+        "intermediate parent never wrote the daemon pid"
+    );
+    let daemon_pid = read_pid().expect("daemon pid recorded");
+
+    // Wait for the daemon to bind its attach socket — by then the watchdog has
+    // captured its original parent pid and is polling.
+    assert!(
+        common::wait_until(Duration::from_secs(10), || attach_socket.exists()),
+        "daemon never bound its attach socket"
+    );
+    assert!(
+        common::process_running(daemon_pid),
+        "precondition: the daemon must be alive before we orphan it"
+    );
+
+    // Orphan the daemon: SIGKILL the intermediate parent (Drop never gets a
+    // chance — exactly the leak scenario). The daemon reparents to init.
+    let _ = parent.kill();
+    let _ = parent.wait();
+
+    // The watchdog (polling ~1/s) must notice the orphaning and gracefully
+    // shut the daemon down within a few seconds — despite idle being disabled.
+    assert!(
+        common::wait_until(Duration::from_secs(10), || !common::process_running(
+            daemon_pid
+        )),
+        "orphaned daemon (pid {daemon_pid}) did not self-exit — the \
+         exit-when-orphaned watchdog failed to fire"
+    );
+
+    // Defensive: if somehow still alive, don't leak it out of the test.
+    if common::process_running(daemon_pid) {
+        // SAFETY: best-effort cleanup kill.
+        unsafe {
+            libc::kill(daemon_pid, libc::SIGKILL);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Idle-disabled (`DOT_AGENT_DECK_IDLE_SHUTDOWN_SECS=0`) test daemons were only cleaned up in `Drop`, which never runs on SIGKILL / panic-abort / nextest-timeout / Ctrl-C. As a result daemons orphaned to PID 1 and kept running for hours after a test run died abruptly.

## Fix

Two env-gated, **test-only** daemon self-defense mechanisms, both **OFF by default** so detached/lazy-spawned production daemons are unaffected:

- **`DOT_AGENT_DECK_EXIT_WHEN_ORPHANED`** — the daemon captures its parent pid at startup and gracefully shuts down (via the same `shutdown` signal the idle monitor uses, so sockets/agents tear down cleanly) once it is orphaned. Enabled for the non-detached `DaemonProc` harness daemons.
- **`DOT_AGENT_DECK_TEST_MAX_LIFETIME_SECS`** — hard backstop that self-exits after N seconds no matter what. This is the net for *detached* daemons (parent already PID 1) that the orphan watchdog can't help. Set to 300s by the `TuiDeck` harness.

Supporting changes:
- Pure decision helpers (`parse_bool_flag`, `parse_max_lifetime_secs`, `should_exit_orphaned`) — unit-tested without a real fork.
- Harness `Drop` impls now reap the whole process group (`kill(-pgid)`) so agents a daemon spawned go down with it.
- New L2 test `lifecycle/orphan-exit/001` (`tests/e2e_daemon_orphan_exit.rs`) proves an orphaned, idle-disabled daemon self-exits within seconds.

## Testing

- `cargo fmt --check`: clean
- `cargo clippy --all-targets -- -D warnings` (default + `--features e2e`): clean
- New daemon unit tests: 4/4 pass
- `cargo test-e2e orphan_exit_001`: pass
- Full fast tier: 695/695 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)