### PR TITLE
feat(#148): remote connect survives laptop sleep/wake

### DIFF
--- a/changelog.d/148.feature.md
+++ b/changelog.d/148.feature.md
@@ -1,0 +1,9 @@
+## Remote Connect Survives Sleep/Wake
+
+Remote sessions no longer freeze when your laptop sleeps. Previously, closing the lid dropped the underlying TCP connection silently — the SSH client had no way to detect the dead socket, so on wake the TUI was frozen, keystrokes went nowhere, and the only escape was closing the terminal tab entirely and reconnecting manually.
+
+Two layers work together to eliminate this: SSH keepalive probing on the live session detects the dropped connection within roughly 45 seconds of wake and terminates the session cleanly (`ServerAliveInterval=15`, `ServerAliveCountMax=3`). An automatic reconnect loop then re-probes the remote host and re-spawns the session transparently — you see a brief "reconnecting to `<name>`…" message and land back in your running agents without having to touch anything. Because the remote daemon is persistent and agent state is preserved across reconnects, you re-attach to the same agents you were already working with.
+
+Reconnection is bounded: if the host is unreachable after five attempts (`MAX_CONNECT_ATTEMPTS=5`), the session exits cleanly and restores the local terminal to a sane state. Only SSH transport failures (exit code 255) trigger reconnection — a deliberate quit, Ctrl-C, or remote TUI crash exits immediately as before.
+
+See the [Remote Environments guide](https://devopstoolkit.ai/docs/ui/remote-environments) for details on the keepalive tuning and retry behaviour.

--- a/docs/remote-environments.md
+++ b/docs/remote-environments.md
@@ -69,7 +69,7 @@ laptop                       remote host
 
 Three properties follow from this shape:
 
-1. **Agents survive your laptop.** Close the lid, lose Wi-Fi, kill the ssh session — the remote TUI process dies with its terminal, but the daemon and agents are separate processes and keep running. Reconnect later from the same laptop or a different one.
+1. **Agents survive your laptop.** Close the lid, lose Wi-Fi, kill the ssh session — the remote TUI process dies with its terminal, but the daemon and agents are separate processes and keep running. Reconnect later from the same laptop or a different one. A sleep or network drop reconnects on its own without closing the tab (see [Surviving sleep/wake](#surviving-sleepwake)); an explicit `connect` is only needed after you deliberately quit or move to another machine.
 2. **Hooks never cross the network.** Agents run on the remote and so does the daemon; hook events travel over a Unix socket on the remote. Network drops do not lose hook events.
 3. **One environment per project.** A remote is registered to a single project's working tree on the host. Running multiple projects on one host is supported (one directory per project under `~/projects/`), but each project should still be one registered remote.
 
@@ -82,7 +82,7 @@ Two distinct user actions; very different consequences.
 | **Stop** (`Ctrl+W` on a remote pane) | Sends `StopAgent` to the daemon over the local-on-remote socket; the daemon kills the PTY and removes the agent from the registry. | You're done with the agent; want it gone. |
 | **Detach** (Ctrl+C in dashboard, then "Detach" in the dialog) | The TUI sends an explicit `KIND_DETACH` frame to the daemon on its Unix socket, then exits. The daemon records a clean detach and keeps the agents running. The ssh session ends when the TUI exits. | You want to step away and come back later, and want the daemon's logs to show a voluntary detach. |
 | **Quit** (Ctrl+C in dashboard, then "Quit") | The TUI exits without sending a detach frame. The daemon observes EOF on its socket and treats it the same as detach — agents stay alive. The ssh session ends when the TUI exits. | You're done for the day; don't need the explicit signal. |
-| **Sleep / network drop** (no action) | The ssh session dies abruptly; the remote TUI process is killed by its lost controlling terminal, but the daemon is a separate process and keeps running. Agents stay alive. | Implicit; happens automatically when the laptop disconnects. |
+| **Sleep / network drop** (no action) | SSH keepalive detects the dead connection within ~45s and ssh exits; `connect` then re-probes and **reconnects automatically** to the still-running agents, so the session resumes in place. The daemon and agents never stopped. See [Surviving sleep/wake](#surviving-sleepwake). | Implicit; happens automatically when the laptop sleeps or the network drops. |
 
 The TUI reflects this split in its quit dialog. Pressing `Ctrl+C` in the dashboard opens a three-option prompt:
 
@@ -99,6 +99,19 @@ Quit and Detach both leave agents running. The only difference is that Detach se
 Run `connect` again. That re-runs `ssh -t` to the remote, which launches a fresh TUI; the TUI calls `list_agents` on the still-running daemon and hydrates one pane per agent (each `AgentRecord` carries the agent's `display_name` and `cwd`, so the dashboard looks the way you left it). Each pane then attaches to the daemon's per-agent stream, and the daemon replays its scrollback snapshot as the first bytes of the new attach so you can see what was happening while you were gone.
 
 Per-agent scrollback is a 1 MiB ring buffer (`SCROLLBACK_CAP_BYTES` in `src/agent_pty.rs`): if an agent produced more than 1 MiB since you last attached, the oldest bytes are evicted. This is not a feature ceiling — long-running agent transcripts are best read from the agent's own log file, not the deck's scrollback buffer.
+
+## Surviving sleep/wake
+
+A long-lived `connect` session survives the laptop sleeping or the network dropping out from under it — you don't have to close the tab and start over. Reopen the laptop and the session reconnects to the same running agents on its own. Two mechanisms cooperate:
+
+1. **SSH keepalive detects the dead connection.** When the laptop sleeps, the TCP connection dies silently — the sleeping endpoint never sends a FIN/RST, so on wake ssh is parked on a dead socket it can't tell is dead, and the TUI freezes. To prevent that, the live session probes the remote over the encrypted channel every 15 seconds (`ServerAliveInterval=15`) and aborts after 3 consecutive unanswered probes (`ServerAliveCountMax=3`). So a connection killed by sleep is noticed and torn down within roughly **45 seconds** of wake instead of hanging forever. Probing over the encrypted channel works through NAT and firewalls, unlike TCP-level keepalive.
+2. **`connect` reconnects automatically.** When ssh exits because the transport dropped (its exit code 255), `connect` prints `connection to <name> lost — reconnecting…` to stderr, re-runs its version/protocol probe to confirm the host is reachable again, and re-launches the TUI. Because the daemon and agents on the remote never stopped (see [Reattaching](#reattaching)), the fresh session re-attaches to the **same running agents** — you see your session resume, not a blank dashboard.
+
+Reconnection is **bounded**, so a genuinely-gone remote surfaces an error instead of looping forever: `connect` retries up to four times after the initial drop, with a short backoff between attempts. If the host is still unreachable when the budget is exhausted, `connect` prints a clear "giving up" message, restores your local terminal to a sane state (a session interrupted mid-stream may otherwise leave the terminal in raw mode), and exits.
+
+Only a **dropped transport** triggers a reconnect. A clean quit or detach (exit 0), a `Ctrl-C` (exit 130), or a remote-side crash all end the session immediately — `connect` never reconnects into an intentional exit or a crashing TUI, and `last_connected` is recorded only on a clean exit, not on intermediate reconnects.
+
+The keepalive interval/count and retry budget are sensible fixed defaults today; exposing them as configuration is a future improvement.
 
 ## Failure modes
 

--- a/prds/148-remote-connect-survive-sleep-wake.md
+++ b/prds/148-remote-connect-survive-sleep-wake.md
@@ -1,6 +1,6 @@
 # PRD #148: Remote connect survives laptop sleep/wake
 
-**Status**: Planning
+**Status**: In Progress — implementation, tests, and docs complete (M1–M3, M5); pending real-remote sleep/wake verification (M4)
 **Priority**: High
 **Created**: 2026-06-12
 **GitHub Issue**: [#148](https://github.com/vfarcic/dot-agent-deck/issues/148)
@@ -85,28 +85,28 @@ Why this is safe and correct:
 ## Acceptance Criteria
 
 ### Keepalive on live session
-- [ ] `build_connect_command` emits `-o ServerAliveInterval=<n>` and `-o ServerAliveCountMax=<m>` in addition to the existing `ConnectTimeout`.
-- [ ] After a real sleep/wake (or a simulated transport drop), the ssh session terminates within roughly `interval × countMax` seconds instead of hanging indefinitely.
-- [ ] The probe path in `src/remote.rs` is unchanged (still `ServerAliveCountMax=1`).
+- [x] `build_connect_command` emits `-o ServerAliveInterval=<n>` and `-o ServerAliveCountMax=<m>` in addition to the existing `ConnectTimeout`. *(M1: `LIVE_KEEPALIVE_INTERVAL_SECS=15`, `LIVE_KEEPALIVE_COUNT_MAX=3`; arg-assertion test updated.)*
+- [ ] After a real sleep/wake (or a simulated transport drop), the ssh session terminates within roughly `interval × countMax` seconds instead of hanging indefinitely. *(Runtime ssh behavior — pending M4 real-remote verification.)*
+- [x] The probe path in `src/remote.rs` is unchanged (still `ServerAliveCountMax=1`). *(Confirmed untouched by reviewer + auditor.)*
 
 ### Auto-reconnect
-- [ ] When `spawn` returns 255, `run_connect` re-probes and re-spawns rather than returning; the user is shown a "reconnecting to `<name>`…" message between sessions.
-- [ ] On reconnect, the remote TUI re-attaches to the still-running agents (verified the session resumes, not a fresh empty dashboard).
-- [ ] A clean remote exit (0), a Ctrl-C/signal exit (e.g. 130/143), and a non-255 remote-TUI crash all return immediately with that exit code — **no** reconnect.
-- [ ] Reconnection is bounded by a retry/backoff budget; once exhausted, `run_connect` returns a clear error and restores a sane local terminal.
-- [ ] `last_connected` bookkeeping still updates only on a genuine clean exit (status 0), not on intermediate reconnects.
+- [x] When `spawn` returns 255, `run_connect` re-probes and re-spawns rather than returning; the user is shown a "reconnecting to `<name>`…" message between sessions. *(M2; test `reconnect_then_clean_exit_returns_zero`.)*
+- [ ] On reconnect, the remote TUI re-attaches to the still-running agents (verified the session resumes, not a fresh empty dashboard). *(Real-remote behavior — pending M4 verification.)*
+- [x] A clean remote exit (0), a Ctrl-C/signal exit (e.g. 130/143), and a non-255 remote-TUI crash all return immediately with that exit code — **no** reconnect. *(Tests `clean_exit_does_not_reconnect`, `ctrl_c_exit_is_terminal_no_reconnect`.)*
+- [x] Reconnection is bounded by a retry/backoff budget; once exhausted, `run_connect` returns a clear error and restores a sane local terminal. *(`MAX_CONNECT_ATTEMPTS=5`; tests `repeated_transport_failure_is_bounded`, `reconnect_time_unreachable_is_bounded_not_immediate`; terminal restore on both give-up routes.)*
+- [x] `last_connected` bookkeeping still updates only on a genuine clean exit (status 0), not on intermediate reconnects. *(Asserted in reconnect tests.)*
 
 ### Tests
-- [ ] Unit test: `build_connect_command` arg assertion updated to expect the new keepalive options.
-- [ ] Unit tests via the fake `ConnectSpawner` + fake `SshExecutor`: `[255, 0]` ⇒ exactly two spawns + one reconnect, returns 0; `[0]` ⇒ one spawn, no reconnect; `[130]` ⇒ one spawn, no reconnect; repeated `255` ⇒ bounded number of spawns then a terminal error (backoff sleep is injectable so tests don't actually wait).
+- [x] Unit test: `build_connect_command` arg assertion updated to expect the new keepalive options.
+- [x] Unit tests via the fake `ConnectSpawner` + fake `SshExecutor`: `[255, 0]` ⇒ exactly two spawns + one reconnect, returns 0; `[0]` ⇒ one spawn, no reconnect; `[130]` ⇒ one spawn, no reconnect; repeated `255` ⇒ bounded number of spawns then a terminal error (backoff sleep is injectable so tests don't actually wait). *(All present; plus reconnect-time probe-failure bounded-retry coverage.)*
 
 ## Milestones
 
-- [ ] **M1 — Keepalive on the live session.** Add `ServerAliveInterval`/`ServerAliveCountMax` to `build_connect_command` with named constants; update the existing arg-assertion unit test. (Layer 1 alone already removes the freeze.)
-- [ ] **M2 — Auto-reconnect loop.** Wrap spawn/bookkeeping in `run_connect` with the 255-keyed, probe-gated, bounded-backoff reconnect loop, including user-visible messaging and local-terminal restore on give-up. Make the backoff sleep injectable for tests.
-- [ ] **M3 — Tests.** Fake-spawner/fake-executor unit tests covering the reconnect state machine and exit-code routing (M2 acceptance list); confirm `cargo test-fast`, `cargo fmt --check`, `cargo clippy -- -D warnings` are green.
-- [ ] **M4 — Verified against a real remote.** Connect to a remote daemon, sleep/wake the laptop (or drop the network), and confirm the session is dropped promptly and auto-reconnects to the running agents without closing the tab. Run `cargo test-e2e` before the PR.
-- [ ] **M5 — Docs.** Update the Remote Environments docs to note that sessions now survive sleep/wake and auto-reconnect, including the keepalive tuning knobs and the bounded-retry behavior.
+- [x] **M1 — Keepalive on the live session.** Add `ServerAliveInterval`/`ServerAliveCountMax` to `build_connect_command` with named constants; update the existing arg-assertion unit test. (Layer 1 alone already removes the freeze.)
+- [x] **M2 — Auto-reconnect loop.** Wrap spawn/bookkeeping in `run_connect` with the 255-keyed, probe-gated, bounded-backoff reconnect loop, including user-visible messaging and local-terminal restore on give-up. Make the backoff sleep injectable for tests. *(Review blocker found + fixed: reconnect-time `HostUnreachable` probe failures now fold into the same bounded retry/restore path via `is_reachability_error` + shared `on_transport_failure`.)*
+- [x] **M3 — Tests.** Fake-spawner/fake-executor unit tests covering the reconnect state machine and exit-code routing (M2 acceptance list); confirm `cargo test-fast`, `cargo fmt --check`, `cargo clippy -- -D warnings` are green. *(`cargo test-fast` 708 passed; fmt clean; clippy 0 warnings.)*
+- [ ] **M4 — Verified against a real remote.** Connect to a remote daemon, sleep/wake the laptop (or drop the network), and confirm the session is dropped promptly and auto-reconnects to the running agents without closing the tab. Run `cargo test-e2e` before the PR. *(`cargo test-e2e` 1026 passed; real-hardware sleep/wake manual check still pending — a user step.)*
+- [x] **M5 — Docs.** Update the Remote Environments docs to note that sessions now survive sleep/wake and auto-reconnect, including the keepalive tuning knobs and the bounded-retry behavior. *(`docs/remote-environments.md`: new "Surviving sleep/wake" section + updated Stop-vs-detach row.)*
 
 ## Out of Scope
 

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -22,6 +22,7 @@
 use std::io::{BufRead, Write};
 use std::path::Path;
 use std::process::Command;
+use std::time::Duration;
 
 use thiserror::Error;
 
@@ -71,6 +72,44 @@ const PROBE_TIMEOUT_ENV: &str = "DOT_AGENT_DECK_SSH_PROBE_TIMEOUT_SECS";
 /// that module here because connect.rs is built into the laptop CLI surface
 /// and shouldn't pull agent-side internals into its dependency graph.
 const VIA_DAEMON_ENV: &str = "DOT_AGENT_DECK_VIA_DAEMON";
+
+/// PRD #148: SSH keepalive cadence for the *live* connect session. Once an
+/// `ssh -t` session is up ssh otherwise keeps it alive indefinitely with no
+/// liveness probing, so a connection killed by laptop sleep is never noticed
+/// and the TUI freezes on a dead socket. `ServerAlive*` makes ssh probe the
+/// peer over the encrypted channel every `LIVE_KEEPALIVE_INTERVAL_SECS` and
+/// drop the session after `LIVE_KEEPALIVE_COUNT_MAX` consecutive unanswered
+/// probes, so a dead connection is torn down within roughly
+/// `interval × count` (~45s) instead of hanging forever.
+///
+/// Distinct from the probe path in `remote.rs` (`ServerAliveCountMax=1`, which
+/// wants fail-fast): the live interactive session uses a higher count so a
+/// brief real network blip (15–30s) doesn't tear down a working session.
+const LIVE_KEEPALIVE_INTERVAL_SECS: u64 = 15;
+const LIVE_KEEPALIVE_COUNT_MAX: u64 = 3;
+
+/// PRD #148: total number of `ssh -t` spawns `run_connect` will attempt before
+/// giving up — the initial connect plus up to `MAX_CONNECT_ATTEMPTS - 1`
+/// automatic reconnects after a transport drop (ssh exit 255). Bounded so a
+/// genuinely-gone remote surfaces an error and a sane exit code instead of
+/// looping forever; with [`RECONNECT_BACKOFF`] this caps the reconnect window
+/// at roughly `(MAX_CONNECT_ATTEMPTS - 1) × backoff` plus probe round-trips.
+const MAX_CONNECT_ATTEMPTS: usize = 5;
+
+/// PRD #148: fixed delay between reconnect attempts. Gives a just-woken
+/// laptop's network a moment to come back (wifi association, DHCP, VPN) before
+/// the next re-probe; the probe itself is the reachability gate, this just
+/// avoids hammering it the instant ssh reports the drop.
+const RECONNECT_BACKOFF: Duration = Duration::from_secs(2);
+
+/// PRD #148: ssh's own exit code for a transport/auth failure (dropped
+/// connection, keepalive timeout, refused, auth). ssh passes a clean remote
+/// exit through verbatim, so 255 uniquely marks "the transport died, not the
+/// user quit" — the signal auto-reconnect keys on. Also returned by
+/// `run_connect` when the reconnect budget is exhausted, since a transport
+/// failure is ultimately what happened. Mirrors the contract documented at
+/// `src/remote.rs` (the exit-255 handling in `SystemSshExecutor::run`).
+const SSH_TRANSPORT_FAILURE_EXIT_CODE: i32 = 255;
 
 #[derive(Debug, Error)]
 pub enum RemoteConnectError {
@@ -631,11 +670,22 @@ fn map_probe_ssh_error(name: &str, err: SshError) -> RemoteConnectError {
 pub fn build_connect_command(target: &SshTarget, install_path: &str) -> Command {
     let mut cmd = Command::new("ssh");
     cmd.arg("-t");
-    // ConnectTimeout (separate from session-runtime — once the session is up,
-    // ssh keeps it alive indefinitely). Aligned with the version probe so the
-    // two stages have the same fail-fast budget.
+    // ConnectTimeout caps only the pre-handshake phase. Once the session is up
+    // ssh would otherwise keep it alive indefinitely with no liveness probing,
+    // so a connection killed by laptop sleep is never noticed and the TUI
+    // freezes on a dead socket. ServerAlive* (PRD #148) makes ssh probe the
+    // peer over the encrypted channel (works through NAT/firewalls, unlike
+    // TCPKeepAlive) and abort after ServerAliveCountMax consecutive unanswered
+    // probes — so a dead connection is dropped within ~interval×count instead
+    // of hanging forever. CountMax here is higher than the remote.rs probe
+    // path's (=1) so a brief real network blip doesn't tear down a live
+    // interactive session.
     cmd.arg("-o")
         .arg(format!("ConnectTimeout={}", probe_timeout_secs()));
+    let keepalive_interval = format!("ServerAliveInterval={LIVE_KEEPALIVE_INTERVAL_SECS}");
+    let keepalive_count = format!("ServerAliveCountMax={LIVE_KEEPALIVE_COUNT_MAX}");
+    cmd.arg("-o").arg(&keepalive_interval);
+    cmd.arg("-o").arg(&keepalive_count);
     cmd.arg("-p").arg(target.port.to_string());
     if let Some(key) = &target.key {
         cmd.arg("-i").arg(key);
@@ -688,6 +738,67 @@ impl ConnectSpawner for SystemConnectSpawner {
     }
 }
 
+/// PRD #148: abstraction over the inter-attempt backoff sleep in the
+/// reconnect loop. Production sleeps for real ([`SleepBackoff`]); unit tests
+/// inject a recorder that returns immediately and counts invocations, so the
+/// reconnect state machine can be exercised without real wall-clock delays.
+/// Modeled on the [`ConnectSpawner`] / [`SshExecutor`] seams already used to
+/// keep the connect path testable.
+pub trait ReconnectBackoff {
+    /// Sleep before the next reconnect attempt. `attempt` is the 1-based index
+    /// of the reconnect about to be made (the production impl uses a fixed
+    /// delay and ignores it; the parameter leaves room for an exponential
+    /// policy later without another signature change).
+    fn backoff(&self, attempt: usize);
+}
+
+/// Production backoff: sleeps [`RECONNECT_BACKOFF`] on the calling thread.
+pub struct SleepBackoff;
+
+impl SleepBackoff {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SleepBackoff {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReconnectBackoff for SleepBackoff {
+    fn backoff(&self, _attempt: usize) {
+        std::thread::sleep(RECONNECT_BACKOFF);
+    }
+}
+
+/// PRD #148: best-effort restore of a sane local terminal after auto-reconnect
+/// gives up.
+///
+/// When ssh dies on a transport failure, the *remote* TUI never ran its own
+/// teardown (leave alternate screen, show cursor, disable mouse reporting), so
+/// the laptop terminal is left in the remote app's screen state. A successful
+/// reconnect re-inits the terminal via the next `ssh -t`; but when we exhaust
+/// the retry budget there is no new session to fix it, so we reset it here.
+///
+/// ssh normally restores the local line discipline itself (it owns the raw
+/// mode it set for `-t`), but we still attempt a cooked-mode restore in case
+/// it didn't. Everything is best-effort: errors are ignored (no controlling
+/// tty under tests; an unwritable terminal can't be helped on the give-up
+/// path anyway).
+fn restore_local_terminal() {
+    // Cooked-mode restore in case ssh's own cleanup didn't run.
+    let _ = crossterm::terminal::disable_raw_mode();
+    // Leave the alternate screen, show the cursor, disable the common
+    // mouse-tracking modes, and reset SGR attributes — the state a
+    // ratatui/crossterm TUI typically leaves set.
+    let mut out = std::io::stdout();
+    let _ =
+        out.write_all(b"\x1b[?1049l\x1b[?25h\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[0m");
+    let _ = out.flush();
+}
+
 /// Map a child `ExitStatus` to the conventional shell exit code.
 ///
 /// - Normal exit: pass through `status.code()` verbatim, so a remote shell
@@ -730,78 +841,190 @@ fn touch_last_connected(name: &str, path: &Path) -> Result<Option<String>, Remot
     Ok(Some(now))
 }
 
-/// Orchestrate one connect: probe → spawn `ssh -t` → record `last_connected`.
+/// PRD #148: classify a probe error as the "host not reachable *yet*" class
+/// (transient) vs a genuine incompatibility (fatal). Every ssh-transport-level
+/// probe failure folds into [`RemoteConnectError::HostUnreachable`] (see
+/// `map_probe_ssh_error`), so that single variant captures the reachability
+/// class. Everything else — binary missing, protocol/build mismatch, handshake
+/// rejection, spawn/IO/registry failures — is a problem retrying can't fix, so
+/// it stays fatal even on a reconnect and we never blindly retry into an
+/// incompatible or absent remote.
+fn is_reachability_error(err: &RemoteConnectError) -> bool {
+    matches!(err, RemoteConnectError::HostUnreachable { .. })
+}
+
+/// PRD #148: shared bounded-retry decision for a transport failure on attempt
+/// `attempt` (1-based) — either a spawn that returned 255 or a reconnect-time
+/// reachability probe failure. Returns `Some(exit_code)` when the retry budget
+/// is exhausted (caller should `return Ok(code)`); returns `None` after backing
+/// off (caller should `continue` to the next attempt).
 ///
-/// Returns ssh's exit code so the caller can propagate it as the laptop
-/// process's exit code (mirroring `ssh`'s own behavior — a remote shell
-/// that exits 17 makes `ssh` exit 17, and we keep that contract one level
-/// up). `last_connected` is only updated on a clean exit (status 0):
+/// On give-up it restores a sane local terminal — the remote TUI never got to
+/// leave alt screen / raw mode when the transport died — and prints the
+/// "giving up" line to stderr, so BOTH the spawn-255 path and the
+/// reconnect-probe-failure path restore the terminal and surface the same
+/// message. Keeping this in one place is what guarantees a still-unreachable
+/// host on a reconnect can't escape the loop without counting against the
+/// budget, backing off, and (on exhaustion) restoring the terminal.
+fn on_transport_failure(attempt: usize, name: &str, backoff: &dyn ReconnectBackoff) -> Option<i32> {
+    if attempt >= MAX_CONNECT_ATTEMPTS {
+        // Budget exhausted: the remote stayed unreachable across every attempt.
+        restore_local_terminal();
+        eprintln!(
+            "connection to '{}' lost and could not be re-established after {} attempts — giving up.",
+            name, MAX_CONNECT_ATTEMPTS
+        );
+        return Some(SSH_TRANSPORT_FAILURE_EXIT_CODE);
+    }
+    // Message goes to stderr, between the handed-over terminal sessions.
+    // `attempt + 1` is the attempt we're about to make.
+    eprintln!(
+        "connection to '{}' lost — reconnecting… (attempt {}/{})",
+        name,
+        attempt + 1,
+        MAX_CONNECT_ATTEMPTS
+    );
+    backoff.backoff(attempt);
+    None
+}
+
+/// Orchestrate one connect: probe → spawn `ssh -t` → record `last_connected`,
+/// with PRD #148 auto-reconnect wrapped around the probe/spawn step.
+///
+/// The whole probe + spawn + bookkeeping flow runs inside a loop keyed on
+/// ssh's transport-failure exit code (255). ssh passes a clean remote exit
+/// through verbatim (TUI quit → 0, Ctrl-C → 130, SIGTERM → 143, remote panic
+/// → its own non-255 code) and reserves 255 for its own connection/auth
+/// failures, so we reconnect *only* on a dropped transport — never on a user
+/// quitting or a crashing remote TUI (which would just crash again):
+///
+/// - **exit 255** → print a "reconnecting…" line to stderr, back off
+///   ([`ReconnectBackoff`], injectable so tests don't really sleep), and loop
+///   to re-probe + re-spawn. The remote daemon is external and persistent
+///   (#93) and the remote TUI restores its view from daemon state on startup
+///   (#89), so a fresh `ssh -t` re-attaches to the *same* running agents.
+/// - **any other code** → terminal; returned verbatim. ssh's exit code
+///   propagates as the laptop process's exit code (a remote shell that exits
+///   17 makes the laptop exit 17 — same contract one level up).
+///
+/// The re-probe each attempt doubles as the reachability gate: right after
+/// sleep/wake the laptop's wifi/DHCP may not be back, so the *initial*
+/// connect's probe is fatal (returns the existing "Could not reach…" error),
+/// but a probe **reachability** failure on a *reconnect* attempt
+/// ([`is_reachability_error`]) folds into the SAME bounded-retry/backoff/
+/// give-up path a dropped session uses — otherwise a still-down network would
+/// let the reconnect escape the loop without counting against the budget,
+/// backing off, or restoring the terminal. Genuine incompatibilities
+/// (protocol/build mismatch, missing binary) stay fatal even on a reconnect.
+///
+/// Reconnection is bounded by [`MAX_CONNECT_ATTEMPTS`]. When exhausted we
+/// restore a sane local terminal (the remote TUI never got to leave alt
+/// screen / raw mode when ssh died mid-session), print a "giving up" line, and
+/// return [`SSH_TRANSPORT_FAILURE_EXIT_CODE`] — surfacing the transport
+/// failure as the process exit code rather than looping forever.
+///
+/// `last_connected` is only updated on a genuine clean exit (status 0), never
+/// on an intermediate 255 reconnect:
 ///
 /// - User exits the TUI cleanly → laptop registry records the session.
-/// - User Ctrl-C's the ssh, daemon dies, network drops mid-session → no
-///   bookkeeping update; the registry only ever shows sessions that
-///   actually ran to completion.
-///
-/// `_cli_theme` and `_continue_session` are accepted to preserve the
-/// existing call site (M2.7-era stub) but are *intentionally ignored* in
-/// M2.9. The remote TUI runs on the remote, so a laptop-side `--theme` /
-/// `--continue` would have no effect on what the user sees. Piping them
-/// through as remote flags is a future ergonomic improvement (deferred to
-/// M5.5 when the connect UX is documented end-to-end).
+/// - User Ctrl-C's the ssh, daemon dies, network drops mid-session, or we
+///   exhaust reconnects → no bookkeeping update; the registry only ever shows
+///   sessions that actually ran to completion.
 pub fn run_connect(
     entry: &RemoteEntry,
     executor: &dyn SshExecutor,
     spawner: &dyn ConnectSpawner,
+    backoff: &dyn ReconnectBackoff,
     remotes_path: &Path,
     local_version: &str,
     install_path: &str,
 ) -> Result<i32, RemoteConnectError> {
     let target = entry.ssh_target();
 
-    // Stage 1: binary-version probe. Errors short-circuit; warnings (mismatch)
-    // get surfaced on stderr and we proceed.
-    match probe_remote_version(executor, &target, &entry.name, install_path, local_version)? {
-        ProbeOutcome::Match => {}
-        ProbeOutcome::Mismatch { remote, local } => {
-            eprintln!(
-                "warning: remote '{}' runs dot-agent-deck {}; laptop runs {}. Run `dot-agent-deck remote upgrade {}` to align.",
-                entry.name, remote, local, entry.name
-            );
+    // 1-based count of connect attempts made (initial connect + reconnects).
+    // This is the retry budget: a transport failure on attempt N — a spawn
+    // that returned 255, OR (on a reconnect) a reachability probe failure —
+    // gives up once N reaches MAX_CONNECT_ATTEMPTS.
+    let mut attempt = 0usize;
+    loop {
+        attempt += 1;
+
+        // Stage 1: binary-version probe. A version *mismatch* warns and
+        // proceeds. A probe *error* is fatal on the initial connect (returns
+        // the existing "Could not reach…" UX), but on a RECONNECT a
+        // reachability failure (the normal "wifi/DHCP not back yet" state after
+        // sleep/wake) folds into the same bounded-retry/backoff/give-up path a
+        // dropped session uses — see `on_transport_failure`. Genuine
+        // incompatibilities stay fatal even on a reconnect.
+        match probe_remote_version(executor, &target, &entry.name, install_path, local_version) {
+            Ok(ProbeOutcome::Match) => {}
+            Ok(ProbeOutcome::Mismatch { remote, local }) => {
+                eprintln!(
+                    "warning: remote '{}' runs dot-agent-deck {}; laptop runs {}. Run `dot-agent-deck remote upgrade {}` to align.",
+                    entry.name, remote, local, entry.name
+                );
+            }
+            Err(e) if attempt > 1 && is_reachability_error(&e) => {
+                match on_transport_failure(attempt, &entry.name, backoff) {
+                    Some(code) => return Ok(code),
+                    None => continue,
+                }
+            }
+            Err(e) => return Err(e),
         }
-    }
 
-    // Stage 1b: protocol-version handshake. A binary-version match doesn't
-    // guarantee wire-format compatibility (the protocol is bumped
-    // independently of the binary semver, see PRD #76 M2.21), and a
-    // binary-version mismatch can still be safe if the protocol versions
-    // agree. Fail the connect with a clear error on any protocol disagreement
-    // — the wire format isn't backward-compatible and the silent failure
-    // mode (frozen dashboard, no error) is worse than a hard-stop here.
-    probe_remote_protocol(executor, &target, &entry.name, install_path)?;
+        // Stage 1b: protocol-version handshake. A binary-version match doesn't
+        // guarantee wire-format compatibility (the protocol is bumped
+        // independently of the binary semver, see PRD #76 M2.21), and a
+        // binary-version mismatch can still be safe if the protocol versions
+        // agree. Same reachability-vs-fatal split as the version probe: a
+        // transient transport failure on a reconnect retries, but a
+        // protocol/build incompatibility (the downgrade/safety case) stays
+        // fatal so we never re-spawn into an incompatible remote.
+        match probe_remote_protocol(executor, &target, &entry.name, install_path) {
+            Ok(()) => {}
+            Err(e) if attempt > 1 && is_reachability_error(&e) => {
+                match on_transport_failure(attempt, &entry.name, backoff) {
+                    Some(code) => return Ok(code),
+                    None => continue,
+                }
+            }
+            Err(e) => return Err(e),
+        }
 
-    // Stage 2: hand the terminal over. This blocks until the user exits.
-    let exit_code =
-        spawner
-            .spawn(&target, install_path)
-            .map_err(|source| RemoteConnectError::SpawnFailed {
+        // Stage 2: hand the terminal over. This blocks until the user exits.
+        let exit_code = spawner.spawn(&target, install_path).map_err(|source| {
+            RemoteConnectError::SpawnFailed {
                 name: entry.name.clone(),
                 source,
-            })?;
+            }
+        })?;
 
-    // Stage 3: bookkeeping. Only on a clean exit — see doc comment.
-    if exit_code == 0 {
-        // Registry I/O failures here are reported but don't fail the
-        // command — the user already finished their session, and a busted
-        // registry shouldn't surface as a connect error after the fact.
-        if let Err(e) = touch_last_connected(&entry.name, remotes_path) {
-            eprintln!(
-                "warning: connect to '{}' succeeded but the registry update failed: {}",
-                entry.name, e
-            );
+        // Stage 3: route on the exit code. Reconnect ONLY on ssh's
+        // transport-failure code (255); any other code is terminal.
+        if exit_code == SSH_TRANSPORT_FAILURE_EXIT_CODE {
+            match on_transport_failure(attempt, &entry.name, backoff) {
+                Some(code) => return Ok(code),
+                None => continue,
+            }
         }
-    }
 
-    Ok(exit_code)
+        // Terminal exit (clean 0, Ctrl-C 130, SIGTERM 143, non-255 crash).
+        // Bookkeeping only on a genuine clean exit — see doc comment.
+        if exit_code == 0 {
+            // Registry I/O failures here are reported but don't fail the
+            // command — the user already finished their session, and a busted
+            // registry shouldn't surface as a connect error after the fact.
+            if let Err(e) = touch_last_connected(&entry.name, remotes_path) {
+                eprintln!(
+                    "warning: connect to '{}' succeeded but the registry update failed: {}",
+                    entry.name, e
+                );
+            }
+        }
+
+        return Ok(exit_code);
+    }
 }
 
 /// Public entry point used by `main.rs`'s `run_connect` handler. Wires up
@@ -818,10 +1041,12 @@ pub fn run_connect_default(
     // `connect` indefinitely (cmd.output() has no timeout of its own).
     let executor = SystemSshExecutor::with_wallclock_timeout(probe_timeout_secs());
     let spawner = SystemConnectSpawner::new();
+    let backoff = SleepBackoff::new();
     run_connect(
         entry,
         &executor,
         &spawner,
+        &backoff,
         remotes_path,
         local_version,
         REMOTE_INSTALL_PATH,
@@ -855,6 +1080,24 @@ mod tests {
         // -t must be present (remote TUI requires a pty); install_path is
         // passed verbatim and the env var is set on the remote shell.
         assert_eq!(args[0], "-t", "must request remote pty: {args:?}");
+        // PRD #148: the live session carries ConnectTimeout *and* the
+        // ServerAlive* keepalive pair so a sleep-killed connection is detected
+        // and dropped instead of hanging forever. The keepalive count is the
+        // tolerant value (3), distinct from the probe path's fail-fast 1.
+        assert!(
+            args.iter().any(|a| a.starts_with("ConnectTimeout=")),
+            "must set ConnectTimeout: {args:?}"
+        );
+        assert!(
+            args.iter()
+                .any(|a| a == &format!("ServerAliveInterval={LIVE_KEEPALIVE_INTERVAL_SECS}")),
+            "must set ServerAliveInterval={LIVE_KEEPALIVE_INTERVAL_SECS}: {args:?}"
+        );
+        assert!(
+            args.iter()
+                .any(|a| a == &format!("ServerAliveCountMax={LIVE_KEEPALIVE_COUNT_MAX}")),
+            "must set ServerAliveCountMax={LIVE_KEEPALIVE_COUNT_MAX}: {args:?}"
+        );
         assert!(
             args.iter()
                 .any(|a| a == "DOT_AGENT_DECK_VIA_DAEMON=1"
@@ -982,5 +1225,411 @@ mod tests {
         assert_eq!(exit_code_from_status(&sigterm), 143);
         let sigkill = std::process::ExitStatus::from_raw(9);
         assert_eq!(exit_code_from_status(&sigkill), 137);
+    }
+
+    // ----- PRD #148: auto-reconnect state machine -----
+
+    use crate::remote::SshOutput;
+    use std::cell::Cell;
+
+    const TEST_LOCAL_VERSION: &str = "9.9.9";
+
+    /// Fake executor whose probes always succeed: `--version` echoes the
+    /// laptop version and `daemon hello` returns a matching protocol/build
+    /// handshake. Counts invocations so a test can confirm the *full* probe
+    /// (version + protocol) re-runs on every reconnect attempt.
+    struct ProbeOkExecutor {
+        local_version: String,
+        runs: Cell<usize>,
+    }
+
+    impl ProbeOkExecutor {
+        fn new(local_version: &str) -> Self {
+            Self {
+                local_version: local_version.to_string(),
+                runs: Cell::new(0),
+            }
+        }
+        fn run_count(&self) -> usize {
+            self.runs.get()
+        }
+    }
+
+    impl SshExecutor for ProbeOkExecutor {
+        fn run(&self, _target: &SshTarget, command: &str) -> Result<SshOutput, SshError> {
+            self.runs.set(self.runs.get() + 1);
+            if command.contains("daemon hello") {
+                // `hello()` carries server_version == PROTOCOL_VERSION and
+                // build_version == local_build_id(), which is exactly what
+                // probe_remote_protocol compares against in-process — so the
+                // handshake matches without any env juggling.
+                let body = serde_json::to_string(&AttachResponse::hello(PROTOCOL_VERSION))
+                    .expect("serialize hello");
+                Ok(SshOutput {
+                    status: 0,
+                    stdout: body,
+                    stderr: String::new(),
+                })
+            } else if command.contains("--version") {
+                Ok(SshOutput {
+                    status: 0,
+                    stdout: format!("dot-agent-deck {}\n", self.local_version),
+                    stderr: String::new(),
+                })
+            } else {
+                panic!("unexpected probe command: {command}");
+            }
+        }
+    }
+
+    /// Fake executor that lets the FIRST connect's probe succeed, then fails
+    /// every later `--version` probe with an ssh transport error. The connect
+    /// path folds that into [`RemoteConnectError::HostUnreachable`] — the
+    /// canonical "host not reachable yet" state on a reconnect right after
+    /// sleep/wake, before wifi/DHCP recover. Used to prove a reconnect-time
+    /// reachability failure is bounded (counts against the budget, backs off)
+    /// instead of escaping the loop on the first re-probe.
+    ///
+    /// `daemon hello` always succeeds, but it's only ever reached on the first
+    /// attempt: on reconnects the `--version` probe fails first and short-
+    /// circuits before the protocol handshake runs.
+    struct UnreachableAfterFirstConnectExecutor {
+        local_version: String,
+        version_calls: Cell<usize>,
+    }
+
+    impl UnreachableAfterFirstConnectExecutor {
+        fn new(local_version: &str) -> Self {
+            Self {
+                local_version: local_version.to_string(),
+                version_calls: Cell::new(0),
+            }
+        }
+    }
+
+    impl SshExecutor for UnreachableAfterFirstConnectExecutor {
+        fn run(&self, target: &SshTarget, command: &str) -> Result<SshOutput, SshError> {
+            if command.contains("daemon hello") {
+                let body = serde_json::to_string(&AttachResponse::hello(PROTOCOL_VERSION))
+                    .expect("serialize hello");
+                return Ok(SshOutput {
+                    status: 0,
+                    stdout: body,
+                    stderr: String::new(),
+                });
+            }
+            if command.contains("--version") {
+                let n = self.version_calls.get();
+                self.version_calls.set(n + 1);
+                if n == 0 {
+                    // First connect: reachable.
+                    return Ok(SshOutput {
+                        status: 0,
+                        stdout: format!("dot-agent-deck {}\n", self.local_version),
+                        stderr: String::new(),
+                    });
+                }
+                // Every reconnect attempt: host not reachable yet. An ssh
+                // transport error maps to HostUnreachable in probe_remote_version.
+                return Err(SshError::ConnectionRefused {
+                    host: target.host.clone(),
+                    port: target.port,
+                    detail: "connection refused".to_string(),
+                });
+            }
+            panic!("unexpected probe command: {command}");
+        }
+    }
+
+    /// Fake spawner returning a scripted sequence of exit codes, counting
+    /// spawns. Past the end of the script it repeats the last code, so "always
+    /// 255" is a one-element script and an unexpected extra spawn surfaces as a
+    /// failed count assertion rather than a panic.
+    struct ScriptedSpawner {
+        codes: Vec<i32>,
+        calls: Cell<usize>,
+    }
+
+    impl ScriptedSpawner {
+        fn new(codes: Vec<i32>) -> Self {
+            assert!(!codes.is_empty(), "script needs at least one exit code");
+            Self {
+                codes,
+                calls: Cell::new(0),
+            }
+        }
+        fn spawn_count(&self) -> usize {
+            self.calls.get()
+        }
+    }
+
+    impl ConnectSpawner for ScriptedSpawner {
+        fn spawn(&self, _target: &SshTarget, _install_path: &str) -> Result<i32, std::io::Error> {
+            let n = self.calls.get();
+            self.calls.set(n + 1);
+            let code = self
+                .codes
+                .get(n)
+                .copied()
+                .unwrap_or_else(|| *self.codes.last().expect("non-empty"));
+            Ok(code)
+        }
+    }
+
+    /// Fake backoff that records how many times it was asked to sleep and never
+    /// actually sleeps, so reconnect tests run instantly.
+    struct RecordingBackoff {
+        calls: Cell<usize>,
+    }
+
+    impl RecordingBackoff {
+        fn new() -> Self {
+            Self {
+                calls: Cell::new(0),
+            }
+        }
+        fn count(&self) -> usize {
+            self.calls.get()
+        }
+    }
+
+    impl ReconnectBackoff for RecordingBackoff {
+        fn backoff(&self, _attempt: usize) {
+            self.calls.set(self.calls.get() + 1);
+        }
+    }
+
+    fn test_entry(name: &str) -> RemoteEntry {
+        RemoteEntry {
+            name: name.to_string(),
+            kind: "ssh".to_string(),
+            host: "viktor@host.example.com".to_string(),
+            port: 22,
+            key: None,
+            version: TEST_LOCAL_VERSION.to_string(),
+            added_at: "2026-06-12T00:00:00Z".to_string(),
+            upgraded_at: None,
+            last_connected: None,
+        }
+    }
+
+    /// Write a registry containing `entry` to a fresh temp file. Returns the
+    /// tempdir (kept alive by the caller so the file isn't removed) and the
+    /// registry path.
+    fn registry_with(entry: &RemoteEntry) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("remotes.toml");
+        RemotesFile {
+            remotes: vec![entry.clone()],
+        }
+        .save(&path)
+        .expect("save registry");
+        (dir, path)
+    }
+
+    #[test]
+    fn reconnect_then_clean_exit_returns_zero() {
+        // [255, 0] ⇒ exactly two spawns + one reconnect, returns 0. Backoff
+        // fires once; the full probe re-runs on the reconnect; last_connected
+        // is recorded once (on the final clean exit, not the 255 drop).
+        let entry = test_entry("prod");
+        let (_dir, path) = registry_with(&entry);
+        let executor = ProbeOkExecutor::new(TEST_LOCAL_VERSION);
+        let spawner = ScriptedSpawner::new(vec![255, 0]);
+        let backoff = RecordingBackoff::new();
+
+        let code = run_connect(
+            &entry,
+            &executor,
+            &spawner,
+            &backoff,
+            &path,
+            TEST_LOCAL_VERSION,
+            REMOTE_INSTALL_PATH,
+        )
+        .expect("run_connect should succeed after one reconnect");
+
+        assert_eq!(code, 0, "clean exit on the second attempt");
+        assert_eq!(
+            spawner.spawn_count(),
+            2,
+            "exactly two spawns: initial + one reconnect"
+        );
+        assert_eq!(
+            backoff.count(),
+            1,
+            "backoff invoked once, for the single reconnect"
+        );
+        assert_eq!(
+            executor.run_count(),
+            4,
+            "full probe (version + protocol) re-ran on each of the two attempts"
+        );
+        let reloaded = RemotesFile::load(&path).expect("reload registry");
+        assert!(
+            reloaded.remotes[0].last_connected.is_some(),
+            "last_connected recorded on the clean exit"
+        );
+    }
+
+    #[test]
+    fn clean_exit_does_not_reconnect() {
+        // [0] ⇒ one spawn, no reconnect, returns 0.
+        let entry = test_entry("prod");
+        let (_dir, path) = registry_with(&entry);
+        let executor = ProbeOkExecutor::new(TEST_LOCAL_VERSION);
+        let spawner = ScriptedSpawner::new(vec![0]);
+        let backoff = RecordingBackoff::new();
+
+        let code = run_connect(
+            &entry,
+            &executor,
+            &spawner,
+            &backoff,
+            &path,
+            TEST_LOCAL_VERSION,
+            REMOTE_INSTALL_PATH,
+        )
+        .expect("run_connect");
+
+        assert_eq!(code, 0);
+        assert_eq!(spawner.spawn_count(), 1, "single spawn, no reconnect");
+        assert_eq!(backoff.count(), 0, "no backoff on a clean exit");
+    }
+
+    #[test]
+    fn ctrl_c_exit_is_terminal_no_reconnect() {
+        // [130] (Ctrl-C / SIGINT) is a user-intent exit, not a transport
+        // failure ⇒ one spawn, no reconnect, returned verbatim. Non-zero exit
+        // ⇒ no last_connected bookkeeping.
+        let entry = test_entry("prod");
+        let (_dir, path) = registry_with(&entry);
+        let executor = ProbeOkExecutor::new(TEST_LOCAL_VERSION);
+        let spawner = ScriptedSpawner::new(vec![130]);
+        let backoff = RecordingBackoff::new();
+
+        let code = run_connect(
+            &entry,
+            &executor,
+            &spawner,
+            &backoff,
+            &path,
+            TEST_LOCAL_VERSION,
+            REMOTE_INSTALL_PATH,
+        )
+        .expect("run_connect");
+
+        assert_eq!(code, 130, "Ctrl-C exit returned verbatim");
+        assert_eq!(spawner.spawn_count(), 1, "single spawn, no reconnect");
+        assert_eq!(backoff.count(), 0, "no backoff on a terminal exit");
+        let reloaded = RemotesFile::load(&path).expect("reload registry");
+        assert!(
+            reloaded.remotes[0].last_connected.is_none(),
+            "no bookkeeping on a non-zero exit"
+        );
+    }
+
+    #[test]
+    fn repeated_transport_failure_is_bounded() {
+        // Always 255 ⇒ exactly MAX_CONNECT_ATTEMPTS spawns, then give up with
+        // the transport-failure exit code. Backoff fires only *between*
+        // attempts (MAX_CONNECT_ATTEMPTS - 1 times). The 255 path never records
+        // last_connected, so it stays None.
+        let entry = test_entry("prod");
+        let (_dir, path) = registry_with(&entry);
+        let executor = ProbeOkExecutor::new(TEST_LOCAL_VERSION);
+        let spawner = ScriptedSpawner::new(vec![255]);
+        let backoff = RecordingBackoff::new();
+
+        let code = run_connect(
+            &entry,
+            &executor,
+            &spawner,
+            &backoff,
+            &path,
+            TEST_LOCAL_VERSION,
+            REMOTE_INSTALL_PATH,
+        )
+        .expect("run_connect returns Ok with the terminal-error code");
+
+        assert_eq!(
+            code, SSH_TRANSPORT_FAILURE_EXIT_CODE,
+            "give-up returns the transport-failure exit code"
+        );
+        assert_eq!(
+            spawner.spawn_count(),
+            MAX_CONNECT_ATTEMPTS,
+            "spawns are capped at the retry budget"
+        );
+        assert_eq!(
+            backoff.count(),
+            MAX_CONNECT_ATTEMPTS - 1,
+            "backoff invoked between attempts only"
+        );
+        let reloaded = RemotesFile::load(&path).expect("reload registry");
+        assert!(
+            reloaded.remotes[0].last_connected.is_none(),
+            "no bookkeeping on a transport-failure give-up"
+        );
+    }
+
+    #[test]
+    fn reconnect_time_unreachable_is_bounded_not_immediate() {
+        // Regression for Blocker 1: a re-probe that keeps failing with the
+        // reachability error after a first successful connect + a 255 drop must
+        // be BOUNDED — counted against the budget, backed off, and given up on
+        // with the terminal error code — NOT returned immediately on the first
+        // re-probe failure.
+        //
+        // Trace with MAX_CONNECT_ATTEMPTS = 5:
+        //   attempt 1: probe ok → spawn 255 (drop)            → backoff(1)
+        //   attempts 2..=4: --version probe → HostUnreachable → backoff(2..4)
+        //   attempt 5: --version probe → HostUnreachable      → give up → 255
+        // So: exactly ONE spawn (the initial connect), MAX-1 backoffs, return
+        // 255. The buggy code would back off once then return Err on attempt 2.
+        let entry = test_entry("prod");
+        let (_dir, path) = registry_with(&entry);
+        let executor = UnreachableAfterFirstConnectExecutor::new(TEST_LOCAL_VERSION);
+        let spawner = ScriptedSpawner::new(vec![255]);
+        let backoff = RecordingBackoff::new();
+
+        let code = run_connect(
+            &entry,
+            &executor,
+            &spawner,
+            &backoff,
+            &path,
+            TEST_LOCAL_VERSION,
+            REMOTE_INSTALL_PATH,
+        )
+        .expect("run_connect folds reconnect-time unreachable into bounded retry, returns Ok(255)");
+
+        assert_eq!(
+            code, SSH_TRANSPORT_FAILURE_EXIT_CODE,
+            "give-up after exhausting reconnects returns the transport-failure code, \
+             not an early HostUnreachable error"
+        );
+        assert_eq!(
+            backoff.count(),
+            MAX_CONNECT_ATTEMPTS - 1,
+            "every reconnect attempt backed off — proves it did NOT return early \
+             after the first re-probe failure (the bug would back off once)"
+        );
+        assert_eq!(
+            spawner.spawn_count(),
+            1,
+            "only the initial connect spawned; reconnects fail at the probe before spawning"
+        );
+        // restore_local_terminal() runs on this give-up path: it is the first
+        // line of `on_transport_failure`'s budget-exhausted branch, and the
+        // only way to reach a returned 255 here is through that branch — so the
+        // 255 return above proves restore ran (asserted by code inspection, not
+        // a separate observable seam, to avoid threading a restore-injection
+        // param through run_connect and every call site).
+        let reloaded = RemotesFile::load(&path).expect("reload registry");
+        assert!(
+            reloaded.remotes[0].last_connected.is_none(),
+            "no bookkeeping when reconnects exhaust on an unreachable host"
+        );
     }
 }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -853,20 +853,66 @@ fn is_reachability_error(err: &RemoteConnectError) -> bool {
     matches!(err, RemoteConnectError::HostUnreachable { .. })
 }
 
+/// PRD #148: which situation triggered a transport failure. This controls
+/// ONLY the user-visible "we'll retry" line printed before the backoff — the
+/// give-up message, terminal restore, and bounded-retry logic are identical
+/// for both. Distinguishing them matters because the two read very differently
+/// to a user (Greptile PR #152 finding 1): a dropped live session is "you were
+/// connected and it broke", a still-unreachable reconnect probe is "the host
+/// hasn't come back yet".
+#[derive(Clone, Copy)]
+enum TransportFailureKind {
+    /// A live `ssh -t` session was up and then dropped (spawn returned 255).
+    SessionDropped,
+    /// A reconnect-attempt probe found the host still unreachable; no session
+    /// ran this round.
+    StillUnreachable,
+}
+
+/// PRD #148: the stderr line printed before backing off for another attempt.
+/// Pure (no I/O) so it can be unit-tested directly without capturing process
+/// stderr. `attempt` is the 1-based number of the attempt that just failed;
+/// the message advertises `attempt + 1`, the one we're about to make.
+fn retry_message(kind: TransportFailureKind, name: &str, attempt: usize) -> String {
+    let next = attempt + 1;
+    match kind {
+        // Live session dropped — "connection lost" is accurate here.
+        TransportFailureKind::SessionDropped => {
+            format!(
+                "connection to '{name}' lost — reconnecting… (attempt {next}/{MAX_CONNECT_ATTEMPTS})"
+            )
+        }
+        // Host was already unreachable this round; "connection lost" would
+        // mislead the user into thinking a fresh session dropped again.
+        TransportFailureKind::StillUnreachable => {
+            format!(
+                "'{name}' not reachable yet — retrying… (attempt {next}/{MAX_CONNECT_ATTEMPTS})"
+            )
+        }
+    }
+}
+
 /// PRD #148: shared bounded-retry decision for a transport failure on attempt
-/// `attempt` (1-based) — either a spawn that returned 255 or a reconnect-time
-/// reachability probe failure. Returns `Some(exit_code)` when the retry budget
-/// is exhausted (caller should `return Ok(code)`); returns `None` after backing
-/// off (caller should `continue` to the next attempt).
+/// `attempt` (1-based) — either a spawn that returned 255 ([`TransportFailureKind::SessionDropped`])
+/// or a reconnect-time reachability probe failure
+/// ([`TransportFailureKind::StillUnreachable`]). Returns `Some(exit_code)` when
+/// the retry budget is exhausted (caller should `return Ok(code)`); returns
+/// `None` after backing off (caller should `continue` to the next attempt).
 ///
 /// On give-up it restores a sane local terminal — the remote TUI never got to
 /// leave alt screen / raw mode when the transport died — and prints the
-/// "giving up" line to stderr, so BOTH the spawn-255 path and the
-/// reconnect-probe-failure path restore the terminal and surface the same
-/// message. Keeping this in one place is what guarantees a still-unreachable
-/// host on a reconnect can't escape the loop without counting against the
-/// budget, backing off, and (on exhaustion) restoring the terminal.
-fn on_transport_failure(attempt: usize, name: &str, backoff: &dyn ReconnectBackoff) -> Option<i32> {
+/// "giving up" line to stderr, so BOTH paths restore the terminal and surface
+/// the same give-up message (only the per-attempt "we'll retry" line, via
+/// [`retry_message`], differs by `kind`). Keeping this in one place is what
+/// guarantees a still-unreachable host on a reconnect can't escape the loop
+/// without counting against the budget, backing off, and (on exhaustion)
+/// restoring the terminal.
+fn on_transport_failure(
+    attempt: usize,
+    name: &str,
+    kind: TransportFailureKind,
+    backoff: &dyn ReconnectBackoff,
+) -> Option<i32> {
     if attempt >= MAX_CONNECT_ATTEMPTS {
         // Budget exhausted: the remote stayed unreachable across every attempt.
         restore_local_terminal();
@@ -877,13 +923,7 @@ fn on_transport_failure(attempt: usize, name: &str, backoff: &dyn ReconnectBacko
         return Some(SSH_TRANSPORT_FAILURE_EXIT_CODE);
     }
     // Message goes to stderr, between the handed-over terminal sessions.
-    // `attempt + 1` is the attempt we're about to make.
-    eprintln!(
-        "connection to '{}' lost — reconnecting… (attempt {}/{})",
-        name,
-        attempt + 1,
-        MAX_CONNECT_ATTEMPTS
-    );
+    eprintln!("{}", retry_message(kind, name, attempt));
     backoff.backoff(attempt);
     None
 }
@@ -965,7 +1005,12 @@ pub fn run_connect(
                 );
             }
             Err(e) if attempt > 1 && is_reachability_error(&e) => {
-                match on_transport_failure(attempt, &entry.name, backoff) {
+                match on_transport_failure(
+                    attempt,
+                    &entry.name,
+                    TransportFailureKind::StillUnreachable,
+                    backoff,
+                ) {
                     Some(code) => return Ok(code),
                     None => continue,
                 }
@@ -984,7 +1029,12 @@ pub fn run_connect(
         match probe_remote_protocol(executor, &target, &entry.name, install_path) {
             Ok(()) => {}
             Err(e) if attempt > 1 && is_reachability_error(&e) => {
-                match on_transport_failure(attempt, &entry.name, backoff) {
+                match on_transport_failure(
+                    attempt,
+                    &entry.name,
+                    TransportFailureKind::StillUnreachable,
+                    backoff,
+                ) {
                     Some(code) => return Ok(code),
                     None => continue,
                 }
@@ -1003,7 +1053,12 @@ pub fn run_connect(
         // Stage 3: route on the exit code. Reconnect ONLY on ssh's
         // transport-failure code (255); any other code is terminal.
         if exit_code == SSH_TRANSPORT_FAILURE_EXIT_CODE {
-            match on_transport_failure(attempt, &entry.name, backoff) {
+            match on_transport_failure(
+                attempt,
+                &entry.name,
+                TransportFailureKind::SessionDropped,
+                backoff,
+            ) {
                 Some(code) => return Ok(code),
                 None => continue,
             }
@@ -1630,6 +1685,36 @@ mod tests {
         assert!(
             reloaded.remotes[0].last_connected.is_none(),
             "no bookkeeping when reconnects exhaust on an unreachable host"
+        );
+    }
+
+    #[test]
+    fn retry_message_differentiates_drop_from_unreachable() {
+        // Greptile PR #152 finding 1: the spawn-255 live-drop path and the
+        // reconnect-time probe-unreachable path must read differently. Both
+        // advertise the *next* attempt (attempt + 1) and share the em-dash +
+        // ellipsis style; only the live-drop line says "connection … lost".
+        let dropped = retry_message(TransportFailureKind::SessionDropped, "prod", 1);
+        assert_eq!(
+            dropped,
+            format!("connection to 'prod' lost — reconnecting… (attempt 2/{MAX_CONNECT_ATTEMPTS})")
+        );
+
+        let unreachable = retry_message(TransportFailureKind::StillUnreachable, "prod", 2);
+        assert_eq!(
+            unreachable,
+            format!("'prod' not reachable yet — retrying… (attempt 3/{MAX_CONNECT_ATTEMPTS})")
+        );
+
+        // The whole point of the fix: the two paths must NOT print the same
+        // line, and the unreachable line must not claim a connection was lost.
+        assert_ne!(
+            retry_message(TransportFailureKind::SessionDropped, "prod", 1),
+            retry_message(TransportFailureKind::StillUnreachable, "prod", 1),
+        );
+        assert!(
+            !unreachable.contains("lost"),
+            "the still-unreachable line must not say a connection was 'lost': {unreachable}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Adds SSH keepalive (`ServerAliveInterval=15`, `ServerAliveCountMax=3`) to the live `ssh -t` connect session so a connection killed by laptop sleep is detected and terminated within ~45 s instead of freezing the TUI indefinitely.
- Wraps `run_connect`'s spawn/bookkeeping in a 255-keyed auto-reconnect loop: on transport failure (exit 255) `run_connect` re-probes the remote host and re-spawns, showing a "reconnecting to `<name>`…" message between sessions.
- Reconnection is bounded by `MAX_CONNECT_ATTEMPTS=5` with local terminal restore on give-up; clean exits (0, Ctrl-C/130, non-255) return immediately without reconnecting.
- Unit tests via fake `ConnectSpawner`/`SshExecutor` cover the reconnect state machine, exit-code routing, and bounded-retry paths.
- Docs updated in `docs/remote-environments.md` with a "Surviving sleep/wake" section.

## Related Issues

Closes #148

## Changes Made

- `src/connect.rs` — M1 keepalive args on `build_connect_command` + M2 auto-reconnect loop in `run_connect` + M3 unit tests
- `docs/remote-environments.md` — M5 "Surviving sleep/wake" section + updated Stop-vs-detach row
- `prds/148-remote-connect-survive-sleep-wake.md` — progress update (M1–M3, M5 checked)
- `changelog.d/148.feature.md` — towncrier fragment for release notes

## Testing

- `cargo fmt --check`: clean
- `cargo clippy -- -D warnings`: 0 warnings
- `cargo test-fast`: 708 passed, 0 skipped (includes new reconnect state-machine tests)
- `cargo test-e2e`: 1026 passed, 0 skipped (pre-PR L2 gate)
- Review: reviewer + auditor both signed off ("ship"); one blocker (probe-failure bypass of retry budget) found and fixed before re-review

## Notes

M4 (real-hardware sleep/wake verification) is a manual user step pending after this PR merges. The remote daemon is persistent (#93) so agent state survives reconnect; the remote TUI restores session state on reattach (#89).