### PR TITLE
fix(prd-147): right-size orchestration deck card heights

### DIFF
--- a/changelog.d/147.bugfix.md
+++ b/changelog.d/147.bugfix.md
@@ -1,0 +1,5 @@
+## Orchestration deck card heights right-sized to content
+
+Orchestration deck cards previously reserved more vertical space than their content filled, showing 1–2 blank rows at the bottom of each card and forcing unnecessary scrolling with 7 or more decks.
+
+Card heights are now derived from the exact lines `render_session_card` emits: Compact cards shrink from 7 to 5 rows (wide) or 8 to 6 rows (narrow), eliminating the 2-row gap that caused the most visible waste. Normal and Spacious tiers are also tightened by 1 row each. With the corrected Compact height, 7 decks in the single-column orchestration panel fit in ~35 rows — well within a typical ~48-row card area — so all decks are visible without scrolling. Scrolling still engages when the deck count genuinely exceeds the available space.

--- a/prds/done/147-orchestration-deck-card-height.md
+++ b/prds/done/147-orchestration-deck-card-height.md
@@ -1,6 +1,7 @@
 # PRD #147: Right-size orchestration deck card height
 
-**Status**: Planning
+**Status**: Complete
+**Completed**: 2026-06-12
 **Priority**: Medium
 **Created**: 2026-06-12
 **GitHub Issue**: [#147](https://github.com/vfarcic/dot-agent-deck/issues/147)
@@ -60,23 +61,23 @@ Effects:
 ## Acceptance Criteria
 
 ### Height matches content
-- [ ] `CardDensity::card_height` returns Compact=5, Normal=8, Spacious=10 (wide) and 6 / 9 / 11 (narrow).
-- [ ] A rendered card has no trailing blank rows below its content at any tier (verified by L1 buffer inspection).
+- [x] `CardDensity::card_height` returns Compact=5, Normal=8, Spacious=10 (wide) and 6 / 9 / 11 (narrow).
+- [x] A rendered card has no trailing blank rows below its content at any tier (verified by L1 buffer inspection).
 
 ### Orchestration fit
-- [ ] With 7 decks in the single-column orchestration card area at a typical terminal height, all 7 cards render without scrolling.
-- [ ] Selecting/navigating past the last visible card still scrolls correctly when the deck count genuinely exceeds the now-tighter capacity.
+- [x] With 7 decks in the single-column orchestration card area at a typical terminal height, all 7 cards render without scrolling.
+- [x] Selecting/navigating past the last visible card still scrolls correctly when the deck count genuinely exceeds the now-tighter capacity.
 
 ### No regressions
-- [ ] Dashboard tab card grid (multi-column) renders correctly at the new heights.
-- [ ] `choose_density` still selects the largest tier that fits; its tier-boundary unit tests are updated for the new heights and pass.
-- [ ] L1 `insta` snapshots in `tests/render_dashboard.rs` are re-accepted at the new card heights.
+- [x] Dashboard tab card grid (multi-column) renders correctly at the new heights.
+- [x] `choose_density` still selects the largest tier that fits; its tier-boundary unit tests are updated for the new heights and pass.
+- [x] L1 `insta` snapshots in `tests/render_dashboard.rs` are re-accepted at the new card heights.
 
 ## Milestones
 
-- [ ] **M1 — Content-derived height.** Replace `CardDensity::card_height` magic numbers with the content-derived computation; confirm the six (tier × wide/narrow) values.
-- [ ] **M2 — Tests updated.** Update `test_choose_density_wide` / `test_choose_density_narrow` boundary assertions; add/adjust an L1 test asserting no trailing blank rows and that 7 decks fit; re-accept affected `insta` snapshots.
-- [ ] **M3 — Verified in the running TUI.** Launch the deck with 7 orchestration decks and confirm all fit with no empty rows (per `run-dot-agent-deck`).
+- [x] **M1 — Content-derived height.** Replace `CardDensity::card_height` magic numbers with the content-derived computation; confirm the six (tier × wide/narrow) values.
+- [x] **M2 — Tests updated.** Update `test_choose_density_wide` / `test_choose_density_narrow` boundary assertions; add/adjust an L1 test asserting no trailing blank rows and that 7 decks fit; re-accept affected `insta` snapshots.
+- [x] **M3 — Verified in the running TUI.** Launch the deck with 7 orchestration decks and confirm all fit with no empty rows (per `run-dot-agent-deck`).
 
 ## Out of Scope
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -81,21 +81,29 @@ const MOD_KEY: &str = "Ctrl";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CardDensity {
-    Compact,  // 6 rows: 1 prompt, 1 tool
-    Normal,   // 8 rows: 1 prompt, 3 tools
-    Spacious, // 10 rows: 3 prompts, 3 tools
+    Compact,  // wide 5 / narrow 6 rows: 1 prompt, 1 tool
+    Normal,   // wide 8 / narrow 9 rows: 1 prompt, 3 tools
+    Spacious, // wide 10 / narrow 11 rows: 3 prompts, 3 tools
 }
 
 impl CardDensity {
-    /// Card height in rows. When `wide` is false an extra stats line is rendered,
-    /// so each non-compact mode needs one more row.
+    /// Card height in rows, derived from the exact lines `render_session_card`
+    /// emits so reserved height never drifts from rendered content:
+    ///   Dir (1) + prompts + [narrow: inline stats line] + [non-compact: blank
+    ///   separator] + tools, plus 2 rows for the top/bottom border.
+    ///
+    /// Resulting heights — wide: Compact 5, Normal 8, Spacious 10;
+    /// narrow: 6 / 9 / 11.
     fn card_height(self, wide: bool) -> u16 {
-        let extra = if wide { 0 } else { 1 };
-        match self {
-            CardDensity::Compact => 7 + extra,
-            CardDensity::Normal => 9 + extra,
-            CardDensity::Spacious => 11 + extra,
-        }
+        let prompts = self.max_prompts() as u16;
+        let tools = self.max_tools() as u16;
+        let stats_line = if wide { 0 } else { 1 };
+        let separator = if matches!(self, CardDensity::Compact) {
+            0
+        } else {
+            1
+        };
+        (1 + prompts + stats_line + separator + tools) + 2 // +2 top/bottom border
     }
 
     fn max_tools(self) -> usize {
@@ -131,6 +139,24 @@ fn choose_density(
         }
     }
     CardDensity::Compact
+}
+
+/// Clamp a (possibly stale) vertical scroll offset to the largest value that
+/// still fills the visible window: `scroll_offset.min(total_rows - visible_rows)`
+/// (saturating at 0).
+///
+/// When a terminal resize *grows* `visible_rows` so that more — or all — card
+/// rows now fit, an offset left over from the previous overflow state would
+/// otherwise scroll the top rows off and leave blank space below the last card
+/// until the next navigation keystroke. This only ever *reduces* an over-large
+/// offset; while content genuinely overflows (`total_rows > visible_rows`) a
+/// legitimate offset is returned unchanged, so normal scrolling is untouched.
+///
+/// Hidden-public so the in-source unit tests can exercise the pure window math
+/// directly; it is not a library API surface for downstream consumers.
+#[doc(hidden)]
+pub fn clamp_scroll_offset(scroll_offset: usize, total_rows: usize, visible_rows: usize) -> usize {
+    scroll_offset.min(total_rows.saturating_sub(visible_rows))
 }
 
 // ---------------------------------------------------------------------------
@@ -7868,6 +7894,12 @@ fn render_frame(
         ui.scroll_offset = selected_row + 1 - visible_rows;
     }
 
+    // Re-clamp after a resize may have grown `visible_rows`: an offset left over
+    // from a previous overflow state must shrink so the last card row still sits
+    // at the bottom (no scrolled-off top / blank tail). Only reduces an
+    // over-large offset; legitimate scrolling is unchanged.
+    ui.scroll_offset = clamp_scroll_offset(ui.scroll_offset, total_rows, visible_rows);
+
     let end = (ui.scroll_offset + visible_rows).min(total_rows);
     let rows = &all_rows[ui.scroll_offset..end];
     let row_ids = &all_row_ids[ui.scroll_offset..end];
@@ -14271,22 +14303,22 @@ mod tests {
     #[test]
     fn test_choose_density_wide() {
         // Wide layout (no extra stats line)
-        // Spacious=11, Normal=9, Compact=7
+        // Spacious=10, Normal=8, Compact=5
 
         // 1 session, 1 col, plenty of height -> Spacious
         assert_eq!(choose_density(1, 1, 20, true), CardDensity::Spacious);
 
-        // 2 sessions, 2 cols = 1 row, height 11 -> Spacious (1*11=11)
-        assert_eq!(choose_density(2, 2, 11, true), CardDensity::Spacious);
+        // 2 sessions, 2 cols = 1 row, height 10 -> Spacious (1*10=10)
+        assert_eq!(choose_density(2, 2, 10, true), CardDensity::Spacious);
 
-        // 2 sessions, 2 cols = 1 row, height 10 -> Normal (1*9=9 fits)
-        assert_eq!(choose_density(2, 2, 10, true), CardDensity::Normal);
+        // 2 sessions, 2 cols = 1 row, height 9 -> Normal (1*8=8 fits)
+        assert_eq!(choose_density(2, 2, 9, true), CardDensity::Normal);
 
-        // 4 sessions, 2 cols = 2 rows, height 18 -> Normal (2*9=18)
-        assert_eq!(choose_density(4, 2, 18, true), CardDensity::Normal);
+        // 4 sessions, 2 cols = 2 rows, height 16 -> Normal (2*8=16)
+        assert_eq!(choose_density(4, 2, 16, true), CardDensity::Normal);
 
-        // 4 sessions, 2 cols = 2 rows, height 17 -> Compact (2*7=14 fits)
-        assert_eq!(choose_density(4, 2, 17, true), CardDensity::Compact);
+        // 4 sessions, 2 cols = 2 rows, height 15 -> Compact (2*5=10 fits)
+        assert_eq!(choose_density(4, 2, 15, true), CardDensity::Compact);
 
         // Many sessions, small screen -> Compact
         assert_eq!(choose_density(10, 1, 20, true), CardDensity::Compact);
@@ -14298,19 +14330,50 @@ mod tests {
     #[test]
     fn test_choose_density_narrow() {
         // Narrow layout: each mode needs 1 extra row for stats line
-        // Spacious=12, Normal=10, Compact=8
+        // Spacious=11, Normal=9, Compact=6
 
-        // 1 session, height 12 -> Spacious (1*12=12)
-        assert_eq!(choose_density(1, 1, 12, false), CardDensity::Spacious);
+        // 1 session, height 11 -> Spacious (1*11=11)
+        assert_eq!(choose_density(1, 1, 11, false), CardDensity::Spacious);
 
-        // 1 session, height 11 -> Normal (1*10=10 fits)
-        assert_eq!(choose_density(1, 1, 11, false), CardDensity::Normal);
+        // 1 session, height 10 -> Normal (1*9=9 fits)
+        assert_eq!(choose_density(1, 1, 10, false), CardDensity::Normal);
 
-        // 2 sessions, 1 col, height 20 -> Normal (2*10=20)
-        assert_eq!(choose_density(2, 1, 20, false), CardDensity::Normal);
+        // 2 sessions, 1 col, height 18 -> Normal (2*9=18)
+        assert_eq!(choose_density(2, 1, 18, false), CardDensity::Normal);
 
-        // 2 sessions, 1 col, height 19 -> Compact (2*8=16 fits)
-        assert_eq!(choose_density(2, 1, 19, false), CardDensity::Compact);
+        // 2 sessions, 1 col, height 17 -> Compact (2*6=12 fits)
+        assert_eq!(choose_density(2, 1, 17, false), CardDensity::Compact);
+    }
+
+    /// Acceptance criterion 1: `card_height` is derived from rendered content,
+    /// so it returns exactly Compact=5 / Normal=8 / Spacious=10 (wide) and
+    /// 6 / 9 / 11 (narrow). Locks the six values against future drift.
+    #[test]
+    fn card_height_001_content_derived_values() {
+        // Wide layout (no inline stats line).
+        assert_eq!(CardDensity::Compact.card_height(true), 5);
+        assert_eq!(CardDensity::Normal.card_height(true), 8);
+        assert_eq!(CardDensity::Spacious.card_height(true), 10);
+
+        // Narrow layout (+1 row for the inline stats line on every tier).
+        assert_eq!(CardDensity::Compact.card_height(false), 6);
+        assert_eq!(CardDensity::Normal.card_height(false), 9);
+        assert_eq!(CardDensity::Spacious.card_height(false), 11);
+    }
+
+    /// Review finding S1: the card grid must re-clamp a stale scroll offset
+    /// when a resize grows `visible_rows`. While content still overflows the
+    /// window a valid offset is left alone; once everything (or more) fits, the
+    /// offset is reduced so no rows scroll off the top leaving a blank tail.
+    #[test]
+    fn clamp_scroll_offset_reclamps_on_resize_grow() {
+        // Overflow, offset still valid (7 rows, window 3, max offset 7-3=4):
+        // scrolled to 4 stays 4.
+        assert_eq!(clamp_scroll_offset(4, 7, 3), 4);
+
+        // Resize grew the window to 10 so all 7 rows fit: the stale offset 4
+        // must clamp back to 0 (7.saturating_sub(10) == 0).
+        assert_eq!(clamp_scroll_offset(4, 7, 10), 0);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -152,10 +152,13 @@ fn choose_density(
 /// offset; while content genuinely overflows (`total_rows > visible_rows`) a
 /// legitimate offset is returned unchanged, so normal scrolling is untouched.
 ///
-/// Hidden-public so the in-source unit tests can exercise the pure window math
-/// directly; it is not a library API surface for downstream consumers.
-#[doc(hidden)]
-pub fn clamp_scroll_offset(scroll_offset: usize, total_rows: usize, visible_rows: usize) -> usize {
+/// Crate-private: the only consumers are the render call site and the in-crate
+/// unit test, so it needs no crate-external visibility.
+pub(crate) fn clamp_scroll_offset(
+    scroll_offset: usize,
+    total_rows: usize,
+    visible_rows: usize,
+) -> usize {
     scroll_offset.min(total_rows.saturating_sub(visible_rows))
 }
 

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -83,6 +83,13 @@ Platform coverage column shorthand: **mac+linux** = macOS and Linux (Windows onc
 - **Does not assert:** card visual style beyond the rendered character buffer.
 - **Platform coverage:** mac+linux+windows.
 
+##### dashboard/density/004 — A rendered card has no trailing blank rows below its content at any density tier (PRD #147).
+- **Layer:** L1 (ratatui `TestBackend`, buffer inspection).
+- **Agent:** none.
+- **Asserts:** a fully-populated session card (3 prompts + 3 tools) rendered at each tier's own `rendered_height` in an 80-column wide viewport has zero blank inner rows between its last content line and the bottom border on Compact, Normal, and Spacious — reserved card height equals rendered content height.
+- **Does not assert:** the exact `card_height` value per tier (covered by the `choose_density` unit tests); the mid-card blank separator line on Normal/Spacious (intentional content, not a trailing row).
+- **Platform coverage:** mac+linux+windows.
+
 #### dashboard/selection
 
 ##### dashboard/selection/001 — `j` / `Down` selects next card; wraps at end.
@@ -1045,6 +1052,15 @@ without depending on the config struct API.
 - **Asserts:** worker's pane gains an error line; no task is delivered to any role.
 - **Does not assert:** the daemon-side log entry.
 - **Platform coverage:** mac+linux.
+
+#### orchestration/layout
+
+##### orchestration/layout/001 — Seven decks fit the single-column orchestration card area without scrolling (PRD #147).
+- **Layer:** L1 (ratatui `TestBackend`, buffer inspection + capacity math via the public `rendered_height` seam).
+- **Agent:** none.
+- **Asserts:** in the ~34%-width single-column orchestration card area at a typical ~48-row card height, the renderer's `visible_rows = available / card_height` fits all 7 decks with no scrolling and the 7th deck actually renders in the visible slice; a much larger deck count (20) still engages scrolling, so right-sizing the card height does not remove the scroll fallback.
+- **Does not assert:** the full orchestration-tab frame (tab bar, side panes, stats bar); the `ORCHESTRATION_LEFT_PERCENT` width split or `grid_columns` thresholds (out of scope per PRD #147).
+- **Platform coverage:** mac+linux+windows.
 
 ### Session restore
 

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -87,7 +87,7 @@ Platform coverage column shorthand: **mac+linux** = macOS and Linux (Windows onc
 - **Layer:** L1 (ratatui `TestBackend`, buffer inspection).
 - **Agent:** none.
 - **Asserts:** a fully-populated session card (3 prompts + 3 tools) rendered at each tier's own `rendered_height` in an 80-column wide viewport has zero blank inner rows between its last content line and the bottom border on Compact, Normal, and Spacious — reserved card height equals rendered content height.
-- **Does not assert:** the exact `card_height` value per tier (covered by the `choose_density` unit tests); the mid-card blank separator line on Normal/Spacious (intentional content, not a trailing row).
+- **Does not assert:** the exact `card_height` value per tier (covered by `card_height_001_content_derived_values`); the mid-card blank separator line on Normal/Spacious (intentional content, not a trailing row).
 - **Platform coverage:** mac+linux+windows.
 
 #### dashboard/selection

--- a/tests/render_dashboard.rs
+++ b/tests/render_dashboard.rs
@@ -6,9 +6,9 @@
 //! `dashboard/*/NNN` land in this file with function names
 //! `<sub-area>_<NNN>_<short_suffix>` per Decision 17.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 
-use dot_agent_deck::event::AgentType;
+use dot_agent_deck::event::{AgentEvent, AgentType, EventType};
 use dot_agent_deck::state::{ActiveTool, DashboardStats, SessionState, SessionStatus};
 use dot_agent_deck::tab::Tab;
 use dot_agent_deck::ui::{
@@ -414,4 +414,239 @@ fn pane_005_highlight_follows_selected_session_id() {
         80,
     );
     insta::assert_snapshot!(buffer_to_text(&buffer));
+}
+
+/// Build one event-rich session fixture that fills `render_session_card`
+/// to capacity at every density tier: three user prompts (Spacious shows 3,
+/// Normal/Compact show the latest 1) and three `ToolStart` events
+/// (Normal/Spacious show 3, Compact shows 1). With this fixture the rendered
+/// card carries its maximum content lines on every tier, so any rows left
+/// blank inside the border are reserved-but-unused — exactly what
+/// `dashboard/density/004` asserts must not happen.
+///
+/// `last_activity = now` keeps the inline `Last: Xs ago` text at `0s ago`
+/// (mirrors `pane_004`); these tests only inspect blank/non-blank rows, so the
+/// elapsed value never affects the assertion.
+fn filled_session() -> SessionState {
+    let now = chrono::Utc::now();
+    let mut events: VecDeque<AgentEvent> = VecDeque::new();
+    for prompt in ["first prompt", "second prompt", "third prompt"] {
+        events.push_back(AgentEvent {
+            session_id: "sess-fill".to_string(),
+            agent_type: AgentType::ClaudeCode,
+            event_type: EventType::Thinking,
+            tool_name: None,
+            tool_detail: None,
+            cwd: None,
+            timestamp: now,
+            user_prompt: Some(prompt.to_string()),
+            metadata: HashMap::new(),
+            pane_id: None,
+            agent_id: None,
+        });
+    }
+    for (name, detail) in [
+        ("Read", "src/main.rs"),
+        ("Edit", "src/ui.rs"),
+        ("Bash", "cargo test"),
+    ] {
+        events.push_back(AgentEvent {
+            session_id: "sess-fill".to_string(),
+            agent_type: AgentType::ClaudeCode,
+            event_type: EventType::ToolStart,
+            tool_name: Some(name.to_string()),
+            tool_detail: Some(detail.to_string()),
+            cwd: None,
+            timestamp: now,
+            user_prompt: None,
+            metadata: HashMap::new(),
+            pane_id: None,
+            agent_id: None,
+        });
+    }
+    SessionState {
+        session_id: "sess-fill".to_string(),
+        agent_type: AgentType::ClaudeCode,
+        cwd: Some("/home/dev/example-project".to_string()),
+        status: SessionStatus::Working,
+        active_tool: Some(ActiveTool {
+            name: "Bash".to_string(),
+            detail: Some("cargo test".to_string()),
+        }),
+        started_at: now,
+        last_activity: now,
+        recent_events: events,
+        tool_count: 12,
+        last_user_prompt: Some("third prompt".to_string()),
+        first_prompts: vec!["first prompt".to_string()],
+        pane_id: Some("pane-1".to_string()),
+        agent_id: Some("1".to_string()),
+        display_name: None,
+    }
+}
+
+/// Count inner card rows that are blank starting from the row directly above
+/// the bottom border and scanning upward, stopping at the first row that
+/// carries content. Inner columns only (`1..width-1`) so the left/right border
+/// `│` glyphs are ignored. The result is the number of reserved-but-empty rows
+/// the card holds below its real content — `0` means the reserved card height
+/// equals the rendered content height. The mid-card blank separator line
+/// (Normal/Spacious) is never counted because the scan stops at the tool line
+/// rendered beneath it.
+fn trailing_blank_inner_rows(buffer: &ratatui::buffer::Buffer) -> usize {
+    let area = buffer.area();
+    let (w, h) = (area.width, area.height);
+    if h < 3 || w < 3 {
+        return 0;
+    }
+    let mut count = 0usize;
+    let mut y = h - 2; // last inner row (the one just above the bottom border)
+    loop {
+        let row_blank = (1..w - 1).all(|x| buffer[(x, y)].symbol().trim().is_empty());
+        if row_blank {
+            count += 1;
+        } else {
+            break;
+        }
+        if y == 1 {
+            break;
+        }
+        y -= 1;
+    }
+    count
+}
+
+/// Scenario: Render a single fully-populated session card at each density tier
+/// (Compact, Normal, Spacious) in a wide 80-column viewport sized to the tier's
+/// own `rendered_height`, then assert the card has zero trailing blank rows —
+/// the row directly above the bottom border carries rendered content on every
+/// tier. This locks in PRD #147's content-derived `card_height`: the reserved
+/// height equals the lines `render_session_card` actually emits (wide 5/8/10),
+/// so no row is reserved-but-empty. Before #147 the heights were hardcoded
+/// larger than the content (Compact 7 rows for 3 content lines, Normal 9 for 6,
+/// Spacious 11 for 8), which would trip this assertion as trailing blank rows.
+#[spec("dashboard/density/004")]
+#[test]
+fn density_004_no_trailing_blank_rows() {
+    // PRD #147 M2: reserved card height must equal rendered content height, so
+    // a card shows no empty rows below its content at any tier. The fixture
+    // fills every tier to capacity (3 prompts + 3 tools); we render at the
+    // width-80 "wide" branch (inline stats row) at the tier's declared
+    // `rendered_height`, then count trailing blank inner rows — which must be 0.
+    let session = filled_session();
+    let width: u16 = 80;
+    let wide = width >= RENDER_CARD_WIDE_LAYOUT_MIN_WIDTH;
+    for (density, label) in [
+        (CardDensityKind::Compact, "Compact"),
+        (CardDensityKind::Normal, "Normal"),
+        (CardDensityKind::Spacious, "Spacious"),
+    ] {
+        let height = density.rendered_height(wide);
+        let buffer = render_card_to_buffer(
+            &session,
+            Some("example-coder"),
+            Some(1),
+            density,
+            0,     // animation tick
+            false, // not selected
+            width,
+            height,
+        );
+        let trailing = trailing_blank_inner_rows(&buffer);
+        assert_eq!(
+            trailing,
+            0,
+            "{label} card reserves {trailing} blank row(s) below its content \
+             (height={height}); reserved height must match rendered content:\n{}",
+            buffer_to_text(&buffer)
+        );
+    }
+}
+
+/// Replicate `choose_density`'s tier selection using the public
+/// `rendered_height` seam: pick the largest tier whose stacked card rows fit
+/// in `avail`, falling back to Compact. Mirrors `src/ui.rs::choose_density` so
+/// the orchestration capacity test tracks the same selection the renderer uses
+/// without depending on the private function.
+fn pick_density(n_decks: usize, cols: usize, avail: u16, wide: bool) -> CardDensityKind {
+    let rows = n_decks.div_ceil(cols.max(1)) as u16;
+    for density in [
+        CardDensityKind::Spacious,
+        CardDensityKind::Normal,
+        CardDensityKind::Compact,
+    ] {
+        if rows * density.rendered_height(wide) <= avail {
+            return density;
+        }
+    }
+    CardDensityKind::Compact
+}
+
+/// Scenario: Model the single-column orchestration deck card area (the ~34%
+/// width column → one grid column) at a typical terminal where ~48 rows are
+/// available for cards, and compute the renderer's own capacity
+/// (`visible_rows = available / card_height`) for 7 decks; assert all 7 fit
+/// without scrolling and that the 7th deck actually renders in the visible
+/// slice, while a much larger deck count still engages scrolling. This locks in
+/// PRD #147: with the content-derived Compact height of 5, 48 / 5 = 9 rows fit
+/// so all 7 decks show. Before #147 the hardcoded Compact height of 7 fit only
+/// 48 / 7 = 6 rows, dropping the 7th deck to a scroll — the regression this
+/// test guards against.
+#[spec("orchestration/layout/001")]
+#[test]
+fn layout_001_seven_decks_fit_single_column() {
+    // PRD #147 M2: on the orchestration tab decks stack in one column and
+    // density bottoms out at Compact. The renderer fits
+    // `visible_rows = available_for_density / card_height` rows (src/ui.rs
+    // ~7861); the rest scroll. We mirror that math through the public
+    // `rendered_height` seam, then confirm it with a real card render.
+
+    // Card-area rows available for cards (production: dashboard_area.height - 2,
+    // i.e. a ~50-row card column). WIDE = single orchestration column rendered
+    // wide enough (inner width >= 60) to show the inline stats row — the branch
+    // PRD #147's capacity example is worked through.
+    const AVAILABLE: u16 = 48;
+    const COLS: usize = 1;
+    const WIDE: bool = true;
+    const DECKS: usize = 7;
+
+    let density = pick_density(DECKS, COLS, AVAILABLE, WIDE);
+    let card_height = density.rendered_height(WIDE);
+    let visible_rows = (AVAILABLE / card_height).max(1) as usize;
+
+    // (1) Capacity: all 7 decks must fit in the single column with no scrolling.
+    assert!(
+        visible_rows >= DECKS,
+        "all {DECKS} orchestration decks must fit without scrolling at \
+         card-area height {AVAILABLE} (density={density:?}, card_height={card_height}); \
+         only {visible_rows} fit"
+    );
+
+    // (2) Buffer proof: the orchestration renderer draws only the first
+    //     `visible_rows` of the deck rows (src/ui.rs ~7871); render that visible
+    //     slice as real cards and assert the 7th deck shows. If the cards were
+    //     too tall to all fit, the 7th would be scrolled off and absent.
+    let visible = visible_rows.min(DECKS);
+    let session = filled_session();
+    let names: Vec<String> = (1..=visible).map(|i| format!("deck-{i}")).collect();
+    let cards: Vec<(&SessionState, Option<&str>)> =
+        names.iter().map(|n| (&session, Some(n.as_str()))).collect();
+    let buffer = render_dashboard_cards_to_buffer(&cards, usize::MAX, density, 0, 64);
+    let text = buffer_to_text(&buffer);
+    assert!(
+        text.contains("deck-7"),
+        "the 7th orchestration deck must render in the visible card area \
+         (rendered {visible} of {DECKS} decks):\n{text}"
+    );
+
+    // (3) Over-correction guard: a deck count well past the (now tighter)
+    //     capacity must still engage scrolling — the fix right-sizes the cards,
+    //     it does not remove scrolling for genuinely too-many decks.
+    const MANY: usize = 20;
+    let many_density = pick_density(MANY, COLS, AVAILABLE, WIDE);
+    let many_visible = (AVAILABLE / many_density.rendered_height(WIDE)).max(1) as usize;
+    assert!(
+        many_visible < MANY,
+        "with {MANY} decks scrolling must still engage (only {many_visible} fit)"
+    );
 }

--- a/tests/snapshots/render_dashboard__pane_004_card_title_row.snap
+++ b/tests/snapshots/render_dashboard__pane_004_card_title_row.snap
@@ -1,12 +1,10 @@
 ---
 source: tests/render_dashboard.rs
-assertion_line: 84
 expression: buffer_to_text(&buffer)
 ---
 ┌ 1 example-coder ────────────────────────────────────────────────── ● Working ┐
 │Dir:  example-project                                   Last: 0s ago  Tools: 7│
 │Prmt: fix the login bug                                                       │
-│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │

--- a/tests/snapshots/render_dashboard__pane_005_highlight_follows_selected_session_id.snap
+++ b/tests/snapshots/render_dashboard__pane_005_highlight_follows_selected_session_id.snap
@@ -1,12 +1,10 @@
 ---
 source: tests/render_dashboard.rs
-assertion_line: 195
 expression: buffer_to_text(&buffer)
 ---
 ┌ 1 example-alpha ────────────────────────────────────────────────── ● Working ┐
 │Dir:  alpha                                             Last: 0s ago  Tools: 3│
 │Prmt: do the thing                                                            │
-│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │
@@ -19,12 +17,10 @@ expression: buffer_to_text(&buffer)
 │                                                                              │
 │                                                                              │
 │                                                                              │
-│                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
 ┌ 3 example-gamma ────────────────────────────────────────────────── ● Working ┐
 │Dir:  gamma                                             Last: 0s ago  Tools: 3│
 │Prmt: do the thing                                                            │
-│                                                                              │
 │                                                                              │
 │                                                                              │
 │                                                                              │


### PR DESCRIPTION
## Description

Orchestration deck cards reserved more vertical space than their content filled, showing 1–2 trailing blank rows per card and forcing unnecessary scrolling when 7+ decks were open.

`CardDensity::card_height` now derives heights from the exact lines `render_session_card` emits instead of hardcoded magic numbers:

| Tier | Old (wide) | New (wide) | Old (narrow) | New (narrow) |
|------|-----------|-----------|-------------|-------------|
| Compact  | 7 | **5** | 8 | **6** |
| Normal   | 9 | **8** | 10 | **9** |
| Spacious | 11 | **10** | 12 | **11** |

With Compact at 5 rows, 7 decks fit in ~35 rows (vs ~49 before), eliminating scroll for the common case.

## Related Issues

Closes #147

## Changes Made

- `src/ui.rs`: content-derived `CardDensity::card_height`; updated `test_choose_density_wide`/`_narrow` boundary assertions; new `card_height_001` value test; new `clamp_scroll_offset` helper + unit test
- `tests/render_dashboard.rs`: new L1 tests `density_004_no_trailing_blank_rows` and `layout_001_seven_decks_fit_single_column`; helpers `filled_session`, `trailing_blank_inner_rows`, `pick_density`
- `tests/CATALOG.md`: entries for `dashboard/density/004` and `orchestration/layout/001`
- `tests/snapshots/render_dashboard__pane_004*.snap`, `__pane_005*.snap`: re-accepted at new heights
- `changelog.d/147.bugfix.md`: release notes fragment

## Testing

- Fast tier: 707/707 tests pass (`cargo test-fast`)
- E2E tier: 1025/1025 tests pass (`cargo test-e2e`)
- Two pre-existing non-blocking items deliberately deferred (S2 multi-column boundary blank, ~17.8k-session overflow overflow)

## Notes

- No breaking changes — existing API unchanged, only card heights adjusted
- Height is now self-consistent with renderer; cannot drift when content changes again