### PR TITLE
fix(prd-107): orchestration tab name survives detach/reattach

### DIFF
--- a/changelog.d/160.bugfix.md
+++ b/changelog.d/160.bugfix.md
@@ -1,0 +1,5 @@
+## Orchestration Tab Name Survives Detach/Reattach
+
+The custom name you type when launching an orchestration now persists across detach and reattach. Previously the typed name appeared correctly on creation, but reattaching to the orchestration — including after reconnecting to a remote daemon — silently reverted the tab title to the name from the TOML config (or the working-directory basename for unnamed orchestrations), discarding whatever you had entered.
+
+The name now travels with each role through the daemon, so reattaching restores the title you chose. Orchestrations launched without a custom name continue to use the config name, with the existing cwd-basename fallback.

--- a/src/agent_pty.rs
+++ b/src/agent_pty.rs
@@ -249,6 +249,16 @@ pub enum TabMembership {
         /// name-only, matching the pre-round-11 behavior.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         orchestration_cwd: Option<String>,
+        /// PRD #107 follow-up: the user-typed orchestration name from the
+        /// new-pane form. Carried through the daemon round-trip so a
+        /// detach/reattach restores the displayed tab TITLE instead of
+        /// recomputing it from `resolve_orchestration_name` (config name or
+        /// cwd basename). The orchestration IDENTITY stays in `name` — this
+        /// is title-only and never feeds delegate/role lookups. `None` (the
+        /// common case for daemon-initiated/scheduled orchestrations and
+        /// older clients) means the title falls back to the canonical name.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        display_title: Option<String>,
     },
 }
 
@@ -2463,6 +2473,7 @@ mod tests {
             role_name: "coder".into(),
             is_start_role: false,
             orchestration_cwd: Some("/proj/\0evil".into()),
+            display_title: None,
         };
         assert!(validate_tab_membership(tm).is_none());
     }
@@ -2475,6 +2486,7 @@ mod tests {
             role_name: "coder".into(),
             is_start_role: false,
             orchestration_cwd: Some("/proj/\x1b[31m".into()),
+            display_title: None,
         };
         assert!(validate_tab_membership(tm).is_none());
     }
@@ -2491,6 +2503,7 @@ mod tests {
             // or quietly collide with other orchs whose resolved
             // cwd happens to match.
             orchestration_cwd: Some("relative/proj".into()),
+            display_title: None,
         };
         assert!(validate_tab_membership(tm).is_none());
     }
@@ -2504,6 +2517,7 @@ mod tests {
             role_name: "coder".into(),
             is_start_role: false,
             orchestration_cwd: Some(oversized),
+            display_title: None,
         };
         assert!(validate_tab_membership(tm).is_none());
     }
@@ -2516,6 +2530,7 @@ mod tests {
             role_name: "coder".into(),
             is_start_role: false,
             orchestration_cwd: Some("/home/user/project-a".into()),
+            display_title: None,
         };
         assert!(validate_tab_membership(tm).is_some());
     }
@@ -2532,6 +2547,7 @@ mod tests {
             role_name: "coder".into(),
             is_start_role: false,
             orchestration_cwd: None,
+            display_title: None,
         };
         assert!(validate_tab_membership(tm).is_none());
     }
@@ -2544,6 +2560,7 @@ mod tests {
             role_name: "coder".into(),
             is_start_role: false,
             orchestration_cwd: None,
+            display_title: None,
         };
         assert!(validate_tab_membership(tm).is_some());
     }
@@ -2560,6 +2577,7 @@ mod tests {
             role_name: "\x1b[31mpwn".into(),
             is_start_role: false,
             orchestration_cwd: None,
+            display_title: None,
         };
         assert!(validate_tab_membership(tm).is_none());
     }
@@ -2572,6 +2590,7 @@ mod tests {
             role_name: "co\0der".into(),
             is_start_role: false,
             orchestration_cwd: None,
+            display_title: None,
         };
         assert!(validate_tab_membership(tm).is_none());
     }
@@ -2587,6 +2606,7 @@ mod tests {
             role_name: String::new(),
             is_start_role: false,
             orchestration_cwd: None,
+            display_title: None,
         };
         assert!(validate_tab_membership(tm).is_some());
     }

--- a/src/agent_pty.rs
+++ b/src/agent_pty.rs
@@ -309,7 +309,7 @@ pub const ORCHESTRATION_ROLE_INDEX_MAX: usize = 256;
 /// `synthesize_from_bucket_metadata` allocates a placeholder vec of
 /// `max_index + 1` length). Both are wire-boundary checks so every
 /// downstream consumer is protected without per-call-site validation.
-pub fn validate_tab_membership(tm: TabMembership) -> Option<TabMembership> {
+pub fn validate_tab_membership(mut tm: TabMembership) -> Option<TabMembership> {
     if !is_valid_display_name(tm.name()) {
         return None;
     }
@@ -317,8 +317,9 @@ pub fn validate_tab_membership(tm: TabMembership) -> Option<TabMembership> {
         role_index,
         role_name,
         orchestration_cwd,
+        display_title,
         ..
-    } = &tm
+    } = &mut tm
     {
         if *role_index > ORCHESTRATION_ROLE_INDEX_MAX {
             return None;
@@ -330,10 +331,23 @@ pub fn validate_tab_membership(tm: TabMembership) -> Option<TabMembership> {
         if !role_name.is_empty() && !is_valid_display_name(role_name) {
             return None;
         }
-        if let Some(c) = orchestration_cwd
+        if let Some(c) = orchestration_cwd.as_deref()
             && !is_valid_orchestration_cwd(c)
         {
             return None;
+        }
+        // display_title flows to the tab label exactly like name/role_name,
+        // so it needs the same control-byte guard. But it's purely
+        // cosmetic with a defined `None` fallback (the title reverts to the
+        // canonical resolved name), so an invalid value is nulled out
+        // rather than rejecting the whole membership — dropping the
+        // orchestration tab over a bad cosmetic string would be a worse
+        // outcome than losing the custom title (Greptile PR #160 P1).
+        if display_title
+            .as_deref()
+            .is_some_and(|t| !is_valid_display_name(t))
+        {
+            *display_title = None;
         }
     }
     Some(tm)
@@ -2593,6 +2607,68 @@ mod tests {
             display_title: None,
         };
         assert!(validate_tab_membership(tm).is_none());
+    }
+
+    // Greptile PR #160 P1: display_title flows to the tab label like
+    // name/role_name, so a control-byte value must be neutralised. Unlike
+    // those identity fields it's cosmetic with a `None` fallback, so an
+    // invalid value is nulled out (membership preserved) rather than
+    // rejecting the whole membership and stranding the orchestration tab.
+    #[test]
+    fn validate_tab_membership_nulls_out_display_title_with_ansi_escape() {
+        let tm = TabMembership::Orchestration {
+            name: "tdd-cycle".into(),
+            role_index: 0,
+            role_name: "coder".into(),
+            is_start_role: false,
+            orchestration_cwd: None,
+            display_title: Some("\x1b[31mpwn".into()),
+        };
+        let validated = validate_tab_membership(tm).expect("membership preserved");
+        match validated {
+            TabMembership::Orchestration { display_title, .. } => {
+                assert_eq!(display_title, None, "invalid display_title nulled out");
+            }
+            _ => panic!("expected Orchestration variant"),
+        }
+    }
+
+    #[test]
+    fn validate_tab_membership_nulls_out_display_title_with_nul_byte() {
+        let tm = TabMembership::Orchestration {
+            name: "tdd-cycle".into(),
+            role_index: 0,
+            role_name: "coder".into(),
+            is_start_role: false,
+            orchestration_cwd: None,
+            display_title: Some("My\0Run".into()),
+        };
+        let validated = validate_tab_membership(tm).expect("membership preserved");
+        match validated {
+            TabMembership::Orchestration { display_title, .. } => {
+                assert_eq!(display_title, None);
+            }
+            _ => panic!("expected Orchestration variant"),
+        }
+    }
+
+    #[test]
+    fn validate_tab_membership_preserves_well_formed_display_title() {
+        let tm = TabMembership::Orchestration {
+            name: "tdd-cycle".into(),
+            role_index: 0,
+            role_name: "coder".into(),
+            is_start_role: false,
+            orchestration_cwd: None,
+            display_title: Some("My Custom Run".into()),
+        };
+        let validated = validate_tab_membership(tm).expect("membership preserved");
+        match validated {
+            TabMembership::Orchestration { display_title, .. } => {
+                assert_eq!(display_title.as_deref(), Some("My Custom Run"));
+            }
+            _ => panic!("expected Orchestration variant"),
+        }
     }
 
     #[test]

--- a/src/daemon_client.rs
+++ b/src/daemon_client.rs
@@ -783,6 +783,7 @@ mod tests {
                 role_name: "coder".into(),
                 is_start_role: false,
                 orchestration_cwd: None,
+                display_title: None,
             }),
             agent_type: None,
             rows: 0,
@@ -797,6 +798,7 @@ mod tests {
                 role_name: "coder".into(),
                 is_start_role: false,
                 orchestration_cwd: None,
+                display_title: None,
             }),
         );
     }

--- a/src/daemon_protocol.rs
+++ b/src/daemon_protocol.rs
@@ -1530,6 +1530,7 @@ mod tests {
                 role_name: "coder".into(),
                 is_start_role: false,
                 orchestration_cwd: None,
+                display_title: None,
             }),
             agent_type: None,
         };
@@ -1551,6 +1552,7 @@ mod tests {
                         role_name: "coder".into(),
                         is_start_role: false,
                         orchestration_cwd: None,
+                        display_title: None,
                     })
                 );
             }
@@ -1574,6 +1576,7 @@ mod tests {
                 role_name: "coder".into(),
                 is_start_role: false,
                 orchestration_cwd: None,
+                display_title: None,
             }),
             agent_type: None,
             rows: 0,

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -308,6 +308,7 @@ pub async fn spawn(
                     role_name: role.role_name.clone(),
                     is_start_role: role.is_start_role,
                     orchestration_cwd: Some(req.working_dir.clone()),
+                    display_title: None,
                 };
                 let id = spawn_one(
                     registry,

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -513,10 +513,13 @@ impl TabManager {
         // be the user's form name. Pre-fix these were one field, so the
         // form/basename leaked into the identity and broke the delegate
         // respawn in every worktree whose basename != the config name.
-        let title = match display_title {
-            Some(t) if !t.is_empty() => t.to_string(),
-            _ => resolved_name.clone(),
-        };
+        // Normalise the user-typed form name once: `None`/empty collapses to
+        // `None` so both the local title and the persisted membership fall
+        // back to the canonical `resolved_name`.
+        let display_title_owned = display_title.filter(|t| !t.is_empty()).map(str::to_string);
+        let title = display_title_owned
+            .clone()
+            .unwrap_or_else(|| resolved_name.clone());
 
         // PRD #76 M2.12: tag each role pane with its orchestration tab
         // membership so the daemon-side registry can echo it back via
@@ -535,6 +538,10 @@ impl TabManager {
                     // so the daemon can disambiguate two unnamed
                     // orchestrations whose basenames collide.
                     orchestration_cwd: Some(cwd.to_string()),
+                    // PRD #107 follow-up: persist the user-typed title on
+                    // every role pane so reattach restores it (see the
+                    // hydration path in `open_orchestration_tab_with_existing_role_panes`).
+                    display_title: display_title_owned.clone(),
                 }),
                 rows: spawn_rows,
                 cols: spawn_cols,
@@ -642,6 +649,13 @@ impl TabManager {
         config: &OrchestrationConfig,
         cwd: &str,
         role_pane_ids: Vec<Option<String>>,
+        // PRD #107 follow-up: the user-typed title the daemon echoed back on
+        // each role pane's `TabMembership::Orchestration.display_title`. Used
+        // for the tab TITLE so detach/reattach preserves the name the user
+        // entered; `None`/empty falls back to the canonical resolved name
+        // (the pre-fix behaviour). The IDENTITY still derives from
+        // `resolve_orchestration_name` below — this is title-only.
+        display_title: Option<&str>,
     ) -> Result<(usize, Vec<String>), TabError> {
         // M2.12 fixup auditor #3: this is a hydration-oriented API, so
         // mismatched lengths must surface as a `TabError` for the
@@ -687,7 +701,12 @@ impl TabManager {
 
         let start_role_index = config.roles.iter().position(|r| r.start).unwrap_or(0);
 
-        let name = resolve_orchestration_name(&config.name, std::path::Path::new(cwd));
+        // Title-only: prefer the user-typed title the daemon round-tripped,
+        // falling back to the canonical resolved name when absent/empty.
+        let name = display_title
+            .filter(|t| !t.is_empty())
+            .map(str::to_string)
+            .unwrap_or_else(|| resolve_orchestration_name(&config.name, std::path::Path::new(cwd)));
 
         self.tabs.push(Tab::Orchestration {
             id,
@@ -1086,6 +1105,57 @@ mod tests {
                 },
             ],
         }
+    }
+
+    /// Scenario: Create an orchestration with a user-typed name ("My Custom
+    /// Run") and confirm the tab shows it; then simulate detach/reattach via
+    /// the hydration entry point and confirm the user-typed title is
+    /// restored (PRD #107 follow-up — the daemon round-trips it on
+    /// `TabMembership::Orchestration.display_title`). Finally, reattach with
+    /// no persisted title and confirm the tab falls back to the canonical
+    /// config name, matching daemon-spawned/older-client behaviour.
+    #[test]
+    fn orchestration_010_reattach_preserves_user_title() {
+        let pc = Arc::new(MockPaneController::new());
+        let mut tm = TabManager::new(pc.clone());
+
+        // Create: the user-typed form name becomes the tab title.
+        let (created_idx, _) = tm
+            .open_orchestration_tab(
+                &orch_config("orch"),
+                "/work",
+                None,
+                Some("My Custom Run"),
+                (24, 80),
+            )
+            .expect("create orchestration");
+        assert_eq!(tm.tab_labels()[created_idx], "My Custom Run");
+
+        // Reattach with the persisted title (the value the daemon
+        // round-trips via `TabMembership::Orchestration.display_title`): the
+        // tab keeps the user-typed name instead of the canonical config name.
+        let (reattach_idx, _) = tm
+            .open_orchestration_tab_with_existing_role_panes(
+                &orch_config("orch"),
+                "/work",
+                vec![Some("p0".into()), Some("p1".into())],
+                Some("My Custom Run"),
+            )
+            .expect("reattach with title");
+        assert_eq!(tm.tab_labels()[reattach_idx], "My Custom Run");
+
+        // Reattach without a persisted title falls back to the canonical
+        // resolved name (the config name) — the pre-fix behaviour preserved
+        // for daemon-spawned/older orchestrations.
+        let (fallback_idx, _) = tm
+            .open_orchestration_tab_with_existing_role_panes(
+                &orch_config("orch"),
+                "/work",
+                vec![Some("p0".into()), Some("p1".into())],
+                None,
+            )
+            .expect("reattach without title");
+        assert_eq!(tm.tab_labels()[fallback_idx], "orch");
     }
 
     /// Scenario: Give the Dashboard, a Mode tab, and an Orchestration tab

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1562,6 +1562,12 @@ pub(crate) struct ModeHydrationBucket {
 pub(crate) struct OrchestrationHydrationBucket {
     pub cwd: String,
     pub orchestration_name: String,
+    /// PRD #107 follow-up: the user-typed tab title echoed back by the
+    /// daemon on each role pane's `TabMembership::Orchestration.display_title`
+    /// (shared across roles, so the first non-`None` slot wins). Routed to
+    /// the rebuilt tab's TITLE so detach/reattach preserves the entered name;
+    /// `None` falls back to the canonical resolved name.
+    pub display_title: Option<String>,
     pub role_slots: Vec<OrchestrationRoleSlot>,
 }
 
@@ -1778,6 +1784,7 @@ pub(crate) fn partition_hydrated_panes(hydrated: &[HydratedPane]) -> HydrationPa
                 role_name,
                 is_start_role,
                 orchestration_cwd,
+                display_title,
             }) => {
                 // Round-12 reviewer #1: bucket by `(orchestration_cwd,
                 // name)` — the same identity tuple the daemon uses for
@@ -1817,11 +1824,18 @@ pub(crate) fn partition_hydrated_panes(hydrated: &[HydratedPane]) -> HydrationPa
                             .push(OrchestrationHydrationBucket {
                                 cwd: bucket_cwd,
                                 orchestration_name: name.clone(),
+                                display_title: display_title.clone(),
                                 role_slots: Vec::new(),
                             });
                         i
                     }
                 };
+                // All role panes of one orchestration carry the same
+                // display_title, but guard against a leading legacy/dead slot
+                // that omitted it: keep the first non-`None` value we see.
+                if out.orchestration_buckets[idx].display_title.is_none() {
+                    out.orchestration_buckets[idx].display_title = display_title.clone();
+                }
                 out.orchestration_buckets[idx]
                     .role_slots
                     .push(OrchestrationRoleSlot {
@@ -5777,6 +5791,7 @@ pub fn run_tui(
                 &orch_config,
                 &bucket.cwd,
                 role_pane_ids.clone(),
+                bucket.display_title.as_deref(),
             ) {
                 Ok((tab_index, _)) => {
                     if first_orchestration_tab_index.is_none() {
@@ -12079,6 +12094,7 @@ mod tests {
                     role_name: "orchestrator".into(),
                     is_start_role: true,
                     orchestration_cwd: Some(orch_cwd.clone()),
+                    display_title: None,
                 }),
             ),
             hydrated(
@@ -12091,6 +12107,7 @@ mod tests {
                     role_name: "coder".into(),
                     is_start_role: false,
                     orchestration_cwd: Some(orch_cwd.clone()),
+                    display_title: None,
                 }),
             ),
             hydrated(
@@ -12103,6 +12120,7 @@ mod tests {
                     role_name: "reviewer".into(),
                     is_start_role: false,
                     orchestration_cwd: Some(orch_cwd.clone()),
+                    display_title: None,
                 }),
             ),
         ];
@@ -12116,6 +12134,51 @@ mod tests {
         assert_eq!(bucket.cwd, orch_cwd);
         assert_eq!(bucket.orchestration_name, "tdd-cycle");
         assert_eq!(bucket.role_slots.len(), 3);
+    }
+
+    /// PRD #107 follow-up: the user-typed title persisted on each role
+    /// pane's `TabMembership::Orchestration.display_title` flows into the
+    /// hydration bucket so reattach can restore it. A leading slot that
+    /// omits the title (legacy/dead pane) must not mask a later slot that
+    /// carries it — the first non-`None` value wins.
+    #[test]
+    fn partition_propagates_orchestration_display_title_first_non_none_wins() {
+        let orch_cwd = "/proj".to_string();
+        let panes = vec![
+            hydrated(
+                "1",
+                "a-1",
+                Some("/proj"),
+                Some(TabMembership::Orchestration {
+                    name: "tdd-cycle".into(),
+                    role_index: 0,
+                    role_name: "orchestrator".into(),
+                    is_start_role: true,
+                    orchestration_cwd: Some(orch_cwd.clone()),
+                    display_title: None, // leading slot omits the title
+                }),
+            ),
+            hydrated(
+                "2",
+                "a-2",
+                Some("/proj"),
+                Some(TabMembership::Orchestration {
+                    name: "tdd-cycle".into(),
+                    role_index: 1,
+                    role_name: "coder".into(),
+                    is_start_role: false,
+                    orchestration_cwd: Some(orch_cwd.clone()),
+                    display_title: Some("My Custom Run".into()),
+                }),
+            ),
+        ];
+        let p = partition_hydrated_panes(&panes);
+        assert_eq!(p.orchestration_buckets.len(), 1);
+        assert_eq!(
+            p.orchestration_buckets[0].display_title.as_deref(),
+            Some("My Custom Run"),
+            "a later slot's display_title backfills a leading None slot"
+        );
     }
 
     /// Negative-case mirror of the above: two panes with the same
@@ -12135,6 +12198,7 @@ mod tests {
                     role_name: "orchestrator".into(),
                     is_start_role: true,
                     orchestration_cwd: Some("/home/u/project-a".into()),
+                    display_title: None,
                 }),
             ),
             hydrated(
@@ -12147,6 +12211,7 @@ mod tests {
                     role_name: "orchestrator".into(),
                     is_start_role: true,
                     orchestration_cwd: Some("/home/u/project-b".into()),
+                    display_title: None,
                 }),
             ),
         ];
@@ -12174,6 +12239,7 @@ mod tests {
                 role_name: "orchestrator".into(),
                 is_start_role: true,
                 orchestration_cwd: None,
+                display_title: None,
             }),
         )];
         let p = partition_hydrated_panes(&panes);
@@ -12194,6 +12260,7 @@ mod tests {
                     role_name: String::new(),
                     is_start_role: false,
                     orchestration_cwd: None,
+                    display_title: None,
                 }),
             ),
             hydrated(
@@ -12206,6 +12273,7 @@ mod tests {
                     role_name: String::new(),
                     is_start_role: false,
                     orchestration_cwd: None,
+                    display_title: None,
                 }),
             ),
         ];
@@ -12546,7 +12614,8 @@ mod tests {
         let mut tm = crate::tab::TabManager::new(Arc::new(NoopPC));
         let mut bad_vec = role_pane_ids.clone();
         bad_vec.truncate(role_pane_ids.len() - 1);
-        let result = tm.open_orchestration_tab_with_existing_role_panes(&cfg, "/work", bad_vec);
+        let result =
+            tm.open_orchestration_tab_with_existing_role_panes(&cfg, "/work", bad_vec, None);
         assert!(
             result.is_err(),
             "test precondition: mismatched-length role_pane_ids must Err"
@@ -12676,6 +12745,7 @@ mod tests {
                     role_name: String::new(),
                     is_start_role: false,
                     orchestration_cwd: None,
+                    display_title: None,
                 }),
             ),
             hydrated(
@@ -12688,6 +12758,7 @@ mod tests {
                     role_name: String::new(),
                     is_start_role: false,
                     orchestration_cwd: None,
+                    display_title: None,
                 }),
             ),
         ];
@@ -12716,6 +12787,7 @@ mod tests {
                     role_name: String::new(),
                     is_start_role: false,
                     orchestration_cwd: None,
+                    display_title: None,
                 }),
             ),
         ];
@@ -12752,6 +12824,7 @@ mod tests {
                     role_name: "orchestrator".into(),
                     is_start_role: true,
                     orchestration_cwd: Some("/remote/proj".into()),
+                    display_title: None,
                 }),
             ),
             hydrated(
@@ -12764,6 +12837,7 @@ mod tests {
                     role_name: "reviewer".into(),
                     is_start_role: false,
                     orchestration_cwd: Some("/remote/proj".into()),
+                    display_title: None,
                 }),
             ),
         ];
@@ -12808,6 +12882,7 @@ mod tests {
                     role_name: "orchestrator".into(),
                     is_start_role: true,
                     orchestration_cwd: Some("/remote/proj".into()),
+                    display_title: None,
                 }),
             ),
             hydrated(
@@ -12820,6 +12895,7 @@ mod tests {
                     role_name: "reviewer".into(),
                     is_start_role: false,
                     orchestration_cwd: Some("/remote/proj".into()),
+                    display_title: None,
                 }),
             ),
         ];
@@ -12912,7 +12988,12 @@ mod tests {
         }
         let mut tm = crate::tab::TabManager::new(Arc::new(NoopPC));
         let (tab_index, _flat) = tm
-            .open_orchestration_tab_with_existing_role_panes(&cfg, &bucket.cwd, role_pane_ids)
+            .open_orchestration_tab_with_existing_role_panes(
+                &cfg,
+                &bucket.cwd,
+                role_pane_ids,
+                bucket.display_title.as_deref(),
+            )
             .expect("synthesised-config hydration must succeed");
         assert_eq!(tab_index, 1, "first non-dashboard tab is at index 1");
         let labels = tm.tab_labels();
@@ -12943,6 +13024,7 @@ mod tests {
                     role_name: "first".into(),
                     is_start_role: true,
                     orchestration_cwd: Some("/remote/proj".into()),
+                    display_title: None,
                 }),
             ),
             hydrated(
@@ -12955,6 +13037,7 @@ mod tests {
                     role_name: "second".into(),
                     is_start_role: false,
                     orchestration_cwd: Some("/remote/proj".into()),
+                    display_title: None,
                 }),
             ),
         ];
@@ -13052,6 +13135,7 @@ mod tests {
         let bucket = OrchestrationHydrationBucket {
             cwd: "/remote/proj".into(),
             orchestration_name: "review".into(),
+            display_title: None,
             role_slots: vec![
                 OrchestrationRoleSlot {
                     role_index: 0,

--- a/tests/daemon_protocol.rs
+++ b/tests/daemon_protocol.rs
@@ -261,6 +261,7 @@ async fn start_agent_rejects_orchestration_cwd_with_control_byte() {
                 role_name: "coder".into(),
                 is_start_role: false,
                 orchestration_cwd: Some("/proj/\x1b[31m".into()),
+                display_title: None,
             }),
             agent_type: None,
         },
@@ -296,6 +297,7 @@ async fn start_agent_with_orchestration_membership_round_trip() {
             role_name: "coder".into(),
             is_start_role: false,
             orchestration_cwd: None,
+            display_title: None,
         },
     )
     .await;
@@ -313,6 +315,7 @@ async fn start_agent_with_orchestration_membership_round_trip() {
             role_name: "coder".into(),
             is_start_role: false,
             orchestration_cwd: None,
+            display_title: None,
         })
     );
     server.registry.shutdown_all();

--- a/tests/rehydration.rs
+++ b/tests/rehydration.rs
@@ -956,6 +956,7 @@ async fn dead_role_stays_visible_on_reconnect_as_placeholder_card() {
                     role_name: (*role_name).to_string(),
                     is_start_role: role_index == 0,
                     orchestration_cwd: Some(cwd.clone()),
+                    display_title: None,
                 }),
                 ..Default::default()
             })


### PR DESCRIPTION
## Description

When you create an orchestration and type a custom name in the new-pane form, the tab correctly shows that name. But after **detaching and re-attaching**, the tab title silently reverts to the canonical name from `.dot-agent-deck.toml` (or the working-directory basename for unnamed orchestrations). This PR makes the user-typed title survive the round-trip.

This is a follow-up to **PRD #107** (which fixed the *create*-path title in v0.25.2). That fix deliberately decoupled the display **title** from the orchestration **identity** so delegate/role lookups stay keyed on the canonical config name — but it left the title as purely local state, so the daemon round-trip on reattach lost it.

## Root Cause

- On **create**, the typed name became `Tab::Orchestration.name` (local title), while each role pane's `TabMembership::Orchestration` carried only the canonical `resolve_orchestration_name(...)` identity — the value the daemon persists and echoes back.
- On **reattach**, `open_orchestration_tab_with_existing_role_panes` recomputed the title from `resolve_orchestration_name(...)` because the typed title was never persisted.

## Changes

- Added `display_title: Option<String>` to `TabMembership::Orchestration` (`#[serde(default, skip_serializing_if = "Option::is_none")]` → wire back-compatible with older clients/daemons; omitted when absent).
- Stamp it on every role pane at create time. **Identity (`name`) stays canonical** — this is title-only and never feeds delegate/role lookups.
- The daemon needs **no logic change**: it stores and echoes `TabMembership` verbatim, so the new field round-trips automatically.
- Hydration collects `display_title` into the bucket (first non-`None` role slot wins, guarding a leading dead/legacy slot) and applies it as the tab title, falling back to `resolve_orchestration_name(...)` when absent.

The bulk of the diff is mechanical `display_title: None` additions to test fixtures and the daemon-initiated (scheduled) spawn path, where there is no user-typed title.

## Testing

- New `tab::tests::orchestration_010_reattach_preserves_user_title` — create shows the typed name; reattach restores it; reattach without a persisted title falls back to the config name.
- New `ui::tests::partition_propagates_orchestration_display_title_first_non_none_wins` — producer→bucket propagation, including the first-non-`None`-wins guard.
- Full fast tier (745) and full e2e tier (1106) pass locally; `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean.

## Notes for reviewers

- No new user-visible surface is introduced (existing behavior is being fixed), so the experimental-flag convention (PRD #139) does not apply.
- No breaking changes; the wire field is optional and back-compatible in both directions.