### PR TITLE
feat(prd-89): auto-restore TUI state on attach; remove --continue flag

### DIFF
--- a/.dot-agent-deck.toml
+++ b/.dot-agent-deck.toml
@@ -1,3 +1,53 @@
+# =============================================================================
+# MANUAL TEST GUIDE — PRD #89: Auto-restore TUI state on attach; remove
+# `--continue` (PR #169). How to verify the shipped behavior by hand.
+#
+# Build first: `cargo build` (then use `./target/debug/dot-agent-deck`), or run
+# however you normally launch it. Use an ISOLATED snapshot so you don't touch
+# your real session:  export DOT_AGENT_DECK_SESSION=/tmp/dad89/session.toml
+#
+# Key distinction: a clean detach + relaunch restores via WARM DAEMON HYDRATION
+# (the daemon still holds the agents). The snapshot-specific paths below only
+# kick in on the COLD path — when the daemon is empty (fresh machine / crash) —
+# so for those, STOP THE DAEMON (not just the TUI) before relaunching.
+#
+# UI keys: New pane Ctrl+N · Close/detach pane Ctrl+W / Ctrl+D · Quit Ctrl+C · Help ?
+# -----------------------------------------------------------------------------
+# 1) AUTO-RESTORE IS THE DEFAULT (no flag)
+#    - dot-agent-deck                 -> empty dashboard on a fresh snapshot path
+#    - Ctrl+N -> pick a dir -> create 2 panes; rename one
+#    - Quit (Ctrl+C) or detach, then:  dot-agent-deck   (NO flag)
+#    - EXPECT: the panes you created are back.
+#
+# 2) `--continue` IS REMOVED
+#    - dot-agent-deck --continue      -> exits non-zero with a friendly message
+#      ("the --continue flag has been removed. Auto-restore is now the default ...")
+#    - dot-agent-deck --help          -> `--continue` is no longer listed.
+#
+# 3) SNAPSHOT STAYS FRESH (crash recovery, not just clean quit) — COLD path
+#    - dot-agent-deck ; create a pane (do NOT quit)
+#    - STOP THE DAEMON hard (so it has no agents to hydrate)
+#    - dot-agent-deck                 -> EXPECT: the pane is still restored
+#      (the snapshot was written on the state change, not only at clean quit).
+#
+# 4) ORCHESTRATION-TAB RESTORE
+#    - dot-agent-deck ; open the `dot-agent-deck` orchestration via the new-pane
+#      form (Ctrl+N -> cycle Mode to "Orch: dot-agent-deck" -> submit); give it a
+#      prompt
+#    - WARM: detach + relaunch          -> tab rebuilt via daemon hydration
+#    - COLD: stop the daemon + relaunch -> tab rebuilt from the snapshot:
+#      orchestrator + role panes in order, the prompt replayed, start-role cursor
+#    - DRIFT: rename the `dot-agent-deck` orchestration in THIS file, stop the
+#      daemon, relaunch -> a clear warning shows and the tab falls back to a
+#      PLAIN dashboard pane (never a half-broken tab).
+#
+# 5) FRESH-START ESCAPE HATCH
+#    - dot-agent-deck snapshot clear        -> deletes the local snapshot; the
+#      next launch is empty
+#    - dot-agent-deck remote remove <name>  -> registry-only: does NOT clear the
+#      snapshot (your panes still restore on next launch)
+# =============================================================================
+
 [[modes]]
 name = "dev"
 init_command = "devbox shell"

--- a/changelog.d/89.breaking.md
+++ b/changelog.d/89.breaking.md
@@ -1,0 +1,15 @@
+## Auto-Restore TUI State on Attach; `--continue` Flag Removed
+
+Running `dot-agent-deck` now **restores your previous workspace automatically** — panes, agents, and orchestration tabs are recreated from the last saved snapshot. Previously, an empty session was the default and `--continue` was required to restore state; that flag is now removed.
+
+**What changed for users:**
+
+- **Auto-restore is the new default.** Both `dot-agent-deck` (local) and `dot-agent-deck connect` (remote) restore the previous session on startup. On a fresh machine with no prior snapshot, the dashboard starts empty as before. On reconnect after a daemon crash, the workspace is recreated from the snapshot — agents are respawned and orchestration tabs are rebuilt.
+- **`--continue` is removed.** Passing `--continue` prints a friendly message explaining that auto-restore is now the default and exits. Remove `--continue` from any wrapper scripts or aliases.
+- **Fresh start via `dot-agent-deck snapshot clear`.** To begin a new session without the previous workspace, run `dot-agent-deck snapshot clear`. This deletes the global snapshot (`~/.config/dot-agent-deck/session.toml`, or the path set by `DOT_AGENT_DECK_SESSION`) and the next launch starts empty.
+- **Snapshot stays continuously fresh.** The snapshot is written on every meaningful state change (new pane, rename, close, agent stop/restart, orchestration changes) and on detach — not only at clean quit. A 750 ms coalescer prevents excessive disk writes during bursts.
+- **Orchestration tabs survive restart.** When the daemon is empty (first launch on a new machine, or after a crash), orchestration tabs are rebuilt from the snapshot: orchestrator pane, role panes in order, prompts, and role cursor position. On config drift (config deleted or roles removed), a warning is shown and the tab falls back to a plain dashboard pane.
+
+**Migration:** Remove `--continue` from any wrapper scripts or shell aliases. Auto-restore is now the default — no flag needed.
+
+See the [Session Management docs](https://agent-deck.devopstoolkit.ai/docs/session-management) for full details on the restore model and the `snapshot clear` escape hatch.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,10 +14,8 @@ title: Getting Started
 brew tap vfarcic/tap && brew install dot-agent-deck
 
 # 2. Launch the dashboard (hooks are auto-installed for detected agents)
+# Your previous workspace is restored automatically
 dot-agent-deck
-
-# Or resume your previous session
-dot-agent-deck --continue
 ```
 
 ### Linux
@@ -27,10 +25,8 @@ dot-agent-deck --continue
 brew tap vfarcic/tap && brew install dot-agent-deck
 
 # 2. Launch the dashboard (hooks are auto-installed for detected agents)
+# Your previous workspace is restored automatically
 dot-agent-deck
-
-# Or resume your previous session
-dot-agent-deck --continue
 ```
 
 ### Windows

--- a/docs/session-management.md
+++ b/docs/session-management.md
@@ -42,16 +42,37 @@ The more agents you run in parallel, the more cards Agent Deck has to fit on the
 
 ## Resuming Sessions
 
-The dashboard automatically saves your open panes (directories, names, and commands) when you exit. To restore them next time:
+Agent Deck restores your workspace automatically. There is no flag to pass and no decision to make: every time you launch the TUI — `dot-agent-deck` locally or `dot-agent-deck connect <name>` against a remote daemon — your previous panes, names, directories, commands, and tabs come back.
+
+> **Breaking change:** Auto-restore is now the default. Bare `dot-agent-deck` restores your previous workspace instead of starting empty, and the old `--continue` flag has been removed. If you have wrapper scripts or aliases that pass `--continue`, drop it — running `dot-agent-deck --continue` now prints a short message explaining that auto-restore is the default. To start from an empty dashboard on purpose, see [Starting Fresh](#starting-fresh) below.
+
+Restore happens in two layers, tried in order:
+
+1. **Daemon hydration first.** The background daemon owns your running agents, so on attach the dashboard rehydrates whatever the daemon currently holds — agents still in their previous state, with live output. This is the common case when you detach (close the TUI, or disconnect from a remote) and reattach later.
+2. **On-disk snapshot fallback.** If the daemon is empty — a fresh machine, the first launch after a reboot, or recovery after a daemon crash — Agent Deck falls back to the saved snapshot on disk and recreates the workspace structure: panes, names, directories, commands, and tabs. Agent processes are respawned fresh; each agent's own conversation state is restored by its own command line (for example, `claude --continue`), not by Agent Deck.
+
+If both the daemon and the snapshot are empty, you land on a clean, empty dashboard. After restore the dashboard is shown first so you get an overview before switching to a specific tab. If a saved directory no longer exists, that pane is skipped with a warning.
+
+### The snapshot stays fresh
+
+The on-disk snapshot is written continuously, not only when you quit cleanly. Agent Deck saves it on every meaningful change to your workspace — a new pane, a rename, a mode or orchestration tab opening or closing, an agent stopping or restarting — and again when you detach. Writes are coalesced, so a burst of changes (such as spinning up a full orchestration) collapses to one or two disk writes rather than thrashing the disk on every keystroke. This is what makes crash recovery useful: because the snapshot reflects your latest state at detach time, a respawned-empty daemon falls back to an up-to-date workspace, not a weeks-stale one from your last clean quit.
+
+### Mode and orchestration tabs are restored too
+
+Mode tabs are restored in full: each agent pane records which mode it belonged to, and restore reopens the entire mode tab — tab name, agent pane and its command, and all side panes with their commands — by looking up the mode config from the project's `.dot-agent-deck.toml`.
+
+Orchestration tabs are restored as well. From a warm daemon they come back via hydration; when the daemon is empty they are rebuilt from the snapshot, which records the orchestrator pane and its prompt, the role panes in their saved order, and the start-role cursor. Agent Deck re-resolves the orchestration config from the project's `.dot-agent-deck.toml` to rebuild the tab.
+
+In every case only the workspace structure is restored, not an agent's internal conversation state. If the relevant config has drifted at restore time — `.dot-agent-deck.toml` is missing, the mode or orchestration was renamed, or a role was removed — a clear warning is shown and the affected pane falls back to a plain dashboard pane rather than a half-broken tab.
+
+### Starting Fresh
+
+To discard the saved workspace and start from an empty dashboard next time, clear the snapshot:
 
 ```bash
-dot-agent-deck --continue
+dot-agent-deck snapshot clear
 ```
 
-Without `--continue`, the dashboard starts with a blank slate. If a saved directory no longer exists, that pane is skipped with a warning.
-
-After restore the dashboard is shown first so you get an overview before switching to a specific tab.
-
-Mode tabs are also restored: each agent pane records which mode it belonged to, and `--continue` reopens the full mode tab — tab name, agent pane and its command, and all side panes with their commands — by looking up the mode config from the project's `.dot-agent-deck.toml`. The agent's internal conversation state is not restored; only the workspace structure is. If `.dot-agent-deck.toml` is missing or the mode was renamed at restore time, a warning is printed to stderr and the pane falls back to a plain dashboard pane.
+This deletes the single global snapshot file. Note that `dot-agent-deck remote remove <name>` is registry-only — it removes a remote from your local registry and intentionally does **not** clear the snapshot, so removing an unrelated remote never wipes your local workspace.
 
 Session data is stored in `~/.config/dot-agent-deck/session.toml`.

--- a/docs/session-management.md
+++ b/docs/session-management.md
@@ -42,28 +42,26 @@ The more agents you run in parallel, the more cards Agent Deck has to fit on the
 
 ## Resuming Sessions
 
-Agent Deck restores your workspace automatically. There is no flag to pass and no decision to make: every time you launch the TUI — `dot-agent-deck` locally or `dot-agent-deck connect <name>` against a remote daemon — your previous panes, names, directories, commands, and tabs come back.
+Agent Deck restores your workspace automatically. There is no flag to pass and no decision to make: every time you launch the TUI — `dot-agent-deck` locally or `dot-agent-deck connect <name>` for a remote machine — your previous panes, names, directories, commands, and tabs come back.
 
 > **Breaking change:** Auto-restore is now the default. Bare `dot-agent-deck` restores your previous workspace instead of starting empty, and the old `--continue` flag has been removed. If you have wrapper scripts or aliases that pass `--continue`, drop it — running `dot-agent-deck --continue` now prints a short message explaining that auto-restore is the default. To start from an empty dashboard on purpose, see [Starting Fresh](#starting-fresh) below.
 
-Restore happens in two layers, tried in order:
+What you get back depends on whether your agents are still running:
 
-1. **Daemon hydration first.** The background daemon owns your running agents, so on attach the dashboard rehydrates whatever the daemon currently holds — agents still in their previous state, with live output. This is the common case when you detach (close the TUI, or disconnect from a remote) and reattach later.
-2. **On-disk snapshot fallback.** If the daemon is empty — a fresh machine, the first launch after a reboot, or recovery after a daemon crash — Agent Deck falls back to the saved snapshot on disk and recreates the workspace structure: panes, names, directories, commands, and tabs. Agent processes are respawned fresh; each agent's own conversation state is restored by its own command line (for example, `claude --continue`), not by Agent Deck.
+- **They're still running.** When you close the TUI or disconnect, your agents keep running in the background (see [How it runs](getting-started.md#how-it-runs)), so coming back brings them up exactly as they were, with their live output. This is the everyday case.
+- **They're gone.** On a fresh machine, the first launch after a reboot, or after an unexpected shutdown, Agent Deck rebuilds your workspace — panes, names, directories, commands, and tabs — and starts the agents fresh. It restores the *shape* of your workspace, not an agent's in-progress work; each agent picks its own conversation back up through its own command (for example, `claude --continue`).
 
-If both the daemon and the snapshot are empty, you land on a clean, empty dashboard. When a snapshot restore rebuilds one or more orchestration tabs, Agent Deck opens the first restored orchestration tab so you land where you left off; otherwise — and after a daemon hydration with no orchestration to land on — you start on the dashboard for an overview. If a saved directory no longer exists, that pane is skipped with a warning.
+If there's nothing to bring back, you start on a clean, empty dashboard. If your workspace includes orchestration tabs, you land on the first one so you resume where you left off; otherwise you start on the dashboard for an overview. If a saved directory no longer exists, that pane is skipped with a warning.
 
-### The snapshot stays fresh
+### Your setup stays up to date
 
-The on-disk snapshot is written continuously, not only when you quit cleanly. Agent Deck saves it on every meaningful change to your workspace — a new pane, a rename, a mode or orchestration tab opening or closing, an agent stopping or restarting — and again when you detach. Writes are coalesced, so a burst of changes (such as spinning up a full orchestration) collapses to one or two disk writes rather than thrashing the disk on every keystroke. This is what makes crash recovery useful: because the snapshot reflects your latest state at detach time, a respawned-empty daemon falls back to an up-to-date workspace, not a weeks-stale one from your last clean quit.
+Agent Deck keeps your saved workspace current as you work — after every new pane, rename, tab, and agent change, and again whenever you disconnect — so what it brings back is your most recent setup, never a stale copy from the last time you happened to quit. That is what makes recovery worthwhile after an unexpected shutdown: you return to where you actually were, not to a workspace from days ago.
 
-### Mode and orchestration tabs are restored too
+### Mode and orchestration tabs come back too
 
-Mode tabs are restored in full: each agent pane records which mode it belonged to, and restore reopens the entire mode tab — tab name, agent pane and its command, and all side panes with their commands — by looking up the mode config from the project's `.dot-agent-deck.toml`.
+Mode tabs return in full — the tab and its name, the agent pane and its command, and every side pane. Orchestration tabs return too, with the orchestrator and its prompt, the role panes in their original order, and the start-role cursor where you left it.
 
-Orchestration tabs are restored as well. From a warm daemon they come back via hydration; when the daemon is empty they are rebuilt from the snapshot, which records the orchestrator pane and its prompt, the role panes in their saved order, and the start-role cursor. Agent Deck re-resolves the orchestration config from the project's `.dot-agent-deck.toml` to rebuild the tab.
-
-In every case only the workspace structure is restored, not an agent's internal conversation state. If the relevant config has drifted at restore time — `.dot-agent-deck.toml` is missing, the mode or orchestration was renamed, or a role was removed — a clear warning is shown and the affected pane falls back to a plain dashboard pane rather than a half-broken tab.
+In every case only the workspace structure is restored, not an agent's internal conversation. If something in your project's `.dot-agent-deck.toml` has changed since you last ran it — the file is missing, a mode or orchestration was renamed, or a role was removed — Agent Deck shows a clear warning and brings that pane back as a plain dashboard pane instead of a broken tab.
 
 ### Starting Fresh
 
@@ -73,6 +71,6 @@ To discard the saved workspace and start from an empty dashboard next time, clea
 dot-agent-deck snapshot clear
 ```
 
-This deletes the single global snapshot file. Note that `dot-agent-deck remote remove <name>` is registry-only — it removes a remote from your local registry and intentionally does **not** clear the snapshot, so removing an unrelated remote never wipes your local workspace.
+This clears your saved workspace, so the next launch starts empty. Note that `dot-agent-deck remote remove <name>` does **not** do this — it only forgets a remote you had connected to and leaves your saved workspace untouched, so removing an unrelated remote never wipes your setup.
 
-Session data is stored in `~/.config/dot-agent-deck/session.toml`.
+Your saved workspace lives in `~/.config/dot-agent-deck/session.toml`.

--- a/docs/session-management.md
+++ b/docs/session-management.md
@@ -51,7 +51,7 @@ Restore happens in two layers, tried in order:
 1. **Daemon hydration first.** The background daemon owns your running agents, so on attach the dashboard rehydrates whatever the daemon currently holds — agents still in their previous state, with live output. This is the common case when you detach (close the TUI, or disconnect from a remote) and reattach later.
 2. **On-disk snapshot fallback.** If the daemon is empty — a fresh machine, the first launch after a reboot, or recovery after a daemon crash — Agent Deck falls back to the saved snapshot on disk and recreates the workspace structure: panes, names, directories, commands, and tabs. Agent processes are respawned fresh; each agent's own conversation state is restored by its own command line (for example, `claude --continue`), not by Agent Deck.
 
-If both the daemon and the snapshot are empty, you land on a clean, empty dashboard. After restore the dashboard is shown first so you get an overview before switching to a specific tab. If a saved directory no longer exists, that pane is skipped with a warning.
+If both the daemon and the snapshot are empty, you land on a clean, empty dashboard. When a snapshot restore rebuilds one or more orchestration tabs, Agent Deck opens the first restored orchestration tab so you land where you left off; otherwise — and after a daemon hydration with no orchestration to land on — you start on the dashboard for an overview. If a saved directory no longer exists, that pane is skipped with a warning.
 
 ### The snapshot stays fresh
 

--- a/docs/session-management.md
+++ b/docs/session-management.md
@@ -42,9 +42,7 @@ The more agents you run in parallel, the more cards Agent Deck has to fit on the
 
 ## Resuming Sessions
 
-Agent Deck restores your workspace automatically. There is no flag to pass and no decision to make: every time you launch the TUI — `dot-agent-deck` locally or `dot-agent-deck connect <name>` for a remote machine — your previous panes, names, directories, commands, and tabs come back.
-
-> **Breaking change:** Auto-restore is now the default. Bare `dot-agent-deck` restores your previous workspace instead of starting empty, and the old `--continue` flag has been removed. If you have wrapper scripts or aliases that pass `--continue`, drop it — running `dot-agent-deck --continue` now prints a short message explaining that auto-restore is the default. To start from an empty dashboard on purpose, see [Starting Fresh](#starting-fresh) below.
+Agent Deck restores your workspace automatically. There is no flag to pass and no decision to make: every time you launch the TUI — `dot-agent-deck` locally or `dot-agent-deck connect <name>` for a remote machine — your previous panes, names, directories, commands, and tabs come back. If you would rather start from an empty dashboard, see [Starting Fresh](#starting-fresh) below.
 
 What you get back depends on whether your agents are still running:
 

--- a/prds/89-auto-restore-tui-state.md
+++ b/prds/89-auto-restore-tui-state.md
@@ -29,7 +29,7 @@ Unify the restore model across local and remote into a single behavior:
 - **On every TUI startup**, attempt daemon hydration first. If the daemon has agents, that wins. If the daemon is empty (fresh spawn or crash recovery), fall back to the disk snapshot and recreate the workspace.
 - **Keep the snapshot fresh.** Write it on detach and on every meaningful TUI state change (new pane, rename, mode tab open/close, agent stop/restart, orchestration changes) — not only at clean quit.
 - **Delete the `--continue` flag.** With auto-restore as the default, there is no decision left for the user to express via a flag.
-- **Provide a "fresh start" escape hatch.** Per-deck removal for remote (existing `remove` flow clears that deck's saved state); a small CLI affordance for the local snapshot.
+- **Provide a "fresh start" escape hatch.** The snapshot is a single global file, so one CLI affordance covers it: `dot-agent-deck snapshot clear` deletes the global snapshot. (`dot-agent-deck remote remove <name>` is registry-only and does not touch it — see the 2026-06-14 escape-hatch Design Decision.)
 
 As a side effect, daemon crash recovery is "free": a respawned-empty daemon triggers the same snapshot fallback path as a first-time launch on a machine with prior state.
 
@@ -43,7 +43,7 @@ As a side effect, daemon crash recovery is "free": a respawned-empty daemon trig
   - *Daemon-hydration path (warm daemon):* PRD #76 M2.12 + PRD #111 already hydrate orchestration tabs from the daemon registry. **Verify** this covers orchestrator+role panes, prompts, role order, and `start_role_index` end-to-end; if hydration is already complete, no new capture work is needed for the warm-daemon case — only a regression test asserting it.
   - *Snapshot-fallback path (daemon empty — fresh machine or crash recovery):* the disk snapshot must carry enough orchestration metadata to rebuild the tab when the daemon has nothing to hydrate from. This is where the old #74 schema work (orchestration metadata on the saved pane: role order, `orchestrator_prompt`, resolved config name+project for re-resolution, `start_role_index`, a `version` field) genuinely re-homes. On config drift (config deleted, orchestration renamed, role removed) surface a clear `session_warnings` message and fall back to a plain dashboard pane rather than a half-broken tab.
 - **Delete the `--continue` flag.** Remove the CLI argument, the `continue_session` plumbing, and the conditional in `src/ui.rs:2748`. The saved-session-load path becomes unconditional (gated only on whether the daemon was empty).
-- **Fresh-start escape hatch.** For remote: confirm `dot-agent-deck remove <name>` clears the deck's saved state (or add the wiring if it doesn't). For local: add `dot-agent-deck reset` (or equivalent — exact CLI shape is a Design Decision) that deletes the local snapshot.
+- **Fresh-start escape hatch.** The saved snapshot is a single global file, not per-deck (see the 2026-06-14 escape-hatch Design Decision), so there is exactly one fresh-start action: `dot-agent-deck snapshot clear`, which deletes the global snapshot via `config::SavedSession::clear()`. `dot-agent-deck remote remove <name>` stays registry-only and intentionally does NOT touch the snapshot.
 - **Backward-compat consideration.** This changes the meaning of `dot-agent-deck` (no flag) from "empty session" to "restore last setup." Document as a deliberate breaking change in the changelog.
 - **Tests.** Snapshot is written on each in-scope state change; auto-restore prefers daemon over snapshot; empty daemon + non-empty snapshot recreates the workspace; empty daemon + empty snapshot lands at empty dashboard cleanly.
 - **Documentation.** Update `docs/` to reflect the new restore behavior, remove all references to `--continue`, document the fresh-start escape hatch.
@@ -61,7 +61,7 @@ As a side effect, daemon crash recovery is "free": a respawned-empty daemon trig
 - `dot-agent-deck connect <name>` (remote, no flag) attaches to the daemon and restores any hydrated agents; if the daemon is empty (fresh spawn, crash recovery), falls back to the snapshot and recreates the workspace.
 - After a daemon crash and reconnect, the TUI ends up with the same panes/tabs the user had before the crash (modulo in-flight state). Agent processes are respawned fresh; each agent's own conversation state is restored by the agent's own command line (e.g., `claude --continue`).
 - `--continue` is removed from the CLI surface and from `--help`. Existing users of `--continue` get a clear deprecation/removal message if they try to use it.
-- A user who wants a fresh start has one obvious action: remove the deck (remote) or run the local reset command (local). Both clear the snapshot.
+- A user who wants a fresh start has one obvious action: `dot-agent-deck snapshot clear`, which deletes the single global saved-session snapshot. (The snapshot is global, not per-deck; `dot-agent-deck remote remove <name>` is registry-only and intentionally does NOT clear it.)
 - Snapshot writes are coalesced so they don't impact TUI responsiveness during heavy interaction.
 - `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all pass.
 
@@ -101,9 +101,9 @@ As a side effect, daemon crash recovery is "free": a respawned-empty daemon trig
 
 ### Phase 4: Fresh-start escape hatch
 
-- [ ] **M4.1** — Confirm that `dot-agent-deck remove <name>` already clears that deck's saved state. If it doesn't, add the wiring.
-- [ ] **M4.2** — Add a `dot-agent-deck reset` (or `--reset`, or equivalent) subcommand that deletes the local snapshot. Exact CLI shape is a Design Decision; pick during implementation. Confirm with the deck-removal symmetry (one obvious action, no overlap).
-- [ ] **M4.3** — Tests for both escape hatches.
+- [ ] **M4.1** — *Resolved (see the 2026-06-14 escape-hatch Design Decision below).* Investigation found the saved snapshot is a **single global file** (`config::session_path()` → `DOT_AGENT_DECK_SESSION` or `~/.config/dot-agent-deck/session.toml`), not keyed per deck — there is no per-deck saved state on disk. There is also no top-level `dot-agent-deck remove`; the real command is `dot-agent-deck remote remove <name>`, which mutates only the local registry (`remotes.toml`). Decision (Option 1): `remote remove` stays **registry-only and intentionally does NOT clear the snapshot**. The one obvious global fresh-start action is `dot-agent-deck snapshot clear` (M4.2) — so there is no per-deck wiring to add.
+- [ ] **M4.2** — Add a `dot-agent-deck snapshot clear` subcommand — a `snapshot` subcommand **group** (room for future snapshot actions) with a `clear` **action** — that deletes the local snapshot by calling `config::SavedSession::clear()` (the same teardown clear, so it honors the `DOT_AGENT_DECK_SESSION` override). Ships visible by default (no experimental feature flag). Exact CLI shape resolved as a Design Decision (`snapshot clear`, not `reset`/`--reset`).
+- [ ] **M4.3** — Tests for the escape hatch: `snapshot clear` deletes the local snapshot and exits 0 (`session/snapshot/001`); and a green-guard that `remote remove <name>` leaves the global snapshot intact (`session/snapshot/002`).
 
 ### Phase 5: Documentation + release
 
@@ -141,9 +141,9 @@ Considered "make the daemon's registry survive its own crash" as a complementary
 
 Removing `--continue` and making restore the default flips the meaning of plain `dot-agent-deck` from "empty session" to "restore last setup." This is a deliberate breaking change. Justification: restoring is the common case; starting fresh is rare. The current CLI optimizes for the rare case. New users are better served by the new default; existing users get a one-line changelog migration. Worth it.
 
-### Open: shape of the local "fresh start" command
+### ~~Open: shape of the local "fresh start" command~~ — RESOLVED 2026-06-14
 
-The remote case is clear: `dot-agent-deck remove <name>` already removes the deck and (per M4.1) clears its snapshot. The local case needs an analogous action. Options: `dot-agent-deck reset`, `dot-agent-deck --reset`, `dot-agent-deck snapshot clear`, or a TUI affordance ("Quit and clear saved state" in the quit-confirm dialog). Decide during M4.2 implementation.
+The local case needed an analogous action to deck removal. Options considered: `dot-agent-deck reset`, `dot-agent-deck --reset`, `dot-agent-deck snapshot clear`, or a TUI affordance ("Quit and clear saved state" in the quit-confirm dialog). **Resolved** in favour of `dot-agent-deck snapshot clear` — see the 2026-06-14 escape-hatch Design Decision below for the full rationale (the snapshot turned out to be a single global file, which reshaped the whole escape-hatch model).
 
 ### 2026-06-14: Refresh against the shipped daemon architecture (#76 shipped, #93 unified local+remote)
 
@@ -187,3 +187,17 @@ The remote case is clear: `dot-agent-deck remove <name>` already removes the dec
 **Coalescing.** `mark_session_dirty` only sets a dirty flag on a `config::SnapshotCoalescer` (a pure-data leading-edge throttle, unit-tested as `session/save/003`). The main loop calls `flush_session_snapshot_if_due` once per iteration (including the 16ms idle ticks): the first pending change writes immediately, further changes are throttled to at most one write per `SNAPSHOT_COALESCE_INTERVAL` (750 ms), and a single trailing write flushes whatever accumulated during the quiet-down. A burst (e.g. orchestration setup spawning many panes) therefore collapses to one or two disk writes, not one per pane.
 
 **Owner.** Viktor (Phase 1 implementation, 2026-06-14).
+
+### 2026-06-14: Phase 4 escape-hatch — the snapshot is global, so `snapshot clear` is the single fresh-start action and `remote remove` stays registry-only
+
+**Decision (Option 1, chosen by Viktor).** There is exactly one local fresh-start action — `dot-agent-deck snapshot clear` — and `dot-agent-deck remote remove <name>` intentionally does NOT clear the snapshot.
+
+**Finding that reshaped M4.1/M4.2.** The PRD was drafted assuming a *per-deck* saved state that `dot-agent-deck remove <name>` would clear. Investigation during Phase 4 found two things that invalidate that framing: (1) the saved snapshot is a **single global file** — `config::session_path()` resolves to `DOT_AGENT_DECK_SESSION` or `~/.config/dot-agent-deck/session.toml`, not keyed per deck/remote — so there is no per-deck saved state on disk to clear; and (2) there is no top-level `dot-agent-deck remove` command at all — the real command is `dot-agent-deck remote remove <name>` (`RemoteCmd::Remove`), which mutates only the local registry (`remotes.toml`) and never references `SavedSession`.
+
+**Why Option 1 (remove stays registry-only).** Because the snapshot is global and shared with the local deck, wiring `remote remove` to call `SavedSession::clear()` would clear the *local* workspace as a side effect of removing an *unrelated remote* registry entry — surprising cross-deck coupling. Keeping `remote remove` registry-only preserves the principle of least surprise: removing a remote touches only remote metadata. The fresh-start need is then served by one explicit, obvious global action rather than smeared across the remove flow.
+
+**Shape.** `snapshot` is a subcommand **group** (parallel to `remote`/`schedule`) with a `clear` **action**, leaving room for future snapshot operations (e.g. `snapshot show`, `snapshot export`). `clear` calls `config::SavedSession::clear()` — the same teardown clear the TUI already uses — so it honors the `DOT_AGENT_DECK_SESSION` override and deletes the one global file. Ships visible by default; **no experimental feature flag** (decided in `.dot-agent-deck/prd-89-context.md`).
+
+**Test impact.** `session/snapshot/001` asserts `snapshot clear` exits 0 and deletes the staged snapshot. `session/snapshot/002` flips from "remove deletes the snapshot" to a **green-guard** asserting `remote remove <name>` leaves the global snapshot intact.
+
+**Owner.** Viktor (decided 2026-06-14).

--- a/prds/89-auto-restore-tui-state.md
+++ b/prds/89-auto-restore-tui-state.md
@@ -171,3 +171,19 @@ The remote case is clear: `dot-agent-deck remove <name>` already removes the dec
 - #74's schema sketch and restore-branch design remain useful as implementation reference in `prds/done/74-*.md`.
 
 **Owner.** Viktor (decided in 2026-06-14 planning discussion).
+
+### 2026-06-14: M1.1 — the exact state-change events wired to a snapshot write, and how they coalesce
+
+**Decision.** Phase 1 keeps the saved-session snapshot continuously fresh by marking it *dirty* at each meaningful state-change / detach call site and flushing it from the main loop through a coalescer, rather than writing inline at every site. The exact set of events wired to mark the snapshot dirty (all funnel through one helper, `UiState::mark_session_dirty`):
+
+- **New dashboard pane created** — the new-pane form submit (`Action::SpawnPane`, non-orchestration path, right after the `pane_metadata` insert). Covers both a plain dashboard pane and a **mode tab opened** (the mode-tab branch shares that same insert).
+- **Orchestration tab opened** — the `Action::SpawnPane` orchestration path, on the `open_orchestration_tab` success branch.
+- **Pane / tab closed** — `Action::CloseSelected` (Ctrl+W: closable-tab close, mode/orchestration tab close from a dashboard card, and plain-pane close) and `close_tab_by_index` (the `[×]` click / `Action::CloseTab`), covering **mode tab closed** and **orchestration tab closed**.
+- **Pane renamed** — `Action::SaveRename` (after `commit_rename`).
+- **Agent stop / restart** — the main loop's reactive pane-pool change (`route_reactive_commands` returning `(old_id, new_id)` pairs, e.g. after a `/clear` restart), which swaps live pane ids.
+
+**Detach paths (M1.3).** Ctrl+W close-pane marks dirty as above. Explicit *detach from the quit-confirm dialog* (`Action::DetachAndQuit`) breaks the loop straight into the existing unconditional pre-teardown snapshot write, so no extra trigger is needed there. *SSH disconnect (remote)* never runs a clean teardown (the process dies on SIGHUP), so it is covered structurally by the continuous freshness above: the snapshot already reflects the latest state-change at disconnect time.
+
+**Coalescing.** `mark_session_dirty` only sets a dirty flag on a `config::SnapshotCoalescer` (a pure-data leading-edge throttle, unit-tested as `session/save/003`). The main loop calls `flush_session_snapshot_if_due` once per iteration (including the 16ms idle ticks): the first pending change writes immediately, further changes are throttled to at most one write per `SNAPSHOT_COALESCE_INTERVAL` (750 ms), and a single trailing write flushes whatever accumulated during the quiet-down. A burst (e.g. orchestration setup spawning many panes) therefore collapses to one or two disk writes, not one per pane.
+
+**Owner.** Viktor (Phase 1 implementation, 2026-06-14).

--- a/prds/89-auto-restore-tui-state.md
+++ b/prds/89-auto-restore-tui-state.md
@@ -1,9 +1,9 @@
 # PRD #89: Auto-restore TUI state on attach; remove `--continue` flag
 
-**Status**: Planning
+**Status**: Implementation complete — pending changelog fragment (M5.2) + release (M5.3)
 **Priority**: Medium
 **Created**: 2026-05-16
-**Last Updated**: 2026-06-14
+**Last Updated**: 2026-06-15
 **GitHub Issue**: [#89](https://github.com/vfarcic/dot-agent-deck/issues/89)
 
 > **2026-06-14 refresh — read before implementing.** This PRD predates the daemon architecture shipping. The landscape has moved: PRD #76 (Remote Agent Environments) **shipped**, and PRD #93 (always-external daemon) made the daemon the **unified architecture even locally** — `run_tui_session` now always connects to an external daemon (`ensure_external_daemon_or_die`). Two consequences: (1) the original line references below are **stale** (e.g. the `continue_session` gate is no longer at `src/ui.rs:2748` — it is threaded through `run_tui` around `src/ui.rs:5862`, plus `5426/5462/5849`); re-locate by symbol, not line number, at implementation time. (2) Several milestones are **partially delivered** by #76/#93 and the scope has **grown** to absorb orchestration-tab restore (formerly PRD #74, now closed). See the new Design Decision entries dated 2026-06-14 and the revised Dependencies/Scope/Milestones below.
@@ -69,45 +69,45 @@ As a side effect, daemon crash recovery is "free": a respawned-empty daemon trig
 
 ### Phase 1: Snapshot freshness
 
-- [ ] **M1.1** — Identify the set of "meaningful state change" events that should trigger a snapshot write: new pane created, pane renamed, pane closed, mode tab opened/closed, orchestration tab opened/closed/role-changed, agent stop, agent restart. Document the list inline in the PRD or as a Design Decision.
-- [ ] **M1.2** — Add a snapshot-write trigger to each of those events. Coalesce/debounce writes so a burst of changes (e.g., orchestration setup) produces one or two disk writes, not dozens.
-- [ ] **M1.3** — Add a snapshot-write trigger to the detach paths: ssh disconnect (remote), Ctrl+W close-pane (where applicable), explicit detach from the quit-confirm dialog.
-- [ ] **M1.4** — Tests confirming each trigger writes a snapshot and that coalescing actually coalesces.
+- [x] **M1.1** — Identify the set of "meaningful state change" events that should trigger a snapshot write: new pane created, pane renamed, pane closed, mode tab opened/closed, orchestration tab opened/closed/role-changed, agent stop, agent restart. Document the list inline in the PRD or as a Design Decision.
+- [x] **M1.2** — Add a snapshot-write trigger to each of those events. Coalesce/debounce writes so a burst of changes (e.g., orchestration setup) produces one or two disk writes, not dozens.
+- [x] **M1.3** — Add a snapshot-write trigger to the detach paths: ssh disconnect (remote), Ctrl+W close-pane (where applicable), explicit detach from the quit-confirm dialog.
+- [x] **M1.4** — Tests confirming each trigger writes a snapshot and that coalescing actually coalesces.
 
 ### Phase 2: Auto-restore on TUI startup
 
 > **2026-06-14:** Post-#93 the local TUI is daemon-backed, so hydration-first applies uniformly — M2.2 is one path, not local-vs-remote. The snapshot-load gate is no longer at `src/ui.rs:2748`; it is the `continue_session` block around `src/ui.rs:5862` in `run_tui`. Re-locate by symbol.
 
-- [ ] **M2.1** — Make the snapshot-load path (the `if continue_session { … }` block in `run_tui`, ~`src/ui.rs:5862` — verify current location) unconditional (no longer gated on `continue_session`). Restore from snapshot on every TUI startup.
-- [ ] **M2.2** — Wire the daemon-state-vs-snapshot precedence: if M2.11/M2.12 hydration produced any panes, skip snapshot restore. If hydration produced zero panes, load and apply the snapshot. Decide via a structural check (any hydrated `managed_pane_id` in `state`), not a flag.
-- [ ] **M2.3** — Verify the existing M2.11/M2.12 hydration path still works unchanged in the common detach/reattach case. No regressions for users currently relying on automatic remote restore.
-- [ ] **M2.4** — Tests: daemon-with-agents wins over snapshot; daemon-empty + non-empty-snapshot recreates from snapshot; both empty lands at empty dashboard.
+- [x] **M2.1** — Make the snapshot-load path (the `if continue_session { … }` block in `run_tui`, ~`src/ui.rs:5862` — verify current location) unconditional (no longer gated on `continue_session`). Restore from snapshot on every TUI startup.
+- [x] **M2.2** — Wire the daemon-state-vs-snapshot precedence: if M2.11/M2.12 hydration produced any panes, skip snapshot restore. If hydration produced zero panes, load and apply the snapshot. Decide via a structural check (any hydrated `managed_pane_id` in `state`), not a flag.
+- [x] **M2.3** — Verify the existing M2.11/M2.12 hydration path still works unchanged in the common detach/reattach case. No regressions for users currently relying on automatic remote restore.
+- [x] **M2.4** — Tests: daemon-with-agents wins over snapshot; daemon-empty + non-empty-snapshot recreates from snapshot; both empty lands at empty dashboard.
 
 ### Phase 2b: Orchestration-tab restore (absorbed from closed PRD #74)
 
-- [ ] **M2b.1** — **Verify the daemon-hydration path.** Confirm by inspection + a regression test that PRD #76 M2.12 + PRD #111 hydration already recreate an orchestration tab end-to-end from a warm daemon: orchestrator pane + prompt, role panes in saved order, and `start_role_index`. If complete, no new capture code is needed for the warm case.
-- [ ] **M2b.2** — **Snapshot-fallback capture.** For the daemon-empty case (fresh machine / crash recovery), extend the saved-pane schema with orchestration metadata (role order, `orchestrator_prompt`, resolved config name + project path for re-resolution, `start_role_index`, and a `version: u32`), `Option<…>` + `#[serde(default)]` so old snapshots still parse. Port the design from `prds/done/74-restore-orchestration-tabs-on-continue.md`.
-- [ ] **M2b.3** — **Snapshot-fallback restore branch.** Rebuild the orchestration tab from the snapshot when the daemon is empty: re-resolve the `OrchestrationConfig`, recreate orchestrator + role panes in order, re-issue commands, restore `start_role_index`. On config drift (config deleted, orchestration renamed, role removed) surface a clear `session_warnings` message and fall back to a plain dashboard pane — never a half-broken tab.
-- [ ] **M2b.4** — Tests: warm-daemon hydration restores an orchestration tab (M2b.1); daemon-empty + snapshot recreates it; old snapshot without the orchestration field still parses; drift triggers the warning + plain-pane fallback.
+- [x] **M2b.1** — **Verify the daemon-hydration path.** Confirm by inspection + a regression test that PRD #76 M2.12 + PRD #111 hydration already recreate an orchestration tab end-to-end from a warm daemon: orchestrator pane + prompt, role panes in saved order, and `start_role_index`. If complete, no new capture code is needed for the warm case.
+- [x] **M2b.2** — **Snapshot-fallback capture.** For the daemon-empty case (fresh machine / crash recovery), extend the saved-pane schema with orchestration metadata (role order, `orchestrator_prompt`, resolved config name + project path for re-resolution, `start_role_index`, and a `version: u32`), `Option<…>` + `#[serde(default)]` so old snapshots still parse. Port the design from `prds/done/74-restore-orchestration-tabs-on-continue.md`.
+- [x] **M2b.3** — **Snapshot-fallback restore branch.** Rebuild the orchestration tab from the snapshot when the daemon is empty: re-resolve the `OrchestrationConfig`, recreate orchestrator + role panes in order, re-issue commands, restore `start_role_index`. On config drift (config deleted, orchestration renamed, role removed) surface a clear `session_warnings` message and fall back to a plain dashboard pane — never a half-broken tab.
+- [x] **M2b.4** — Tests: warm-daemon hydration restores an orchestration tab (M2b.1); daemon-empty + snapshot recreates it; old snapshot without the orchestration field still parses; drift triggers the warning + plain-pane fallback.
 
 ### Phase 3: Delete `--continue`
 
 > **2026-06-14:** The remote side is **already done** — `run_connect` ignores `_continue_session` ("applies to a laptop-side TUI that no longer exists"). Remaining live work is the **local** plumbing. Line numbers below are stale; re-locate by symbol (`grep continue_session`).
 
-- [ ] **M3.1** — Remove the `--continue` argument from `Cli` (currently `src/main.rs:25-26` — `#[arg(long = "continue")] continue_session: bool`).
-- [ ] **M3.2** — Remove the `continue_session: bool` parameter from `run_dashboard`, `run_tui_session`, the TUI internals (`run_tui`, ~`src/ui.rs:5426`), and drop the already-ignored `_continue_session` from `run_connect`. Sweep all callers via `grep continue_session`.
-- [ ] **M3.3** — Update help text and the in-TUI restore hint (`"  Restore: dot-agent-deck --continue"`, currently ~`src/ui.rs:9698`) to remove the obsolete reference. Also sweep the explanatory `--continue` comments elsewhere in `run_tui` (~`5459`, `5465`, `5850`, `6216`, `7590`) so they don't describe a removed flag.
-- [ ] **M3.4** — Add a friendly error message if a user runs `dot-agent-deck --continue` after removal (clap will reject the unknown flag with its default message; a custom message that tells them auto-restore is the new default is a nice touch).
+- [x] **M3.1** — Remove the `--continue` argument from `Cli` (currently `src/main.rs:25-26` — `#[arg(long = "continue")] continue_session: bool`).
+- [x] **M3.2** — Remove the `continue_session: bool` parameter from `run_dashboard`, `run_tui_session`, the TUI internals (`run_tui`, ~`src/ui.rs:5426`), and drop the already-ignored `_continue_session` from `run_connect`. Sweep all callers via `grep continue_session`.
+- [x] **M3.3** — Update help text and the in-TUI restore hint (`"  Restore: dot-agent-deck --continue"`, currently ~`src/ui.rs:9698`) to remove the obsolete reference. Also sweep the explanatory `--continue` comments elsewhere in `run_tui` (~`5459`, `5465`, `5850`, `6216`, `7590`) so they don't describe a removed flag.
+- [x] **M3.4** — Add a friendly error message if a user runs `dot-agent-deck --continue` after removal (clap will reject the unknown flag with its default message; a custom message that tells them auto-restore is the new default is a nice touch).
 
 ### Phase 4: Fresh-start escape hatch
 
-- [ ] **M4.1** — *Resolved (see the 2026-06-14 escape-hatch Design Decision below).* Investigation found the saved snapshot is a **single global file** (`config::session_path()` → `DOT_AGENT_DECK_SESSION` or `~/.config/dot-agent-deck/session.toml`), not keyed per deck — there is no per-deck saved state on disk. There is also no top-level `dot-agent-deck remove`; the real command is `dot-agent-deck remote remove <name>`, which mutates only the local registry (`remotes.toml`). Decision (Option 1): `remote remove` stays **registry-only and intentionally does NOT clear the snapshot**. The one obvious global fresh-start action is `dot-agent-deck snapshot clear` (M4.2) — so there is no per-deck wiring to add.
-- [ ] **M4.2** — Add a `dot-agent-deck snapshot clear` subcommand — a `snapshot` subcommand **group** (room for future snapshot actions) with a `clear` **action** — that deletes the local snapshot by calling `config::SavedSession::clear()` (the same teardown clear, so it honors the `DOT_AGENT_DECK_SESSION` override). Ships visible by default (no experimental feature flag). Exact CLI shape resolved as a Design Decision (`snapshot clear`, not `reset`/`--reset`).
-- [ ] **M4.3** — Tests for the escape hatch: `snapshot clear` deletes the local snapshot and exits 0 (`session/snapshot/001`); and a green-guard that `remote remove <name>` leaves the global snapshot intact (`session/snapshot/002`).
+- [x] **M4.1** — *Resolved (see the 2026-06-14 escape-hatch Design Decision below).* Investigation found the saved snapshot is a **single global file** (`config::session_path()` → `DOT_AGENT_DECK_SESSION` or `~/.config/dot-agent-deck/session.toml`), not keyed per deck — there is no per-deck saved state on disk. There is also no top-level `dot-agent-deck remove`; the real command is `dot-agent-deck remote remove <name>`, which mutates only the local registry (`remotes.toml`). Decision (Option 1): `remote remove` stays **registry-only and intentionally does NOT clear the snapshot**. The one obvious global fresh-start action is `dot-agent-deck snapshot clear` (M4.2) — so there is no per-deck wiring to add.
+- [x] **M4.2** — Add a `dot-agent-deck snapshot clear` subcommand — a `snapshot` subcommand **group** (room for future snapshot actions) with a `clear` **action** — that deletes the local snapshot by calling `config::SavedSession::clear()` (the same teardown clear, so it honors the `DOT_AGENT_DECK_SESSION` override). Ships visible by default (no experimental feature flag). Exact CLI shape resolved as a Design Decision (`snapshot clear`, not `reset`/`--reset`).
+- [x] **M4.3** — Tests for the escape hatch: `snapshot clear` deletes the local snapshot and exits 0 (`session/snapshot/001`); and a green-guard that `remote remove <name>` leaves the global snapshot intact (`session/snapshot/002`).
 
 ### Phase 5: Documentation + release
 
-- [ ] **M5.1** — Update the user-facing docs that mention `--continue` — verified current set: `docs/getting-started.md` and `docs/session-management.md` — to describe the new auto-restore model and the fresh-start escape hatch. (`session-management.md` is also where closed PRD #74 would have added its orchestration-restore paragraph; cover orchestration-tab restore here instead.)
+- [x] **M5.1** — Update the user-facing docs that mention `--continue` — verified current set: `docs/getting-started.md` and `docs/session-management.md` — to describe the new auto-restore model and the fresh-start escape hatch. (`session-management.md` is also where closed PRD #74 would have added its orchestration-restore paragraph; cover orchestration-tab restore here instead.)
 - [ ] **M5.2** — Draft a changelog fragment (via the `dot-ai-changelog-fragment` skill) flagging this as a breaking change with a one-line migration note ("Remove `--continue` from any wrapper scripts; auto-restore is now the default.").
 - [ ] **M5.3** — Tag a release (`dot-ai-tag-release`) once everything lands.
 

--- a/prds/done/89-auto-restore-tui-state.md
+++ b/prds/done/89-auto-restore-tui-state.md
@@ -1,6 +1,6 @@
 # PRD #89: Auto-restore TUI state on attach; remove `--continue` flag
 
-**Status**: Implementation complete — pending changelog fragment (M5.2) + release (M5.3)
+**Status**: Complete — 2026-06-15
 **Priority**: Medium
 **Created**: 2026-05-16
 **Last Updated**: 2026-06-15
@@ -108,7 +108,7 @@ As a side effect, daemon crash recovery is "free": a respawned-empty daemon trig
 ### Phase 5: Documentation + release
 
 - [x] **M5.1** — Update the user-facing docs that mention `--continue` — verified current set: `docs/getting-started.md` and `docs/session-management.md` — to describe the new auto-restore model and the fresh-start escape hatch. (`session-management.md` is also where closed PRD #74 would have added its orchestration-restore paragraph; cover orchestration-tab restore here instead.)
-- [ ] **M5.2** — Draft a changelog fragment (via the `dot-ai-changelog-fragment` skill) flagging this as a breaking change with a one-line migration note ("Remove `--continue` from any wrapper scripts; auto-restore is now the default.").
+- [x] **M5.2** — Draft a changelog fragment (via the `dot-ai-changelog-fragment` skill) flagging this as a breaking change with a one-line migration note ("Remove `--continue` from any wrapper scripts; auto-restore is now the default.").
 - [ ] **M5.3** — Tag a release (`dot-ai-tag-release`) once everything lands.
 
 ## Dependencies

--- a/src/config.rs
+++ b/src/config.rs
@@ -1251,13 +1251,15 @@ mod tests {
             coalescer.record_write(after);
         }
 
-        assert!(
-            writes <= 2,
-            "a burst of 50 changes must coalesce to at most two disk writes, got {writes}"
-        );
-        assert!(
-            writes >= 1,
-            "the burst must still produce at least one write, got {writes}"
+        // PRD #89 review-fix G2: assert the EXACT write count, not `<= 2` / `>= 1`.
+        // For this scenario the count is fully determined — one leading-edge write
+        // on the first change plus one trailing write after the interval elapses =
+        // 2 — so any off-by-one in the coalescer (an extra leading write, a missed
+        // trailing flush) flips this count and fails the test.
+        assert_eq!(
+            writes, 2,
+            "a 50-change burst must coalesce to exactly two writes \
+             (leading edge + one trailing flush), got {writes}"
         );
 
         // After the trailing flush nothing is pending, so no further write is

--- a/src/config.rs
+++ b/src/config.rs
@@ -348,31 +348,56 @@ pub struct SavedPane {
 ///
 /// This struct ONLY captures the metadata + its (de)serialization; the
 /// restore branch that rebuilds the tab from it is M2b.3 (a separate step).
+///
+/// PRD #89 review-fix F12: every sub-field carries `#[serde(default)]` so a
+/// MALFORMED partial `[panes.orchestration]` block degrades to a defaulted
+/// snapshot (which the restore path then drift-checks and falls back from)
+/// rather than failing the WHOLE-file TOML parse and dropping ALL panes. A
+/// zero-default `version`/empty `roles` is harmless — the restore path treats a
+/// role-less / out-of-range snapshot as drift (F2) and restores a plain pane.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct OrchestrationSnapshot {
     /// Schema version, for future migration. `1` is the initial format.
+    #[serde(default)]
     pub version: u32,
     /// Role names in DISPLAY order — the same order as the tab's
     /// `role_pane_ids`, so the restore branch can recreate the role panes
     /// in the order the user saw them.
+    #[serde(default)]
     pub roles: Vec<String>,
     /// Index into `roles` of the start (orchestrator) role — restores the
     /// "next role to start" cursor.
+    #[serde(default)]
     pub start_role_index: usize,
     /// Pre-built prompt injected into the start (orchestrator) role on
     /// restore. Empty string when the orchestration had no prompt.
+    #[serde(default)]
     pub orchestrator_prompt: String,
     /// Resolved orchestration config NAME — half of the reference used to
     /// re-resolve the `OrchestrationConfig` from disk on restore.
+    #[serde(default)]
     pub config_name: String,
     /// Project PATH the orchestration was resolved from (the directory that
     /// holds `.dot-agent-deck.toml`) — the other half of the re-resolution
     /// reference.
+    #[serde(default)]
     pub project_path: String,
     /// Which roles had been started, by index into `roles`. Optional —
     /// snapshots that predate this field load with an empty list.
+    ///
+    /// PRD #89 review-fix F3: FORWARD-COMPAT ONLY — captured (as
+    /// `vec![start_role_index]`) but not yet consumed on restore. Kept so a
+    /// later "restore which roles were started" feature has the data already
+    /// in old snapshots; do not assume a reader exists today.
     #[serde(default)]
     pub started_role_indices: Vec<usize>,
+    /// PRD #89 review-fix F4: the user-typed orchestration tab TITLE
+    /// (`Tab::Orchestration.name`), captured so the daemon-empty restore path
+    /// rebuilds the tab under the user's title rather than the canonical
+    /// config/cwd name. `None` when the user didn't name the orchestration
+    /// (the title then falls back to the resolved canonical name on restore).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_title: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -401,15 +426,62 @@ impl SavedSession {
     }
 
     pub fn save(&self) -> Result<(), String> {
+        use std::io::Write;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
         let path = session_path();
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("Failed to create session directory: {e}"))?;
-        }
+        let parent = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create session directory: {e}"))?;
+
         let contents = toml::to_string_pretty(self)
             .map_err(|e| format!("Failed to serialize session: {e}"))?;
-        std::fs::write(&path, contents)
-            .map_err(|e| format!("Failed to write session at {}: {e}", path.display()))
+
+        // PRD #89 review-fix F6/F7: write owner-only (0o600) AND atomically. The
+        // snapshot now carries command lines, project paths, and prompts and is
+        // written continuously, so (a) it must not be world-readable regardless
+        // of the user's umask, and (b) a crash mid-write must never leave a
+        // half-written `session.toml` for the next launch to choke on. Mirror
+        // remote.rs: write a sibling temp file opened with mode 0o600, then
+        // `rename(2)` it into place (atomic on a POSIX same-filesystem rename).
+        // The pid suffix avoids collisions between concurrently-saving decks.
+        let file_name = path
+            .file_name()
+            .map(|f| f.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "session.toml".to_string());
+        let tmp_path = parent.join(format!("{file_name}.{}.tmp", std::process::id()));
+
+        let mut tmp_file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&tmp_path)
+            .map_err(|e| format!("Failed to open temp session at {}: {e}", tmp_path.display()))?;
+
+        if let Err(e) = tmp_file.write_all(contents.as_bytes()) {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(format!(
+                "Failed to write temp session at {}: {e}",
+                tmp_path.display()
+            ));
+        }
+        // Defense in depth: a stale temp file from a crashed previous save would
+        // keep its old mode (OpenOptions::mode only applies on create), so
+        // re-assert 0o600 explicitly before the rename.
+        if let Err(e) = tmp_file.set_permissions(std::fs::Permissions::from_mode(0o600)) {
+            let _ = std::fs::remove_file(&tmp_path);
+            return Err(format!(
+                "Failed to set permissions on temp session at {}: {e}",
+                tmp_path.display()
+            ));
+        }
+        drop(tmp_file);
+
+        std::fs::rename(&tmp_path, &path).map_err(|e| {
+            let _ = std::fs::remove_file(&tmp_path);
+            format!("Failed to write session at {}: {e}", path.display())
+        })
     }
 
     pub fn clear() -> Result<(), std::io::Error> {
@@ -1312,6 +1384,7 @@ on_idle = true
                     config_name: "tdd-cycle".to_string(),
                     project_path: "/repo/app".to_string(),
                     started_role_indices: vec![0, 1],
+                    display_title: Some("My TDD Run".to_string()),
                 }),
             }],
         };
@@ -1337,6 +1410,7 @@ on_idle = true
         assert_eq!(orch.config_name, "tdd-cycle");
         assert_eq!(orch.project_path, "/repo/app");
         assert_eq!(orch.started_role_indices, vec![0, 1]);
+        assert_eq!(orch.display_title.as_deref(), Some("My TDD Run"));
 
         // (b) A legacy session.toml predating the orchestration field still
         // parses, with orchestration == None (the #[serde(default)] guarantee).

--- a/src/config.rs
+++ b/src/config.rs
@@ -378,7 +378,7 @@ impl SavedSession {
     /// every pane, including mode-tab agent panes that carry `mode = Some(...)`.
     /// `retain` here only prunes panes the user externally closed before exit;
     /// running it after teardown would also drop the mode-tab agent pane and lose
-    /// the mode field, breaking `--continue` restoration (PRD #69).
+    /// the mode field, breaking auto-restore of the mode tab (PRD #69).
     pub fn snapshot(
         pane_metadata: &mut HashMap<String, SavedPane>,
         pane_display_names: &HashMap<String, String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -397,6 +398,67 @@ impl SavedSession {
                 .filter_map(|id| pane_metadata.get(id).cloned())
                 .collect(),
         }
+    }
+}
+
+/// PRD #89 M1.2 — leading-edge throttle that coalesces saved-session snapshot
+/// writes so a burst of meaningful state changes (e.g. orchestration setup
+/// spawning many panes) produces one or two disk writes, not one per change.
+///
+/// Behaviour: the first pending change writes immediately (leading edge), then
+/// writes are throttled to at most one per `interval`; a single trailing write
+/// flushes whatever accumulated while the throttle was closed. So a tight burst
+/// collapses to ≤2 writes (one leading + one trailing), and sustained activity
+/// is bounded to ~one write per `interval` regardless of how many changes occur.
+///
+/// Pure data + logic: the caller supplies the clock as a monotonic [`Duration`]
+/// from an arbitrary epoch (in production, `epoch.elapsed()`; in tests, any
+/// value), so it is fully unit-testable without wall-clock sleeps.
+#[derive(Debug, Clone)]
+pub struct SnapshotCoalescer {
+    /// Minimum spacing between disk writes.
+    interval: Duration,
+    /// A change is pending (recorded but not yet flushed to disk).
+    dirty: bool,
+    /// Clock value of the last write; `None` until the first write happens.
+    last_write: Option<Duration>,
+}
+
+impl SnapshotCoalescer {
+    /// Create a coalescer that allows at most one write per `interval`.
+    pub fn new(interval: Duration) -> Self {
+        Self {
+            interval,
+            dirty: false,
+            last_write: None,
+        }
+    }
+
+    /// Record that a meaningful state change occurred. Does not write — the
+    /// actual coalesced write happens when the caller next sees [`Self::is_due`]
+    /// return `true`.
+    pub fn mark_dirty(&mut self) {
+        self.dirty = true;
+    }
+
+    /// Whether a write is due at `now`: a change is pending AND either nothing
+    /// has been written yet (leading edge) or at least `interval` has elapsed
+    /// since the last write (trailing edge / throttle release).
+    pub fn is_due(&self, now: Duration) -> bool {
+        if !self.dirty {
+            return false;
+        }
+        match self.last_write {
+            None => true,
+            Some(last) => now.saturating_sub(last) >= self.interval,
+        }
+    }
+
+    /// Mark a write as completed at `now`, clearing the pending flag and arming
+    /// the throttle so the next write waits a full `interval`.
+    pub fn record_write(&mut self, now: Duration) {
+        self.dirty = false;
+        self.last_write = Some(now);
     }
 }
 
@@ -1030,6 +1092,59 @@ pub fn load_features_file(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use spec::spec;
+
+    /// Scenario: Drive a `SnapshotCoalescer` (interval 500ms) synchronously with
+    /// a 50-change burst all observed at the same instant — after each
+    /// `mark_dirty` the simulated event loop checks `is_due(now)` and writes if
+    /// due — then perform one trailing check after the interval has elapsed.
+    /// The leading-edge write fires on the first change; the remaining 49 are
+    /// throttled; the trailing check flushes the accumulated burst — so the
+    /// burst collapses to at most two writes (here exactly two), never the 50 a
+    /// naive write-per-change would produce.
+    #[spec("session/save/003")]
+    #[test]
+    fn save_003_coalesces_burst_to_at_most_two_writes() {
+        let interval = Duration::from_millis(500);
+        let mut coalescer = SnapshotCoalescer::new(interval);
+        let mut writes = 0usize;
+
+        // A tight burst: 50 rapid changes, all at the same instant (now = 0),
+        // each followed by the event loop's `is_due` check — exactly how the
+        // main loop drives it. Only the leading-edge write should fire here.
+        let now = Duration::ZERO;
+        for _ in 0..50 {
+            coalescer.mark_dirty();
+            if coalescer.is_due(now) {
+                writes += 1;
+                coalescer.record_write(now);
+            }
+        }
+
+        // The loop keeps ticking; once `interval` has elapsed with a change
+        // still pending, the single trailing write flushes the coalesced burst.
+        let after = interval;
+        if coalescer.is_due(after) {
+            writes += 1;
+            coalescer.record_write(after);
+        }
+
+        assert!(
+            writes <= 2,
+            "a burst of 50 changes must coalesce to at most two disk writes, got {writes}"
+        );
+        assert!(
+            writes >= 1,
+            "the burst must still produce at least one write, got {writes}"
+        );
+
+        // After the trailing flush nothing is pending, so no further write is
+        // due no matter how far the clock advances.
+        assert!(
+            !coalescer.is_due(after + interval + interval),
+            "no write is due once the burst has been flushed and nothing new is dirty"
+        );
+    }
 
     #[test]
     fn bell_config_defaults() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -323,6 +323,56 @@ pub struct SavedPane {
     /// The value is the mode name from the project config.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mode: Option<String>,
+    /// When set, this pane was the orchestrator pane of an orchestration
+    /// tab; the snapshot carries enough metadata to rebuild the whole tab
+    /// (orchestrator + role panes, prompt, role order, start cursor) on the
+    /// daemon-empty restore path. `Option` + `#[serde(default)]` so older
+    /// `session.toml` files (no `orchestration` key) still parse with
+    /// `orchestration == None`. See [`OrchestrationSnapshot`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orchestration: Option<OrchestrationSnapshot>,
+}
+
+/// PRD #89 M2b.2 — orchestration metadata captured on a saved pane so the
+/// daemon-empty restore path (fresh machine / crash recovery, when there is
+/// no warm daemon to hydrate from) can rebuild the orchestration tab. Schema
+/// ported from the closed PRD #74 design.
+///
+/// Carried as `SavedPane::orchestration: Option<OrchestrationSnapshot>` with
+/// `#[serde(default)]`, so a `session.toml` written before this field existed
+/// (no `[panes.orchestration]` table) still parses, yielding
+/// `orchestration == None`. A `version` field is present from day one so a
+/// future schema change can be migrated rather than silently dropped. No
+/// `#[serde(deny_unknown_fields)]` — forward-compat with snapshots a newer
+/// binary may write with extra keys.
+///
+/// This struct ONLY captures the metadata + its (de)serialization; the
+/// restore branch that rebuilds the tab from it is M2b.3 (a separate step).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrchestrationSnapshot {
+    /// Schema version, for future migration. `1` is the initial format.
+    pub version: u32,
+    /// Role names in DISPLAY order — the same order as the tab's
+    /// `role_pane_ids`, so the restore branch can recreate the role panes
+    /// in the order the user saw them.
+    pub roles: Vec<String>,
+    /// Index into `roles` of the start (orchestrator) role — restores the
+    /// "next role to start" cursor.
+    pub start_role_index: usize,
+    /// Pre-built prompt injected into the start (orchestrator) role on
+    /// restore. Empty string when the orchestration had no prompt.
+    pub orchestrator_prompt: String,
+    /// Resolved orchestration config NAME — half of the reference used to
+    /// re-resolve the `OrchestrationConfig` from disk on restore.
+    pub config_name: String,
+    /// Project PATH the orchestration was resolved from (the directory that
+    /// holds `.dot-agent-deck.toml`) — the other half of the re-resolution
+    /// reference.
+    pub project_path: String,
+    /// Which roles had been started, by index into `roles`. Optional —
+    /// snapshots that predate this field load with an empty list.
+    #[serde(default)]
+    pub started_role_indices: Vec<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -1212,12 +1262,14 @@ on_idle = true
                     name: "api".to_string(),
                     command: "claude".to_string(),
                     mode: None,
+                    orchestration: None,
                 },
                 SavedPane {
                     dir: "/repo/ui".to_string(),
                     name: "ui".to_string(),
                     command: "".to_string(),
                     mode: None,
+                    orchestration: None,
                 },
             ],
         };
@@ -1228,6 +1280,79 @@ on_idle = true
         assert_eq!(loaded.panes[0].name, "api");
         assert_eq!(loaded.panes[0].command, "claude");
         assert_eq!(loaded.panes[1].command, "");
+    }
+
+    /// Scenario: Build a `SavedSession` whose single pane carries an
+    /// `OrchestrationSnapshot` (3 roles in display order, a start-role cursor,
+    /// an orchestrator prompt, the resolved config name + project path, and a
+    /// started-roles list), serialize it to TOML and deserialize it back —
+    /// asserting every orchestration field round-trips intact. Then deserialize
+    /// a legacy `session.toml` string that has NO `orchestration` key and
+    /// assert the pane still parses with `orchestration == None`, proving the
+    /// `#[serde(default)]` forward-compat guarantee for old snapshots.
+    #[spec("config/saved-session/001")]
+    #[test]
+    fn saved_session_001_orchestration_serde_round_trip_and_legacy_parse() {
+        // (a) Round-trip a pane carrying an OrchestrationSnapshot.
+        let session = SavedSession {
+            panes: vec![SavedPane {
+                dir: "/repo/app".to_string(),
+                name: "orchestrator".to_string(),
+                command: "claude".to_string(),
+                mode: None,
+                orchestration: Some(OrchestrationSnapshot {
+                    version: 1,
+                    roles: vec![
+                        "orchestrator".to_string(),
+                        "coder".to_string(),
+                        "reviewer".to_string(),
+                    ],
+                    start_role_index: 0,
+                    orchestrator_prompt: "Build the feature end to end".to_string(),
+                    config_name: "tdd-cycle".to_string(),
+                    project_path: "/repo/app".to_string(),
+                    started_role_indices: vec![0, 1],
+                }),
+            }],
+        };
+
+        let toml_str = toml::to_string_pretty(&session).unwrap();
+        let loaded: SavedSession = toml::from_str(&toml_str).unwrap();
+
+        assert_eq!(loaded.panes.len(), 1);
+        let pane = &loaded.panes[0];
+        assert_eq!(pane.dir, "/repo/app");
+        assert_eq!(pane.name, "orchestrator");
+        assert_eq!(pane.command, "claude");
+        assert_eq!(pane.mode, None);
+
+        let orch = pane
+            .orchestration
+            .as_ref()
+            .expect("orchestration must round-trip as Some");
+        assert_eq!(orch.version, 1);
+        assert_eq!(orch.roles, vec!["orchestrator", "coder", "reviewer"]);
+        assert_eq!(orch.start_role_index, 0);
+        assert_eq!(orch.orchestrator_prompt, "Build the feature end to end");
+        assert_eq!(orch.config_name, "tdd-cycle");
+        assert_eq!(orch.project_path, "/repo/app");
+        assert_eq!(orch.started_role_indices, vec![0, 1]);
+
+        // (b) A legacy session.toml predating the orchestration field still
+        // parses, with orchestration == None (the #[serde(default)] guarantee).
+        let legacy = r#"
+[[panes]]
+dir = "/repo/legacy"
+name = "old-pane"
+command = "vim"
+"#;
+        let legacy_loaded: SavedSession = toml::from_str(legacy).unwrap();
+        assert_eq!(legacy_loaded.panes.len(), 1);
+        assert_eq!(legacy_loaded.panes[0].dir, "/repo/legacy");
+        assert!(
+            legacy_loaded.panes[0].orchestration.is_none(),
+            "a legacy snapshot with no orchestration key must parse with orchestration == None"
+        );
     }
 
     #[test]
@@ -1263,6 +1388,7 @@ on_idle = true
                 name: "test".to_string(),
                 command: "echo hi".to_string(),
                 mode: None,
+                orchestration: None,
             }],
         };
         session.save().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,14 @@ enum Commands {
         #[command(subcommand)]
         action: ScheduleAction,
     },
+    /// Manage the local saved-session snapshot (PRD #89). Auto-restore reads
+    /// this on-disk snapshot on every TUI startup; this group is the local
+    /// fresh-start escape hatch. A subcommand group (not a bare flag) so future
+    /// snapshot operations can be added without changing the surface.
+    Snapshot {
+        #[command(subcommand)]
+        cmd: SnapshotCmd,
+    },
 }
 
 #[derive(Subcommand)]
@@ -293,6 +301,16 @@ enum RemoteCmd {
         #[arg(long = "no-install")]
         no_install: bool,
     },
+}
+
+#[derive(Subcommand)]
+enum SnapshotCmd {
+    /// Delete the local saved-session snapshot. With auto-restore on by
+    /// default (PRD #89), this is the one obvious "start fresh" action for the
+    /// local deck: the next `dot-agent-deck` startup begins from an empty
+    /// dashboard instead of restoring the previous workspace. Registry-only
+    /// `remote remove` intentionally does NOT touch this global snapshot.
+    Clear,
 }
 
 #[derive(Subcommand)]
@@ -592,6 +610,24 @@ fn main() -> ExitCode {
         },
         Some(Commands::Connect { name }) => run_connect(name),
         Some(Commands::Schedule { action }) => run_schedule_cli(action),
+        Some(Commands::Snapshot { cmd }) => match cmd {
+            // PRD #89 M4.2 — local fresh-start escape hatch. Reuses the same
+            // `SavedSession::clear()` the TUI calls at teardown, so it honors
+            // the `DOT_AGENT_DECK_SESSION` override and deletes the one global
+            // snapshot at `config::session_path()`.
+            SnapshotCmd::Clear => match dot_agent_deck::config::SavedSession::clear() {
+                Ok(()) => {
+                    println!(
+                        "Cleared the local saved-session snapshot. The next `dot-agent-deck` startup will begin from an empty dashboard."
+                    );
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("Failed to clear the saved-session snapshot: {e}");
+                    ExitCode::FAILURE
+                }
+            },
+        },
         Some(Commands::Validate { path }) => {
             use dot_agent_deck::config_validation::{has_errors, validate_config};
             use dot_agent_deck::project_config::load_project_config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,7 +351,10 @@ fn main() -> ExitCode {
     // gets a guiding message ("auto-restore is the default; just run
     // `dot-agent-deck`") instead of clap's bare "unexpected argument" error.
     // The exit is non-zero so wrapper scripts still fail loudly until updated.
-    if std::env::args().any(|a| a == "--continue") {
+    // Review-fix F8: also match the `--continue=<value>` form (e.g. a wrapper
+    // that passed `--continue=true`) so it keeps the friendly message instead of
+    // falling through to clap's generic error.
+    if std::env::args().any(|a| a == "--continue" || a.starts_with("--continue=")) {
         eprintln!(
             "error: the `--continue` flag has been removed. Auto-restore is now the default — \
              just run `dot-agent-deck` (no flag) and your previous session is restored \

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,10 +21,6 @@ use dot_agent_deck::ui::run_tui;
 #[derive(Parser)]
 #[command(name = "dot-agent-deck", about = "AI agent session dashboard", version = env!("DAD_VERSION"))]
 struct Cli {
-    /// Restore pane session from last exit
-    #[arg(long = "continue")]
-    continue_session: bool,
-
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -332,6 +328,20 @@ enum ConfigAction {
 }
 
 fn main() -> ExitCode {
+    // PRD #89 M3.4: the `--continue` flag was removed — auto-restore is now the
+    // default. Intercept a stale invocation before clap parsing so the user
+    // gets a guiding message ("auto-restore is the default; just run
+    // `dot-agent-deck`") instead of clap's bare "unexpected argument" error.
+    // The exit is non-zero so wrapper scripts still fail loudly until updated.
+    if std::env::args().any(|a| a == "--continue") {
+        eprintln!(
+            "error: the `--continue` flag has been removed. Auto-restore is now the default — \
+             just run `dot-agent-deck` (no flag) and your previous session is restored \
+             automatically."
+        );
+        return ExitCode::FAILURE;
+    }
+
     let keys_help = dot_agent_deck::config::config_keys_help();
     let cmd = Cli::command().mut_subcommand("config", |c| {
         c.mut_subcommand("get", |g| {
@@ -345,7 +355,7 @@ fn main() -> ExitCode {
         .expect("clap arg matches should be valid for Cli struct");
 
     match cli.command {
-        None => run_dashboard(cli.continue_session),
+        None => run_dashboard(),
         Some(Commands::Hook { agent }) => {
             let agent_str = match agent {
                 CliAgent::ClaudeCode => "claude-code",
@@ -580,7 +590,7 @@ fn main() -> ExitCode {
                 }
             }
         },
-        Some(Commands::Connect { name }) => run_connect(cli.continue_session, name),
+        Some(Commands::Connect { name }) => run_connect(name),
         Some(Commands::Schedule { action }) => run_schedule_cli(action),
         Some(Commands::Validate { path }) => {
             use dot_agent_deck::config_validation::{has_errors, validate_config};
@@ -617,9 +627,9 @@ fn main() -> ExitCode {
 }
 
 #[tokio::main]
-async fn run_dashboard(continue_session: bool) -> ExitCode {
+async fn run_dashboard() -> ExitCode {
     init_logging_from_env();
-    run_tui_session(continue_session).await
+    run_tui_session().await
 }
 
 /// Optional file-based logging from `DOT_AGENT_DECK_LOG`. Pulled out of the
@@ -665,7 +675,7 @@ fn init_logging_from_env() {
 /// (spawn error, start timeout, or trust-check rejection). Successful TUI
 /// runs return `ExitCode::SUCCESS` — including TUI-task errors, which are
 /// already surfaced to stderr.
-async fn run_tui_session(continue_session: bool) -> ExitCode {
+async fn run_tui_session() -> ExitCode {
     // PRD #139 M1.2/M1.3: initialize the process-global experimental flag from
     // `.dot-agent-deck.toml` `[features]` (env override wins) and start the
     // live re-read watcher. The startup state is recorded via a single
@@ -771,13 +781,7 @@ async fn run_tui_session(continue_session: bool) -> ExitCode {
     ));
     let tui_state = state.clone();
     let tui_result = tokio::task::spawn_blocking(move || {
-        run_tui(
-            tui_state,
-            pane_controller,
-            config,
-            keybindings,
-            continue_session,
-        )
+        run_tui(tui_state, pane_controller, config, keybindings)
     })
     .await;
 
@@ -864,12 +868,7 @@ fn spawn_event_subscriber(
 /// `ssh -t` to run the deck TUI on the remote in M2.8 external-daemon
 /// mode. The laptop process blocks until ssh exits and propagates the
 /// exit code.
-///
-/// `_continue_session` is accepted to keep the `Commands::Connect` call shape
-/// stable but is intentionally ignored — it applies to a laptop-side TUI that
-/// no longer exists in this flow. See `connect::run_connect`'s doc comment for
-/// the rationale.
-fn run_connect(_continue_session: bool, name: Option<String>) -> ExitCode {
+fn run_connect(name: Option<String>) -> ExitCode {
     let registry_path = dot_agent_deck::remote::default_remotes_path();
 
     let entry = match name {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5026,6 +5026,10 @@ fn dispatch_action(
                                     name: req.name.clone(),
                                     command: req.command,
                                     mode: mode_name_for_save,
+                                    // PRD #89 M2b.2: capture is a later step
+                                    // (M2b.3); the schema field exists now so
+                                    // older/newer snapshots round-trip.
+                                    orchestration: None,
                                 },
                             );
                             // PRD #89 M1.2 — a new dashboard pane / mode tab is a
@@ -5658,6 +5662,10 @@ pub fn run_tui(
                             .unwrap_or_else(|| h.agent_id.clone()),
                         command: String::new(),
                         mode: mode_hint,
+                        // PRD #89 M2b.2: schema-only; orchestration capture
+                        // from a warm daemon is handled by hydration, not the
+                        // snapshot, so leave None here.
+                        orchestration: None,
                     },
                 );
             }
@@ -12056,6 +12064,7 @@ mod tests {
                 name: "foo".into(),
                 command: String::new(),
                 mode: None,
+                orchestration: None,
             },
         );
         let mut budget = build_dedupe_budget(&metadata);
@@ -12065,12 +12074,14 @@ mod tests {
             name: "foo".into(),
             command: "vim".into(),
             mode: None,
+            orchestration: None,
         };
         let saved_b = SavedPane {
             dir: "/w".into(),
             name: "foo".into(),
             command: "tail -f log".into(),
             mode: None,
+            orchestration: None,
         };
 
         // First saved pane matches the hydrated → consumed.
@@ -12090,6 +12101,7 @@ mod tests {
                 name: "foo".into(),
                 command: String::new(),
                 mode: Some("k8s-ops".into()),
+                orchestration: None,
             },
         );
         let mut budget = build_dedupe_budget(&metadata);
@@ -12100,6 +12112,7 @@ mod tests {
             name: "foo".into(),
             command: "vim".into(),
             mode: None,
+            orchestration: None,
         };
         assert!(!try_consume_dedupe_slot(&mut budget, &saved_dashboard));
 
@@ -12109,6 +12122,7 @@ mod tests {
             name: "foo".into(),
             command: String::new(),
             mode: Some("k8s-ops".into()),
+            orchestration: None,
         };
         assert!(try_consume_dedupe_slot(&mut budget, &saved_mode));
     }
@@ -12127,6 +12141,7 @@ mod tests {
             name: "foo".into(),
             command: "vim".into(),
             mode: None,
+            orchestration: None,
         };
         assert!(!try_consume_dedupe_slot(&mut budget, &saved));
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1721,54 +1721,6 @@ pub(crate) struct HydrationPartition {
 /// orchestration buckets preserve the order in which their (cwd, name)
 /// pairing was first seen so the user's mental "which tab opened first"
 /// model survives reconnect (TabManager appends in iteration order).
-/// Key used by [`build_dedupe_budget`] / [`try_consume_dedupe_slot`] to
-/// match a saved pane against a daemon-hydrated pane. The tuple is
-/// `(dir, name, mode)`. `command` is intentionally excluded — daemon
-/// `list_agents` doesn't echo command, so hydration always stores
-/// `command = ""` and including it in the key would dedupe nothing for
-/// the common case.
-type SavedPaneDedupeKey = (String, String, Option<String>);
-
-/// Build the dedupe budget from the hydration metadata. The budget
-/// maps `(dir, name, mode)` keys to the COUNT of hydrated panes
-/// matching that key. The restore loop consumes slots via
-/// [`try_consume_dedupe_slot`] so it drops at most one saved pane per
-/// hydrated match — preserving distinct saved panes that happen to
-/// share a key (round-10 reviewer #2).
-fn build_dedupe_budget(
-    pane_metadata: &std::collections::HashMap<String, config::SavedPane>,
-) -> std::collections::HashMap<SavedPaneDedupeKey, usize> {
-    let mut budget: std::collections::HashMap<SavedPaneDedupeKey, usize> =
-        std::collections::HashMap::new();
-    for meta in pane_metadata.values() {
-        *budget
-            .entry((meta.dir.clone(), meta.name.clone(), meta.mode.clone()))
-            .or_insert(0) += 1;
-    }
-    budget
-}
-
-/// Returns true and decrements the budget if `saved_pane`'s
-/// `(dir, name, mode)` key has a free slot — the caller should then
-/// skip restoring it. Returns false otherwise.
-fn try_consume_dedupe_slot(
-    budget: &mut std::collections::HashMap<SavedPaneDedupeKey, usize>,
-    saved_pane: &config::SavedPane,
-) -> bool {
-    let key = (
-        saved_pane.dir.clone(),
-        saved_pane.name.clone(),
-        saved_pane.mode.clone(),
-    );
-    if let Some(slot) = budget.get_mut(&key)
-        && *slot > 0
-    {
-        *slot -= 1;
-        return true;
-    }
-    false
-}
-
 pub(crate) fn partition_hydrated_panes(hydrated: &[HydratedPane]) -> HydrationPartition {
     use std::collections::HashSet;
 
@@ -4901,6 +4853,12 @@ fn dispatch_action(
                                         config_name: orch_config.name.clone(),
                                         project_path: dir_str.clone(),
                                         started_role_indices: vec![start_idx],
+                                        // PRD #89 review-fix F4: capture the
+                                        // user-typed tab title so the
+                                        // daemon-empty restore rebuilds the tab
+                                        // under the user's name, not the
+                                        // canonical config/cwd name.
+                                        display_title: display_title.clone(),
                                     }),
                                 },
                             );
@@ -5551,16 +5509,33 @@ fn flush_session_snapshot_if_due(ui: &mut UiState, state: &SharedState) {
     let live_panes = state.blocking_read().managed_pane_ids.clone();
     let session =
         config::SavedSession::snapshot(&mut ui.pane_metadata, &ui.pane_display_names, &live_panes);
-    if session.panes.is_empty() {
-        if let Err(e) = config::SavedSession::clear() {
-            ui.session_warnings
-                .push(format!("Warning: failed to clear session: {e}"));
+    // PRD #89 review-fix F10: only mark the write as done (clearing the dirty
+    // flag via `record_write`) when the persist actually SUCCEEDED. On a
+    // transient disk error we leave the coalescer dirty so the next loop
+    // iteration retries, rather than dropping the pending snapshot until the
+    // next unrelated state change re-dirties it.
+    let persisted = if session.panes.is_empty() {
+        match config::SavedSession::clear() {
+            Ok(()) => true,
+            Err(e) => {
+                ui.session_warnings
+                    .push(format!("Warning: failed to clear session: {e}"));
+                false
+            }
         }
-    } else if let Err(e) = session.save() {
-        ui.session_warnings
-            .push(format!("Warning: failed to save session: {e}"));
+    } else {
+        match session.save() {
+            Ok(()) => true,
+            Err(e) => {
+                ui.session_warnings
+                    .push(format!("Warning: failed to save session: {e}"));
+                false
+            }
+        }
+    };
+    if persisted {
+        ui.session_coalescer.record_write(now);
     }
-    ui.session_coalescer.record_write(now);
 }
 
 /// PRD #89 M2.2 — daemon-vs-snapshot restore precedence seam.
@@ -5597,11 +5572,47 @@ pub fn should_apply_snapshot(state: &AppState) -> bool {
 /// On `Err`, the caller surfaces the reason via `session_warnings` and falls
 /// back to a PLAIN dashboard pane (never a half-broken orchestration tab),
 /// mirroring the mode-tab drift Path D/E fallback (PRD #69).
+///
+/// On `Ok`, returns the resolved config AND the validated start-role index to
+/// honor (the SAVED cursor, bounds-checked — PRD #89 review-fix F2/F3), so the
+/// caller drives prompt delivery from the saved start role rather than
+/// recomputing it from the live config's `start` flags.
 fn resolve_orchestration_for_restore(
     snap: &config::OrchestrationSnapshot,
-) -> Result<OrchestrationConfig, String> {
+    saved_dir: &str,
+) -> Result<(OrchestrationConfig, usize), String> {
+    // PRD #89 review-fix F1 (security): the snapshot's `project_path` and the
+    // saved pane's `dir` are written EQUAL on capture; a divergence only happens
+    // via a tampered `session.toml`. Re-resolving — and auto-running — the
+    // config at a divergent `project_path` would execute a `.dot-agent-deck.toml`
+    // an attacker controls. Canonicalize both and refuse to re-resolve unless
+    // they name the same directory; a divergence (or a `project_path` that no
+    // longer resolves) is treated as drift -> plain-pane fallback, so the
+    // planted config is never executed.
     let project_dir = std::path::Path::new(&snap.project_path);
-    let cfg = match load_project_config(project_dir) {
+    let canon_project = project_dir.canonicalize().map_err(|e| {
+        format!(
+            "orchestration '{}' project_path {} could not be resolved: {e}",
+            snap.config_name, snap.project_path
+        )
+    })?;
+    let canon_saved = std::path::Path::new(saved_dir)
+        .canonicalize()
+        .map_err(|e| {
+            format!(
+                "orchestration '{}' saved dir {saved_dir} could not be resolved: {e}",
+                snap.config_name
+            )
+        })?;
+    if canon_project != canon_saved {
+        return Err(format!(
+            "orchestration '{}' project_path {} does not match saved pane dir {saved_dir} — \
+             refusing to re-resolve a divergent config",
+            snap.config_name, snap.project_path
+        ));
+    }
+
+    let cfg = match load_project_config(&canon_project) {
         Ok(Some(cfg)) => cfg,
         Ok(None) => {
             return Err(format!(
@@ -5640,7 +5651,27 @@ fn resolve_orchestration_for_restore(
             current_roles.join(", "),
         ));
     }
-    Ok(orch)
+    // PRD #89 review-fix F2 (robustness): bounds-check the SAVED start cursor
+    // against the re-resolved role set. `load_project_config` runs no
+    // config_validation, so a whittled-down (or explicitly `roles = []`) config
+    // is structurally valid yet role-less, and a tampered cursor could point
+    // past the end. Either would index an empty/short `role_pane_ids` and panic
+    // at startup (crash-loop). Treat an out-of-range cursor — which includes
+    // every index of an empty role set — as drift, so the caller falls back to
+    // a plain pane instead of panicking.
+    if snap.start_role_index >= orch.roles.len() {
+        return Err(format!(
+            "orchestration '{}' has no role at saved start index {} (role count {}) — falling back",
+            snap.config_name,
+            snap.start_role_index,
+            orch.roles.len()
+        ));
+    }
+    // PRD #89 review-fix F3: honor the SAVED start cursor (now validated in
+    // range) instead of recomputing it from the live config's `start` flags, so
+    // a saved cursor that differs from the config default is preserved on
+    // restore.
+    Ok((orch, snap.start_role_index))
 }
 
 pub fn run_tui(
@@ -6103,10 +6134,6 @@ pub fn run_tui(
         let _ = terminal.autoresize();
 
         let saved = config::SavedSession::load();
-        // CodeRabbit round-9 #4 / round-10 #2: dedupe against panes
-        // the daemon already hydrated. See `build_dedupe_budget` and
-        // `try_consume_dedupe_slot` below for the algorithm.
-        let mut remaining_dedupe_budget = build_dedupe_budget(&ui.pane_metadata);
         // Collect deferred mode pane restores — we need the terminal ready
         // before we can resize PTYs, so mode tabs are opened after the loop.
         let mut deferred_mode_panes: Vec<(config::SavedPane, ModeConfig)> = Vec::new();
@@ -6123,15 +6150,6 @@ pub fn run_tui(
                 ));
                 continue;
             }
-            if try_consume_dedupe_slot(&mut remaining_dedupe_budget, saved_pane) {
-                tracing::debug!(
-                    dir = %saved_pane.dir,
-                    name = %saved_pane.name,
-                    mode = ?saved_pane.mode,
-                    "restore: skipping saved pane — already hydrated from daemon"
-                );
-                continue;
-            }
             // PRD #89 M2b.3 — orchestration-tab restore on the daemon-empty
             // path. A saved pane carrying orchestration metadata rebuilds the
             // WHOLE tab (orchestrator + role panes in saved order, the prompt
@@ -6145,8 +6163,8 @@ pub fn run_tui(
             // path REPLAYS the saved `orchestrator_prompt` to the start role —
             // there is no live agent with the prompt already in scrollback.
             if let Some(ref orch_snap) = saved_pane.orchestration {
-                match resolve_orchestration_for_restore(orch_snap) {
-                    Ok(orch_config) => {
+                match resolve_orchestration_for_restore(orch_snap, &saved_pane.dir) {
+                    Ok((orch_config, saved_start_idx)) => {
                         let frame_area = terminal.get_frame().area();
                         // All roles share spawn dims (Tiled); role_index=0 so the
                         // helper falls back to "role 0 expanded" — the per-frame
@@ -6169,10 +6187,28 @@ pub fn run_tui(
                             &orch_config,
                             &saved_pane.dir,
                             replay_prompt,
-                            None,
+                            // PRD #89 review-fix F4: thread the saved user title
+                            // so the rebuilt tab comes back under the user's name
+                            // rather than the canonical config/cwd name. `None`
+                            // when unset falls back to the canonical name.
+                            orch_snap.display_title.as_deref(),
                             spawn_dims,
                         ) {
                             Ok((tab_idx, role_pane_ids)) => {
+                                // PRD #89 review-fix F3: honor the SAVED start
+                                // cursor. `open_orchestration_tab` computed
+                                // `start_role_index` from the config's `start`
+                                // flags; override it with the validated saved
+                                // index so the prompt-delivery gate (and the
+                                // landing focus) target the role the user left
+                                // as start, even when it differs from the config
+                                // default. The just-opened tab is the active tab.
+                                if let Tab::Orchestration {
+                                    start_role_index, ..
+                                } = tab_manager.active_tab_mut()
+                                {
+                                    *start_role_index = saved_start_idx;
+                                }
                                 // Snapshot each role pane's daemon agent_id before
                                 // the placeholder insert so the strict-equality
                                 // reuse guard accepts each role agent's first
@@ -6216,10 +6252,15 @@ pub fn run_tui(
                                 // Re-capture the orchestration metadata onto the
                                 // start role pane so a later snapshot keeps the
                                 // tab (only the start role carries the block).
-                                let start_idx =
-                                    orch_config.roles.iter().position(|r| r.start).unwrap_or(0);
-                                ui.pane_metadata
-                                    .insert(role_pane_ids[start_idx].clone(), saved_pane.clone());
+                                // PRD #89 review-fix F3: key it under the SAVED
+                                // (validated) start cursor — consistent with the
+                                // honored start role above — not the config
+                                // default, so a re-save preserves the saved
+                                // cursor on the same pane that carries the block.
+                                ui.pane_metadata.insert(
+                                    role_pane_ids[saved_start_idx].clone(),
+                                    saved_pane.clone(),
+                                );
                                 // Record creation time so the prompt-delivery
                                 // gate's 10s timeout fallback works for agents
                                 // that never signal `SessionStart`.
@@ -6657,8 +6698,11 @@ pub fn run_tui(
         {
             let _ = pane.focus_pane(&new_id);
         }
-        // PRD #89 M1.2 — a reactive pane recreation (agent stop/restart, e.g.
-        // after `/clear`) swaps live pane ids; keep the snapshot fresh.
+        // PRD #89 M1.2 — `route_reactive_commands` recreates Mode-tab reactive
+        // SIDE panes, swapping their live pane ids (`pane_changes`); keep the
+        // snapshot fresh so the new ids are reflected. NOTE: this covers only
+        // reactive side-pane swaps — it does NOT broadly cover an agent /clear
+        // restart, whose dirtying flows through other reactive seams.
         if !pane_changes.is_empty() {
             ui.mark_session_dirty();
         }
@@ -12272,104 +12316,6 @@ mod tests {
         assert_eq!(p.dashboard_pane_ids, vec!["1".to_string(), "2".to_string()]);
         assert!(p.mode_buckets.is_empty());
         assert!(p.orchestration_buckets.is_empty());
-    }
-
-    /// Round-10 reviewer #2: two saved panes that share
-    /// `(dir, name, mode)` must NOT both be dropped when only one was
-    /// hydrated. The pre-round-10 `HashSet` dedupe collapsed both;
-    /// the count-based budget drops at most one per match.
-    #[test]
-    fn dedupe_drops_only_count_matched_saved_panes() {
-        use config::SavedPane;
-        let mut metadata: HashMap<String, SavedPane> = HashMap::new();
-        // One hydrated dashboard pane with (dir=/w, name=foo, mode=None).
-        metadata.insert(
-            "pane-1".into(),
-            SavedPane {
-                dir: "/w".into(),
-                name: "foo".into(),
-                command: String::new(),
-                mode: None,
-                orchestration: None,
-            },
-        );
-        let mut budget = build_dedupe_budget(&metadata);
-
-        let saved_a = SavedPane {
-            dir: "/w".into(),
-            name: "foo".into(),
-            command: "vim".into(),
-            mode: None,
-            orchestration: None,
-        };
-        let saved_b = SavedPane {
-            dir: "/w".into(),
-            name: "foo".into(),
-            command: "tail -f log".into(),
-            mode: None,
-            orchestration: None,
-        };
-
-        // First saved pane matches the hydrated → consumed.
-        assert!(try_consume_dedupe_slot(&mut budget, &saved_a));
-        // Second saved pane shares the key but the budget is exhausted → restored.
-        assert!(!try_consume_dedupe_slot(&mut budget, &saved_b));
-    }
-
-    #[test]
-    fn dedupe_distinguishes_mode_panes_from_dashboard() {
-        use config::SavedPane;
-        let mut metadata: HashMap<String, SavedPane> = HashMap::new();
-        metadata.insert(
-            "pane-1".into(),
-            SavedPane {
-                dir: "/w".into(),
-                name: "foo".into(),
-                command: String::new(),
-                mode: Some("k8s-ops".into()),
-                orchestration: None,
-            },
-        );
-        let mut budget = build_dedupe_budget(&metadata);
-
-        // Same (dir, name) but different mode — must NOT dedupe.
-        let saved_dashboard = SavedPane {
-            dir: "/w".into(),
-            name: "foo".into(),
-            command: "vim".into(),
-            mode: None,
-            orchestration: None,
-        };
-        assert!(!try_consume_dedupe_slot(&mut budget, &saved_dashboard));
-
-        // Matching mode → DEDUPED.
-        let saved_mode = SavedPane {
-            dir: "/w".into(),
-            name: "foo".into(),
-            command: String::new(),
-            mode: Some("k8s-ops".into()),
-            orchestration: None,
-        };
-        assert!(try_consume_dedupe_slot(&mut budget, &saved_mode));
-    }
-
-    #[test]
-    fn dedupe_restores_saved_panes_when_daemon_empty() {
-        use config::SavedPane;
-        // No hydrated metadata (daemon restarted, hydration returned
-        // empty). The saved-session file is the only source of truth;
-        // every saved pane must restore.
-        let metadata: HashMap<String, SavedPane> = HashMap::new();
-        let mut budget = build_dedupe_budget(&metadata);
-
-        let saved = SavedPane {
-            dir: "/w".into(),
-            name: "foo".into(),
-            command: "vim".into(),
-            mode: None,
-            orchestration: None,
-        };
-        assert!(!try_consume_dedupe_slot(&mut budget, &saved));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -790,6 +790,15 @@ const STATUS_MESSAGE_TTL: std::time::Duration = std::time::Duration::from_secs(1
 /// which was tuned empirically — keep the two values in sync.
 const SUBMIT_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(150);
 
+/// PRD #89 M1.2 — throttle window for continuous saved-session snapshot writes.
+/// A meaningful state change marks the snapshot dirty; the main loop flushes it
+/// at most once per this interval (plus one trailing write per quiet-down), so
+/// a burst of changes coalesces to one or two disk writes instead of thrashing
+/// the disk on every keystroke. Small enough that a fresh snapshot lands well
+/// within a second of any change; large enough to absorb an orchestration
+/// setup's pane-spawn burst into a single trailing write.
+const SNAPSHOT_COALESCE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(750);
+
 /// PRD #128 Direction B-1 — minimum gap between SessionStart being observed
 /// for the start-role pane and the orchestrator's role prompt being written
 /// into it. Claude Code's `SessionStart` hook fires before its TUI input is
@@ -1062,6 +1071,15 @@ struct UiState {
     /// (matches `write_to_pane`'s SUBMIT_DELAY rationale at
     /// src/embedded_pane.rs:199).
     last_pane_keystroke_at: Option<std::time::Instant>,
+    /// PRD #89 M1.2/M1.3 — coalesces saved-session snapshot writes so a burst
+    /// of meaningful state changes (or detaches) produces one or two disk
+    /// writes, not one per change. Marked dirty by [`UiState::mark_session_dirty`]
+    /// at every state-change/detach call site; flushed by
+    /// `flush_session_snapshot_if_due` once per main-loop iteration.
+    session_coalescer: config::SnapshotCoalescer,
+    /// PRD #89 M1.2 — monotonic reference the coalescer's `Duration` clock is
+    /// measured from (`session_epoch.elapsed()`), set once at construction.
+    session_epoch: std::time::Instant,
 }
 
 /// PRD #80 review FIX 4: which click region produced a [`LastClick`]. Multi-
@@ -1187,6 +1205,8 @@ impl UiState {
             scheduled_delete_confirm: false,
             scheduled_live_names: HashSet::new(),
             last_pane_keystroke_at: None,
+            session_coalescer: config::SnapshotCoalescer::new(SNAPSHOT_COALESCE_INTERVAL),
+            session_epoch: std::time::Instant::now(),
             button_rects: Vec::new(),
             tab_close_rects: Vec::new(),
             tab_header_rects: Vec::new(),
@@ -1199,6 +1219,16 @@ impl UiState {
             form_chip_rects: Vec::new(),
             form_button_rects: Vec::new(),
         }
+    }
+
+    /// PRD #89 M1.2/M1.3 — the single trigger every meaningful state-change and
+    /// detach call site invokes (new pane, rename, close, mode/orchestration tab
+    /// open/close, agent restart, Ctrl+W close-pane). It only marks the
+    /// saved-session snapshot dirty; the coalesced disk write happens in the
+    /// main loop via `flush_session_snapshot_if_due`, so a burst of triggers
+    /// collapses to one or two writes.
+    fn mark_session_dirty(&mut self) {
+        self.session_coalescer.mark_dirty();
     }
 }
 
@@ -4027,6 +4057,9 @@ fn close_tab_by_index(
     {
         ui.selected_index = Some(idx - 1);
     }
+    // PRD #89 M1.2 — closing a mode/orchestration tab (via `[×]` click or the
+    // CloseTab action) is a meaningful state change; keep the snapshot fresh.
+    ui.mark_session_dirty();
 }
 
 /// PRD #92 F1 / PRD #80 M5: finalise Stop — tell the daemon to terminate every
@@ -4355,6 +4388,10 @@ fn dispatch_action(
                     ui.selected_index = Some(idx - 1);
                 }
             }
+            // PRD #89 M1.3 — Ctrl+W close-pane is a detach path; flush a fresh
+            // snapshot reflecting the surviving workspace (every sub-path above:
+            // closable-tab close, mode/orchestration tab close, plain pane).
+            ui.mark_session_dirty();
         }
         // Ctrl+PageDown: next tab (clamped, gated on a visible tab bar).
         // PRD #83: route through `switch_tab_with_focus` so the source tab's
@@ -4827,6 +4864,9 @@ fn dispatch_action(
                                 ui.pane_names
                                     .insert(role_pane_ids[i].clone(), role.name.clone());
                             }
+                            // PRD #89 M1.2 — opening an orchestration tab is a
+                            // meaningful state change; keep the snapshot fresh.
+                            ui.mark_session_dirty();
 
                             // Focus the start role's pane.
                             let start_idx =
@@ -4988,6 +5028,9 @@ fn dispatch_action(
                                     mode: mode_name_for_save,
                                 },
                             );
+                            // PRD #89 M1.2 — a new dashboard pane / mode tab is a
+                            // meaningful state change; keep the snapshot fresh.
+                            ui.mark_session_dirty();
 
                             if let Some(mode_config) = req.mode_config {
                                 // Mode selected — open a mode tab.
@@ -5200,6 +5243,9 @@ fn dispatch_action(
             ui.rename_text.clear();
             ui.mode = UiMode::Normal;
             commit_rename(&new_name, ui, pane, snapshot, selected_id);
+            // PRD #89 M1.2 — a rename changes the saved display name; keep the
+            // snapshot fresh.
+            ui.mark_session_dirty();
         }
         // rename [Cancel]: abandon, leaving the existing name (== Esc).
         Action::CancelRename => {
@@ -5446,6 +5492,33 @@ fn dispatch_action(
         Action::Continue => {}
     }
     Flow::Continue
+}
+
+/// PRD #89 M1.2 — flush the saved-session snapshot to disk when the coalescer
+/// says a write is due (a state change is pending and the throttle interval has
+/// elapsed since the last write). Called once per main-loop iteration, so the
+/// snapshot stays continuously fresh on meaningful state changes and detaches
+/// without writing on every keystroke. Mirrors the pre-teardown snapshot block
+/// (build from the live panes, clear when empty), then records the write so the
+/// throttle re-arms.
+fn flush_session_snapshot_if_due(ui: &mut UiState, state: &SharedState) {
+    let now = ui.session_epoch.elapsed();
+    if !ui.session_coalescer.is_due(now) {
+        return;
+    }
+    let live_panes = state.blocking_read().managed_pane_ids.clone();
+    let session =
+        config::SavedSession::snapshot(&mut ui.pane_metadata, &ui.pane_display_names, &live_panes);
+    if session.panes.is_empty() {
+        if let Err(e) = config::SavedSession::clear() {
+            ui.session_warnings
+                .push(format!("Warning: failed to clear session: {e}"));
+        }
+    } else if let Err(e) = session.save() {
+        ui.session_warnings
+            .push(format!("Warning: failed to save session: {e}"));
+    }
+    ui.session_coalescer.record_write(now);
 }
 
 pub fn run_tui(
@@ -6272,6 +6345,13 @@ pub fn run_tui(
             ui.status_message = None;
         }
 
+        // PRD #89 M1.2/M1.3 — keep the saved-session snapshot continuously
+        // fresh: if a meaningful state change / detach marked it dirty and the
+        // coalescer's throttle window has elapsed, flush it to disk now. This
+        // runs every iteration (including the 16ms idle ticks below), so the
+        // trailing write of a coalesced burst lands without further input.
+        flush_session_snapshot_if_due(&mut ui, &state);
+
         let snapshot = state.blocking_read().clone();
 
         // PRD #76 M2.15 fixup pass 2 G1 — refresh each Mode tab's cached
@@ -6318,6 +6398,11 @@ pub fn run_tui(
             && let Some(new_id) = tab_manager.remap_focus_after_reactive_change(&pane_changes)
         {
             let _ = pane.focus_pane(&new_id);
+        }
+        // PRD #89 M1.2 — a reactive pane recreation (agent stop/restart, e.g.
+        // after `/clear`) swaps live pane ids; keep the snapshot fresh.
+        if !pane_changes.is_empty() {
+            ui.mark_session_dirty();
         }
 
         // Pick up version-check result once

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5521,12 +5521,30 @@ fn flush_session_snapshot_if_due(ui: &mut UiState, state: &SharedState) {
     ui.session_coalescer.record_write(now);
 }
 
+/// PRD #89 M2.2 — daemon-vs-snapshot restore precedence seam.
+///
+/// Returns `true` when the on-disk saved-session snapshot should be applied on
+/// startup, `false` when it must be skipped. On every startup the TUI hydrates
+/// from the daemon first; if that produced *any* managed pane (any
+/// `managed_pane_id` registered in `state`), the daemon already owns the live
+/// workspace and wins — restoring the snapshot on top of it would double up the
+/// panes. Only when hydration produced zero panes (a fresh daemon, or crash
+/// recovery into an empty registry) do we fall back to the disk snapshot. When
+/// both sources are empty, the snapshot load is attempted but yields nothing and
+/// the dashboard lands empty.
+///
+/// The decision is purely *structural* — the presence or absence of hydrated
+/// managed panes — never a flag, which keeps it a pure function that can be
+/// unit-tested in isolation (see `session/restore/005`).
+pub fn should_apply_snapshot(state: &AppState) -> bool {
+    state.managed_pane_ids.is_empty()
+}
+
 pub fn run_tui(
     state: SharedState,
     pane: Arc<dyn PaneController>,
     config: DashboardConfig,
     keybindings: KeybindingConfig,
-    continue_session: bool,
 ) -> std::io::Result<()> {
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
@@ -5559,13 +5577,13 @@ pub fn run_tui(
     }
 
     // PRD #111: preferred landing tab after both the hydration block and the
-    // `--continue` reconnect block have run. Defaults to dashboard (0); the
+    // snapshot-restore block have run. Defaults to dashboard (0); the
     // hydration block overwrites this to the first rebuilt orchestration tab
     // when one exists. Hoisted out of the embedded-pane scope so the
-    // `continue_session` block below can honour it instead of unconditionally
+    // snapshot-restore block below can honour it instead of unconditionally
     // snapping back to the dashboard — without the hoist, the second
-    // `switch_to(0)` in the reconnect path would undo the orchestration
-    // landing on every `--continue` reconnect.
+    // `switch_to(0)` in the restore path would undo the orchestration
+    // landing on every startup.
     let mut preferred_start_tab: usize = 0;
 
     // PRD #76 M2.x / M2.11: in external-daemon mode the daemon may already
@@ -5950,8 +5968,8 @@ pub fn run_tui(
         // failed — fall back to the dashboard so the user gets the
         // overview first (pre-PRD-111 behaviour). The chosen index is
         // also recorded in `preferred_start_tab` so the
-        // `continue_session` block below doesn't snap back to the
-        // dashboard on `--continue` reconnects (CodeRabbit PR #114).
+        // snapshot-restore block below doesn't snap back to the
+        // dashboard on startup (CodeRabbit PR #114).
         preferred_start_tab = first_orchestration_tab_index.unwrap_or(0);
         tab_manager.switch_to(preferred_start_tab);
 
@@ -5963,7 +5981,15 @@ pub fn run_tui(
         // is shown at the wrong dims.
     }
 
-    if continue_session {
+    // PRD #89 M2.1/M2.2: restore is now UNCONDITIONAL — there is no `--continue`
+    // gate. Daemon hydration (above) runs first and wins: if it produced any
+    // managed pane, the daemon already owns the workspace and we skip the disk
+    // snapshot to avoid double-restoring. Only when hydration produced zero
+    // panes (fresh daemon / crash recovery) do we load and apply the snapshot.
+    // The precedence decision lives in the pure `should_apply_snapshot` seam so
+    // it stays structural (any hydrated managed_pane_id) rather than flag-driven.
+    let apply_snapshot = should_apply_snapshot(&state.blocking_read());
+    if apply_snapshot {
         // Ensure the terminal has up-to-date dimensions before we resize
         // any PTYs — without this, get_frame().area() may return stale or
         // default values because no draw() call has happened yet.
@@ -6315,12 +6341,10 @@ pub fn run_tui(
         }
         // PRD #111 / CodeRabbit PR #114: land on the orchestration tab
         // chosen by the hydration block above (if any) instead of always
-        // snapping back to the dashboard. Without the hoist, an
-        // unconditional `switch_to(0)` here would undo the M3 fix for
-        // users who reconnect with `--continue`. `preferred_start_tab`
-        // defaults to 0 (dashboard) when the hydration block didn't run
-        // or didn't rebuild any orchestration tab, preserving the prior
-        // overview-first behaviour for non-orchestration sessions.
+        // snapping back to the dashboard. `preferred_start_tab` defaults to
+        // 0 (dashboard) — and stays there in this snapshot-restore branch,
+        // which only runs when hydration produced no panes — preserving the
+        // overview-first landing for snapshot-restored sessions.
         tab_manager.switch_to(preferred_start_tab);
 
         // Focus the first restored pane and enter PaneInput mode so the user
@@ -7703,7 +7727,7 @@ pub fn run_tui(
         } // end inner event-drain loop
     }
 
-    // Snapshot the session for --continue restore *before* tearing down mode
+    // Snapshot the session for auto-restore *before* tearing down mode
     // tabs. The teardown loop unregisters every mode-tab pane id from
     // `state.managed_pane_ids`; if the snapshot ran after teardown, the
     // `retain` step would drop the mode-tab agent pane (which carries
@@ -9810,8 +9834,8 @@ fn render_help_overlay(
         Line::from(""),
         Line::styled("  Session", cyan),
         Line::from(""),
-        Line::from("  Panes auto-saved on exit."),
-        Line::from("  Restore: dot-agent-deck --continue"),
+        Line::from("  Panes auto-saved continuously."),
+        Line::from("  Restored automatically on launch."),
     ];
 
     if let Some(name) = active_mode_name {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -945,6 +945,14 @@ struct UiState {
     pane_layout: PaneLayout,
     /// Warnings collected during session save/restore, flushed after terminal restore.
     session_warnings: Vec<String>,
+    /// PRD #89 review-fix G1: tracks whether the most recent periodic snapshot
+    /// write (in `flush_session_snapshot_if_due`) failed. F10 keeps the
+    /// coalescer dirty on failure so the next loop retries; on a *persistent*
+    /// failure that retry fires every ~750ms, so we push the warning only on
+    /// the leading edge of a failure streak and suppress duplicates until a
+    /// later write succeeds (which clears this flag, re-arming the warning for
+    /// any subsequent new failure).
+    session_snapshot_write_failed: bool,
     /// Mouse text selection state for copy support.
     selection: Option<TextSelection>,
     /// Screen rect of the focused pane (set during render, used for mouse mapping).
@@ -1182,6 +1190,7 @@ impl UiState {
             update_available: None,
             pane_layout: PaneLayout::Stacked,
             session_warnings: Vec::new(),
+            session_snapshot_write_failed: false,
             selection: None,
             focused_pane_rect: None,
             side_pane_rects: Vec::new(),
@@ -5514,27 +5523,31 @@ fn flush_session_snapshot_if_due(ui: &mut UiState, state: &SharedState) {
     // transient disk error we leave the coalescer dirty so the next loop
     // iteration retries, rather than dropping the pending snapshot until the
     // next unrelated state change re-dirties it.
-    let persisted = if session.panes.is_empty() {
-        match config::SavedSession::clear() {
-            Ok(()) => true,
-            Err(e) => {
-                ui.session_warnings
-                    .push(format!("Warning: failed to clear session: {e}"));
-                false
-            }
-        }
+    let result = if session.panes.is_empty() {
+        config::SavedSession::clear().map_err(|e| format!("Warning: failed to clear session: {e}"))
     } else {
-        match session.save() {
-            Ok(()) => true,
-            Err(e) => {
-                ui.session_warnings
-                    .push(format!("Warning: failed to save session: {e}"));
-                false
+        session
+            .save()
+            .map_err(|e| format!("Warning: failed to save session: {e}"))
+    };
+    match result {
+        Ok(()) => {
+            // PRD #89 review-fix G1: a successful write/clear ends any ongoing
+            // failure streak, so re-arm the one-shot warning for the next time
+            // a *new* failure occurs.
+            ui.session_snapshot_write_failed = false;
+            ui.session_coalescer.record_write(now);
+        }
+        Err(warning) => {
+            // PRD #89 review-fix G1: F10 keeps the coalescer dirty so the next
+            // loop retries, but on a PERSISTENT failure (disk full, bad perms)
+            // that retry fires every ~750ms. Push the warning AT MOST ONCE per
+            // ongoing failure streak so `session_warnings` cannot grow unbounded.
+            if !ui.session_snapshot_write_failed {
+                ui.session_warnings.push(warning);
+                ui.session_snapshot_write_failed = true;
             }
         }
-    };
-    if persisted {
-        ui.session_coalescer.record_write(now);
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4782,6 +4782,11 @@ fn dispatch_action(
                     // identity stays the canonical `orch_config.name`.
                     let display_title = (!req.name.is_empty()).then(|| req.name.clone());
                     let prompt = prepare_orchestrator_prompt(&orch_config, &dir_str);
+                    // PRD #89 M2b.2: keep a copy of the prepared prompt for the
+                    // capture snapshot below — `prompt` itself is moved into
+                    // `open_orchestration_tab`. Empty when the orchestration
+                    // had no prompt.
+                    let captured_prompt = prompt.clone().unwrap_or_default();
                     // PRD #76 M2.15: pre-compute spawn dims using
                     // the orchestration-layout helper (right 66%
                     // column, matching the orchestration
@@ -4864,13 +4869,46 @@ fn dispatch_action(
                                 ui.pane_names
                                     .insert(role_pane_ids[i].clone(), role.name.clone());
                             }
+                            let start_idx =
+                                orch_config.roles.iter().position(|r| r.start).unwrap_or(0);
+                            // PRD #89 M2b.2 — capture the orchestration metadata
+                            // onto the START (orchestrator) role pane so the
+                            // daemon-empty restore path can rebuild the whole tab
+                            // (orchestrator + role panes in display order, the
+                            // prompt, the start cursor) by re-resolving the
+                            // config from `project_path` + `config_name`. Only the
+                            // start role carries the snapshot — a single
+                            // `[panes.orchestration]` block — so restore rebuilds
+                            // the others from the re-resolved config rather than
+                            // duplicating them as plain panes. The non-start role
+                            // panes deliberately get NO `pane_metadata` entry.
+                            ui.pane_metadata.insert(
+                                role_pane_ids[start_idx].clone(),
+                                config::SavedPane {
+                                    dir: dir_str.clone(),
+                                    name: orch_config.roles[start_idx].name.clone(),
+                                    command: orch_config.roles[start_idx].command.clone(),
+                                    mode: None,
+                                    orchestration: Some(config::OrchestrationSnapshot {
+                                        version: 1,
+                                        roles: orch_config
+                                            .roles
+                                            .iter()
+                                            .map(|r| r.name.clone())
+                                            .collect(),
+                                        start_role_index: start_idx,
+                                        orchestrator_prompt: captured_prompt.clone(),
+                                        config_name: orch_config.name.clone(),
+                                        project_path: dir_str.clone(),
+                                        started_role_indices: vec![start_idx],
+                                    }),
+                                },
+                            );
                             // PRD #89 M1.2 — opening an orchestration tab is a
                             // meaningful state change; keep the snapshot fresh.
                             ui.mark_session_dirty();
 
                             // Focus the start role's pane.
-                            let start_idx =
-                                orch_config.roles.iter().position(|r| r.start).unwrap_or(0);
                             let _ = pane.focus_pane(&role_pane_ids[start_idx]);
                             ui.mode = UiMode::PaneInput;
 
@@ -5544,6 +5582,67 @@ pub fn should_apply_snapshot(state: &AppState) -> bool {
     state.managed_pane_ids.is_empty()
 }
 
+/// PRD #89 M2b.3 — re-resolve the `OrchestrationConfig` for a snapshot's
+/// orchestration metadata on the daemon-empty restore path.
+///
+/// Returns the resolved config on success, or a human-readable drift reason
+/// (always NAMING the missing/renamed orchestration) when:
+/// - the project config can't be loaded (file gone / unreadable),
+/// - there is no project config at the saved `project_path`,
+/// - the named orchestration was renamed/removed (no match by `config_name`),
+/// - the saved roles no longer match the resolved config's roles (a role was
+///   added/removed/renamed/reordered) — the tab the user saved no longer
+///   exists as saved.
+///
+/// On `Err`, the caller surfaces the reason via `session_warnings` and falls
+/// back to a PLAIN dashboard pane (never a half-broken orchestration tab),
+/// mirroring the mode-tab drift Path D/E fallback (PRD #69).
+fn resolve_orchestration_for_restore(
+    snap: &config::OrchestrationSnapshot,
+) -> Result<OrchestrationConfig, String> {
+    let project_dir = std::path::Path::new(&snap.project_path);
+    let cfg = match load_project_config(project_dir) {
+        Ok(Some(cfg)) => cfg,
+        Ok(None) => {
+            return Err(format!(
+                "orchestration '{}' not found — no project config in {}",
+                snap.config_name, snap.project_path
+            ));
+        }
+        Err(e) => {
+            return Err(format!(
+                "orchestration '{}' could not be resolved — failed to load project config from {}: {e}",
+                snap.config_name, snap.project_path
+            ));
+        }
+    };
+    let orch = cfg
+        .orchestrations
+        .into_iter()
+        .find(|o| o.name == snap.config_name)
+        .ok_or_else(|| {
+            format!(
+                "orchestration '{}' not found in {} (renamed or removed)",
+                snap.config_name, snap.project_path
+            )
+        })?;
+    // Drift guard: the saved role set must still match the resolved config's
+    // roles (same names, same order). A renamed/removed/reordered/added role
+    // means the saved tab no longer exists as saved — fall back rather than
+    // rebuild a different tab.
+    let current_roles: Vec<&str> = orch.roles.iter().map(|r| r.name.as_str()).collect();
+    let saved_roles: Vec<&str> = snap.roles.iter().map(String::as_str).collect();
+    if current_roles != saved_roles {
+        return Err(format!(
+            "orchestration '{}' role set changed (saved [{}], now [{}])",
+            snap.config_name,
+            saved_roles.join(", "),
+            current_roles.join(", "),
+        ));
+    }
+    Ok(orch)
+}
+
 pub fn run_tui(
     state: SharedState,
     pane: Arc<dyn PaneController>,
@@ -6011,6 +6110,10 @@ pub fn run_tui(
         // Collect deferred mode pane restores — we need the terminal ready
         // before we can resize PTYs, so mode tabs are opened after the loop.
         let mut deferred_mode_panes: Vec<(config::SavedPane, ModeConfig)> = Vec::new();
+        // PRD #89 M2b.3 — the first orchestration tab rebuilt from the snapshot,
+        // so we can land on it (start cursor) after the loop rather than snapping
+        // back to the dashboard — mirroring the hydration block's landing logic.
+        let mut first_restored_orch_tab: Option<usize> = None;
         for saved_pane in &saved.panes {
             let dir = std::path::Path::new(&saved_pane.dir);
             if !dir.is_dir() {
@@ -6028,6 +6131,124 @@ pub fn run_tui(
                     "restore: skipping saved pane — already hydrated from daemon"
                 );
                 continue;
+            }
+            // PRD #89 M2b.3 — orchestration-tab restore on the daemon-empty
+            // path. A saved pane carrying orchestration metadata rebuilds the
+            // WHOLE tab (orchestrator + role panes in saved order, the prompt
+            // replayed to the start role, the start cursor) by re-resolving its
+            // `OrchestrationConfig` from `project_path` + `config_name`. On
+            // success we `continue`; on drift (config gone, orchestration
+            // renamed/removed, role set changed) we push a clear warning NAMING
+            // the orchestration and fall through to the plain-pane restore below
+            // — never a half-broken tab (mirrors the mode-tab Path D/E fallback,
+            // PRD #69). Unlike warm-daemon hydration (session/restore/007), this
+            // path REPLAYS the saved `orchestrator_prompt` to the start role —
+            // there is no live agent with the prompt already in scrollback.
+            if let Some(ref orch_snap) = saved_pane.orchestration {
+                match resolve_orchestration_for_restore(orch_snap) {
+                    Ok(orch_config) => {
+                        let frame_area = terminal.get_frame().area();
+                        // All roles share spawn dims (Tiled); role_index=0 so the
+                        // helper falls back to "role 0 expanded" — the per-frame
+                        // `resize_panes_to_layout` reconciles the exact rects once
+                        // the tab is active. Mirrors the live new-pane path.
+                        let spawn_dims = orchestration_role_pane_dims(
+                            frame_area,
+                            orch_config.roles.len(),
+                            0,
+                            PaneLayout::Tiled,
+                            true,
+                        );
+                        // Empty saved prompt → `None` so the delivery gate
+                        // writes nothing (matching the live path's "no prompt"
+                        // semantics); a non-empty prompt is replayed to the
+                        // start role once it signals readiness.
+                        let replay_prompt = (!orch_snap.orchestrator_prompt.is_empty())
+                            .then(|| orch_snap.orchestrator_prompt.clone());
+                        match tab_manager.open_orchestration_tab(
+                            &orch_config,
+                            &saved_pane.dir,
+                            replay_prompt,
+                            None,
+                            spawn_dims,
+                        ) {
+                            Ok((tab_idx, role_pane_ids)) => {
+                                // Snapshot each role pane's daemon agent_id before
+                                // the placeholder insert so the strict-equality
+                                // reuse guard accepts each role agent's first
+                                // `SessionStart` (mirrors the live path).
+                                let role_agent_ids: Vec<Option<String>> = role_pane_ids
+                                    .iter()
+                                    .map(|id| pane.pane_agent_id(id))
+                                    .collect();
+                                {
+                                    let mut st = state.blocking_write();
+                                    for (id, agent_id) in
+                                        role_pane_ids.iter().zip(role_agent_ids.iter())
+                                    {
+                                        st.register_pane(id.clone());
+                                        st.insert_placeholder_session(
+                                            id.clone(),
+                                            Some(saved_pane.dir.clone()),
+                                            None,
+                                            agent_id.clone(),
+                                        );
+                                    }
+                                    for (i, role) in orch_config.roles.iter().enumerate() {
+                                        st.pane_role_map
+                                            .insert(role_pane_ids[i].clone(), role.name.clone());
+                                        st.pane_cwd_map.insert(
+                                            role_pane_ids[i].clone(),
+                                            saved_pane.dir.clone(),
+                                        );
+                                        if role.start {
+                                            st.orchestrator_pane_ids
+                                                .insert(role_pane_ids[i].clone());
+                                        }
+                                    }
+                                }
+                                for (i, role) in orch_config.roles.iter().enumerate() {
+                                    ui.pane_display_names
+                                        .insert(role_pane_ids[i].clone(), role.name.clone());
+                                    ui.pane_names
+                                        .insert(role_pane_ids[i].clone(), role.name.clone());
+                                }
+                                // Re-capture the orchestration metadata onto the
+                                // start role pane so a later snapshot keeps the
+                                // tab (only the start role carries the block).
+                                let start_idx =
+                                    orch_config.roles.iter().position(|r| r.start).unwrap_or(0);
+                                ui.pane_metadata
+                                    .insert(role_pane_ids[start_idx].clone(), saved_pane.clone());
+                                // Record creation time so the prompt-delivery
+                                // gate's 10s timeout fallback works for agents
+                                // that never signal `SessionStart`.
+                                if let Tab::Orchestration { id, .. } = tab_manager.active_tab() {
+                                    ui.orchestration_created_at
+                                        .insert(*id, std::time::Instant::now());
+                                }
+                                if first_restored_orch_tab.is_none() {
+                                    first_restored_orch_tab = Some(tab_idx);
+                                }
+                                continue;
+                            }
+                            Err(e) => {
+                                ui.session_warnings.push(format!(
+                                    "Warning: failed to rebuild orchestration '{}': {e}; restoring '{}' as a plain pane",
+                                    orch_snap.config_name, saved_pane.name
+                                ));
+                                // Fall through to the plain-pane restore below.
+                            }
+                        }
+                    }
+                    Err(reason) => {
+                        ui.session_warnings.push(format!(
+                            "Warning: {reason}; restoring '{}' as a plain pane",
+                            saved_pane.name
+                        ));
+                        // Fall through to the plain-pane restore below.
+                    }
+                }
             }
             // If the pane belonged to a mode tab, defer it so we can open a
             // full mode tab (with side panes) instead of a plain dashboard pane.
@@ -6353,7 +6574,12 @@ pub fn run_tui(
         // 0 (dashboard) — and stays there in this snapshot-restore branch,
         // which only runs when hydration produced no panes — preserving the
         // overview-first landing for snapshot-restored sessions.
-        tab_manager.switch_to(preferred_start_tab);
+        //
+        // PRD #89 M2b.3: when the snapshot rebuilt an orchestration tab, land
+        // on the first one (start cursor) so its role cards render — the
+        // daemon-empty analogue of the hydration landing above.
+        let landing_tab = first_restored_orch_tab.unwrap_or(preferred_start_tab);
+        tab_manager.switch_to(landing_tab);
 
         // Focus the first restored pane and enter PaneInput mode so the user
         // can type immediately. PRD #84 M4: PTY sizing is handled by the

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -1303,11 +1303,11 @@ without depending on the config struct API.
 
 #### session/restore
 
-##### session/restore/001 — `dot-agent-deck --continue` rehydrates dashboard panes from the saved session.
-- **Layer:** L2.
-- **Agent:** none (a saved `session.toml` with three panes; fixture redirects `DOT_AGENT_DECK_SESSION`).
-- **Asserts:** three cards appear; their display names match the saved session.
-- **Does not assert:** the agents' inner state (not preserved per docs).
+##### session/restore/001 — No-flag startup auto-restores dashboard panes from the saved session (PRD #89 Phase 2).
+- **Layer:** L2 (real-binary PTY; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path).
+- **Agent:** none (a saved `session.toml` with two panes running `sleep 600`; daemon is freshly spawned and empty).
+- **Asserts:** launching with NO `--continue` flag against an empty daemon restores both saved panes as dashboard cards, with their saved display names. (Restore is unconditional now — the old `--continue` gate is gone.)
+- **Does not assert:** the agents' inner state (not preserved per docs); the daemon-vs-snapshot precedence (deferred to Phase 2 M2.2).
 - **Platform coverage:** mac+linux.
 
 ##### session/restore/002 — A saved mode tab is restored as a full mode tab when the project's `.dot-agent-deck.toml` still has the mode.
@@ -1329,6 +1329,13 @@ without depending on the config struct API.
 - **Agent:** none.
 - **Asserts:** N-1 cards restore; stderr names the missing directory.
 - **Does not assert:** which other panes survive (deterministic from the file order).
+- **Platform coverage:** mac+linux.
+
+##### session/restore/006 — Empty daemon + no snapshot + no flag lands on a clean empty dashboard (PRD #89 Phase 2).
+- **Layer:** L2 (real-binary PTY; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path with no file staged).
+- **Agent:** none.
+- **Asserts:** with both restore sources empty (fresh empty daemon, no snapshot on disk) and no `--continue`, the deck lands on the "No active sessions" dashboard with no restore warning and remains interactive (Ctrl+N opens the new-pane directory picker). Locks the post-Phase-2 invariant that unconditional restore still falls through cleanly when there is nothing to restore.
+- **Does not assert:** the daemon-with-agents-wins precedence (deferred to Phase 2 M2.2); the snapshot-restore path (covered by `session/restore/001`).
 - **Platform coverage:** mac+linux.
 
 ### Session save (snapshot freshness, PRD #89 Phase 1)
@@ -1357,6 +1364,17 @@ These entries cover PRD #89 Phase 1: the saved-session snapshot must be kept con
 - **Asserts:** driving the coalescer (750 ms-style interval) with 50 rapid `mark_dirty` notifications observed at one instant — each followed by the loop's `is_due`/`record_write` check — produces only the leading-edge write; a single trailing check after the interval flushes the rest, for ≤2 total writes (and ≥1), and nothing is due once flushed.
 - **Does not assert:** the production interval value, real wall-clock timing, or that the on-disk file content is correct (covered by `session/save/001`–`002`).
 - **Platform coverage:** mac+linux+windows.
+
+### CLI surface (PRD #89 Phase 3)
+
+#### cli/continue-removed
+
+##### cli/continue-removed/001 — `--continue` is removed from the CLI surface and rejected on use (PRD #89 Phase 3).
+- **Layer:** L2 (thin real-binary subprocess spawn; no PTY drive).
+- **Agent:** none.
+- **Asserts:** `dot-agent-deck --help` no longer advertises `--continue`, and `dot-agent-deck --continue` exits non-zero with a message that references the flag (guiding the user toward the now-default auto-restore). Since auto-restore is unconditional, the flag has no remaining purpose.
+- **Does not assert:** the exact wording of the rejection message (clap's default unknown-argument text or a custom friendly message both satisfy it).
+- **Platform coverage:** mac+linux.
 
 ### Chain-smoke (real-agent) coverage
 

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -1331,6 +1331,26 @@ without depending on the config struct API.
 - **Does not assert:** which other panes survive (deterministic from the file order).
 - **Platform coverage:** mac+linux.
 
+### Session save (snapshot freshness, PRD #89 Phase 1)
+
+These entries cover PRD #89 Phase 1: the saved-session snapshot must be kept continuously fresh — written on meaningful TUI state changes and on detach — not only at clean teardown/quit.
+
+#### session/save
+
+##### session/save/001 — A meaningful TUI state change (creating a new dashboard pane) writes a fresh saved-session snapshot to disk without quitting.
+- **Layer:** L2 (real-binary PTY; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path).
+- **Agent:** none (the pane runs `sleep 600`; no LLM).
+- **Asserts:** starting with no prior snapshot on disk, creating a new dashboard pane via the new-pane flow (Ctrl+N → dir-picker → form → submit) — and NOT quitting — causes a `session.toml` to be written that contains the newly created pane's command.
+- **Does not assert:** the coalescing/debounce window (covered by `session/save/003`); restore-on-startup behavior (PRD #89 Phase 2).
+- **Platform coverage:** mac+linux.
+
+##### session/save/002 — Triggering a detach path (Ctrl+W close-pane) flushes a fresh snapshot reflecting the workspace, without quitting.
+- **Layer:** L2 (real-binary PTY; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path).
+- **Agent:** none (panes run `sleep 600`; no LLM).
+- **Asserts:** with two dashboard panes present and any prior snapshot removed, closing a pane with Ctrl+W writes a fresh `session.toml` that still reflects the (non-empty) workspace — proving the detach path flushes the snapshot mid-session, not only at clean quit.
+- **Does not assert:** which specific pane survives the close; the coalescing/debounce window (`session/save/003`).
+- **Platform coverage:** mac+linux.
+
 ### Chain-smoke (real-agent) coverage
 
 #### chain-smoke/claude

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -1331,6 +1331,13 @@ without depending on the config struct API.
 - **Does not assert:** which other panes survive (deterministic from the file order).
 - **Platform coverage:** mac+linux.
 
+##### session/restore/005 — Daemon-with-agents wins over the disk snapshot; snapshot restore is skipped (PRD #89 Phase 2 M2.2).
+- **Layer:** pure-data (in-crate integration test on `ui::should_apply_snapshot` over `AppState.managed_pane_ids`; no TUI harness, runs in the fast tier).
+- **Agent:** none.
+- **Asserts:** with no hydrated managed panes `should_apply_snapshot` returns `true` (daemon empty → apply the disk snapshot); after one or more hydrated `managed_pane_id`s are registered it returns `false` (daemon owns the workspace → skip the snapshot so panes are not double-restored). Pins the M2.2 precedence as a structural decision, not a flag.
+- **Does not assert:** the end-to-end cross-deck PTY hydration path (would need a daemon pre-seeded with an agent that a fresh deck hydrates — a harness primitive not yet built); the snapshot-apply mechanics themselves (covered by `session/restore/001`).
+- **Platform coverage:** mac+linux+windows.
+
 ##### session/restore/006 — Empty daemon + no snapshot + no flag lands on a clean empty dashboard (PRD #89 Phase 2).
 - **Layer:** L2 (real-binary PTY; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path with no file staged).
 - **Agent:** none.

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -1366,6 +1366,34 @@ without depending on the config struct API.
 - **Does not assert:** the exact warning wording (only that it names the missing orchestration); the successful rebuild path (`session/restore/008`); which other panes survive when multiple are staged (only one is here).
 - **Platform coverage:** mac+linux.
 
+##### session/restore/010 — A snapshot re-resolving to a zero-role orchestration falls back to a plain dashboard pane with a warning, never panicking at startup (PRD #89 review-fix F2).
+- **Layer:** L2 (real-binary PTY; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path; daemon freshly spawned and empty).
+- **Agent:** none (the fallback pane runs `sleep 600`; no LLM).
+- **Asserts:** with a project config that still names `tdd-cycle` but whittled to an EXPLICIT empty role set (`roles = []`, which `load_project_config` accepts since it runs no `config_validation`) and a hand-staged snapshot whose saved role set is also empty (so the name+order drift guard passes — `[] == []`) with a `start_role_index` of 0 that is out of range, launching against an empty daemon with no flag does NOT panic/crash-loop: the saved pane restores as a PLAIN dashboard card (`orchestrator`) and a `session_warnings` message naming the orchestration (`tdd-cycle`) is flushed to stderr on a clean detach-quit. Pins that an empty/no-start-role re-resolution is treated as drift, never indexed unguarded at the start cursor.
+- **Does not assert:** the exact warning wording (only that it names the orchestration); the successful rebuild path (`session/restore/008`); the non-empty role-set drift fallback (`session/restore/009`).
+- **Platform coverage:** mac+linux.
+
+##### session/restore/011 — A saved `start_role_index` that differs from the config default is honored on restore: the orchestrator prompt lands on the role at the saved index (PRD #89 review-fix F3).
+- **Layer:** L2 (real-binary PTY; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path; daemon freshly spawned and empty).
+- **Agent:** none (both roles run a recorder shell script that self-posts `SessionStart` and appends its stdin to an absolute `record-<role>.log` — no LLM tokens).
+- **Asserts:** with a `tdd-cycle` config whose default start role is `orchestrator` (index 0, `start = true`) and a recorder on BOTH roles, a hand-staged snapshot saving `start_role_index = 1` (`coder`) makes the replayed `orchestrator_prompt` land on and be recorded by the role at the SAVED index (`coder`, index 1) — and NOT by the config-default start role (`orchestrator`, index 0). Pins that restore reads `snap.start_role_index` rather than recomputing the start cursor from the live config's `start` flag.
+- **Does not assert:** the drift/bounds handling when the saved index is out of range (`session/restore/010`); `started_role_indices` replay (captured but has no reader); the exact role-card styling / focus border.
+- **Platform coverage:** mac+linux.
+
+##### session/restore/012 — A snapshot whose `project_path` diverges from the saved pane `dir` does not auto-run the config planted at `project_path` (PRD #89 review-fix F1).
+- **Layer:** L2 (real-binary PTY; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path; daemon freshly spawned and empty).
+- **Agent:** none (roles run `sleep 600`; no LLM).
+- **Asserts:** with the saved pane `dir` pointing at a legitimate working dir (no orchestration config) while the `[panes.orchestration]` `project_path` points at a SEPARATE planted dir whose config defines a uniquely-named `phantom-reviewer` role, launching against an empty daemon with no flag does NOT execute the planted config — `phantom-reviewer` never materializes as a deck card — while the saved pane still restores as a PLAIN card (`orchestrator`). Pins that the un-cross-checked `project_path` cannot auto-run a config from an unexpected directory (capture always writes `project_path == saved_pane.dir`, so divergence only arises via tampering).
+- **Does not assert:** which fix shape the coder chooses (drift fallback vs. re-resolving from `saved_pane.dir`) — only that the divergent config is not executed; path canonicalization edge cases (symlinks, `..`).
+- **Platform coverage:** mac+linux.
+
+##### session/restore/013 — A custom orchestration tab `display_title` saved in the snapshot is preserved on restore (PRD #89 review-fix F4, RED-pending-schema).
+- **Layer:** L2 (real-binary PTY; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path; daemon freshly spawned and empty).
+- **Agent:** none (roles run `sleep 600`; no LLM).
+- **Asserts:** with a hand-staged snapshot carrying a custom `display_title` (`MYDECKTITLE`) distinct from the canonical config name, the daemon-empty rebuild shows the user's saved title in the tab bar, not the canonical `tdd-cycle` config/cwd name. RED-pending-schema: `OrchestrationSnapshot` has no `display_title` field yet (the staged key parses but is dropped on load, since the struct sets no `deny_unknown_fields`) and restore passes `None` to `open_orchestration_tab`, so the tab comes back titled `tdd-cycle`; goes GREEN once the coder adds the field + capture + restore threading.
+- **Does not assert:** the live-path title plumbing (already covered by the new-pane orchestration flow); the serde round-trip of the new field in isolation (a unit test the coder adds with the field).
+- **Platform coverage:** mac+linux.
+
 ### Session save (snapshot freshness, PRD #89 Phase 1)
 
 These entries cover PRD #89 Phase 1: the saved-session snapshot must be kept continuously fresh — written on meaningful TUI state changes and on detach — not only at clean teardown/quit.

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -1424,6 +1424,26 @@ This entry covers PRD #89 Phase 2b M2b.2: the saved-pane schema gains an `Option
 - **Does not assert:** the exact wording of the rejection message (clap's default unknown-argument text or a custom friendly message both satisfy it).
 - **Platform coverage:** mac+linux.
 
+### Fresh-start escape hatch (PRD #89 Phase 4)
+
+These entries cover PRD #89 Phase 4: with auto-restore now the default, a user who wants to start clean has one obvious action per surface — a local `dot-agent-deck snapshot clear` subcommand (M4.2) and the per-deck `dot-agent-deck remote remove <name>` (M4.1). Both clear the saved-session snapshot.
+
+#### session/snapshot
+
+##### session/snapshot/001 — `dot-agent-deck snapshot clear` deletes the local saved-session snapshot (PRD #89 Phase 4 M4.2).
+- **Layer:** L2 (thin real-binary subprocess spawn; no PTY drive; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path).
+- **Agent:** none.
+- **Asserts:** with a non-empty `session.toml` staged at the redirected path, running `dot-agent-deck snapshot clear` exits 0 and the snapshot file is gone afterward — the local fresh-start escape hatch. The command shape is a `snapshot` subcommand group with a `clear` action (decided; not `reset`/`--reset`).
+- **Does not assert:** the subsequent no-flag startup landing on an empty dashboard (that follows from the deleted snapshot + `session/restore/006`); the exact stdout wording of the success message.
+- **Platform coverage:** mac+linux.
+
+##### session/snapshot/002 — `dot-agent-deck remote remove <name>` clears that deck's saved state (PRD #89 Phase 4 M4.1).
+- **Layer:** L2 (thin real-binary subprocess spawn; no PTY drive; `DOT_AGENT_DECK_SESSION` + `DOT_AGENT_DECK_REMOTES` redirected to test-owned paths).
+- **Agent:** none.
+- **Asserts:** with a remote deck `myhost` registered in the staged `remotes.toml` and a non-empty `session.toml` staged, running `dot-agent-deck remote remove myhost` exits 0 AND clears that deck's saved state — the snapshot file is gone afterward — the per-deck fresh-start escape hatch.
+- **Does not assert:** that the registry entry was removed (that is `remote remove`'s pre-existing behavior, exercised elsewhere); the per-deck keying of saved state (the snapshot is a single global file today).
+- **Platform coverage:** mac+linux.
+
 ### Chain-smoke (real-agent) coverage
 
 #### chain-smoke/claude

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -1351,6 +1351,13 @@ These entries cover PRD #89 Phase 1: the saved-session snapshot must be kept con
 - **Does not assert:** which specific pane survives the close; the coalescing/debounce window (`session/save/003`).
 - **Platform coverage:** mac+linux.
 
+##### session/save/003 — A burst of meaningful state changes coalesces to at most one or two snapshot writes, not one per change.
+- **Layer:** pure-data (in-crate `#[cfg(test)]` unit test on `config::SnapshotCoalescer`; no TUI harness, synchronous clock).
+- **Agent:** none.
+- **Asserts:** driving the coalescer (750 ms-style interval) with 50 rapid `mark_dirty` notifications observed at one instant — each followed by the loop's `is_due`/`record_write` check — produces only the leading-edge write; a single trailing check after the interval flushes the rest, for ≤2 total writes (and ≥1), and nothing is due once flushed.
+- **Does not assert:** the production interval value, real wall-clock timing, or that the on-disk file content is correct (covered by `session/save/001`–`002`).
+- **Platform coverage:** mac+linux+windows.
+
 ### Chain-smoke (real-agent) coverage
 
 #### chain-smoke/claude

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -1426,7 +1426,7 @@ This entry covers PRD #89 Phase 2b M2b.2: the saved-pane schema gains an `Option
 
 ### Fresh-start escape hatch (PRD #89 Phase 4)
 
-These entries cover PRD #89 Phase 4: with auto-restore now the default, a user who wants to start clean has one obvious action per surface — a local `dot-agent-deck snapshot clear` subcommand (M4.2) and the per-deck `dot-agent-deck remote remove <name>` (M4.1). Both clear the saved-session snapshot.
+These entries cover PRD #89 Phase 4: with auto-restore now the default, a user who wants to start clean has one obvious action — `dot-agent-deck snapshot clear` (M4.2) — because the snapshot is a single GLOBAL file. `dot-agent-deck remote remove <name>` (M4.1) is registry-only and intentionally does NOT touch the snapshot (decided Option 1); there is no per-deck saved state to clear.
 
 #### session/snapshot
 
@@ -1437,11 +1437,11 @@ These entries cover PRD #89 Phase 4: with auto-restore now the default, a user w
 - **Does not assert:** the subsequent no-flag startup landing on an empty dashboard (that follows from the deleted snapshot + `session/restore/006`); the exact stdout wording of the success message.
 - **Platform coverage:** mac+linux.
 
-##### session/snapshot/002 — `dot-agent-deck remote remove <name>` clears that deck's saved state (PRD #89 Phase 4 M4.1).
+##### session/snapshot/002 — `dot-agent-deck remote remove <name>` is registry-only and leaves the global snapshot intact (PRD #89 Phase 4 M4.1, Option 1).
 - **Layer:** L2 (thin real-binary subprocess spawn; no PTY drive; `DOT_AGENT_DECK_SESSION` + `DOT_AGENT_DECK_REMOTES` redirected to test-owned paths).
 - **Agent:** none.
-- **Asserts:** with a remote deck `myhost` registered in the staged `remotes.toml` and a non-empty `session.toml` staged, running `dot-agent-deck remote remove myhost` exits 0 AND clears that deck's saved state — the snapshot file is gone afterward — the per-deck fresh-start escape hatch.
-- **Does not assert:** that the registry entry was removed (that is `remote remove`'s pre-existing behavior, exercised elsewhere); the per-deck keying of saved state (the snapshot is a single global file today).
+- **Asserts:** with a remote deck `myhost` registered in the staged `remotes.toml` and a non-empty `session.toml` staged, running `dot-agent-deck remote remove myhost` exits 0 AND leaves the global snapshot intact — the file is still present afterward with byte-for-byte unchanged contents. The snapshot is a single GLOBAL file, so remove is registry-only (decided Option 1); there is no per-deck saved state to clear and `snapshot clear` (001) is the one fresh-start action.
+- **Does not assert:** that the registry entry was removed (that is `remote remove`'s pre-existing behavior, exercised elsewhere); any per-deck keying of saved state (none exists — the snapshot is a single global file).
 - **Platform coverage:** mac+linux.
 
 ### Chain-smoke (real-agent) coverage

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -1352,6 +1352,20 @@ without depending on the config struct API.
 - **Does not assert:** the daemon-empty snapshot-fallback rebuild (`session/restore/008`); the orchestrator-prompt replay (intentionally NOT replayed on warm reconnect — `src/tab.rs` design decision 3); the full `OrchestrationConfig` re-resolution (the partition + `resolve_orch_config_for_hydration` path, exercised elsewhere).
 - **Platform coverage:** mac+linux (Unix-only; `#![cfg(unix)]`).
 
+##### session/restore/008 — A daemon-empty launch with an orchestration snapshot rebuilds the orchestration tab and replays the orchestrator prompt (PRD #89 Phase 2b M2b.3).
+- **Layer:** L2 (real-binary PTY; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path; daemon freshly spawned and empty).
+- **Agent:** none (the orchestration's `coder`/`reviewer` roles run `sleep 600`; the `orchestrator` role runs a recorder shell script that self-posts `SessionStart` and appends its stdin to an absolute `record-orchestrator.log` — no LLM tokens).
+- **Asserts:** with a hand-staged `session.toml` whose single pane carries a `[panes.orchestration]` block (`config_name`/`project_path` pointing at a test-owned orchestration config, `orchestrator_prompt = "Build the feature end to end"`, `start_role_index = 0`) and an empty daemon, launching with NO `--continue` REBUILDS the orchestration tab: the `coder` and `reviewer` role panes appear as deck cards in their saved display order, and — unlike warm hydration (`session/restore/007`) — the saved `orchestrator_prompt` is replayed to the start (orchestrator) role and recorded (echo-immune), which also proves the start role was identified from `start_role_index`.
+- **Does not assert:** the warm-daemon hydration path (`session/restore/007`); the on-disk capture that produces the snapshot (`session/save/004`); the config-drift fallback (`session/restore/009`); the exact role-card styling / focus border.
+- **Platform coverage:** mac+linux.
+
+##### session/restore/009 — An orchestration snapshot whose config no longer resolves falls back to a plain dashboard pane with a `session_warnings` message naming the missing orchestration (PRD #89 Phase 2b M2b.3 drift).
+- **Layer:** L2 (real-binary PTY; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path; daemon freshly spawned and empty).
+- **Agent:** none (the fallback pane runs `sleep 600`; no LLM).
+- **Asserts:** with a hand-staged `session.toml` whose `[panes.orchestration]` block references `config_name = "tdd-cycle"` while the project config at `project_path` defines only a renamed `renamed-orch` (a re-resolution drift), launching against an empty daemon with no flag restores the saved pane as a PLAIN dashboard card (its saved name `orchestrator`, with no `coder`/`reviewer` role panes — never a half-broken tab) AND surfaces a clear `session_warnings` message naming the missing orchestration (`tdd-cycle`), flushed to stderr on detach-quit. Mirrors the mode-tab drift fallback (`session/restore/003`, PRD #69 Path D/E).
+- **Does not assert:** the exact warning wording (only that it names the missing orchestration); the successful rebuild path (`session/restore/008`); which other panes survive when multiple are staged (only one is here).
+- **Platform coverage:** mac+linux.
+
 ### Session save (snapshot freshness, PRD #89 Phase 1)
 
 These entries cover PRD #89 Phase 1: the saved-session snapshot must be kept continuously fresh — written on meaningful TUI state changes and on detach — not only at clean teardown/quit.
@@ -1378,6 +1392,13 @@ These entries cover PRD #89 Phase 1: the saved-session snapshot must be kept con
 - **Asserts:** driving the coalescer (750 ms-style interval) with 50 rapid `mark_dirty` notifications observed at one instant — each followed by the loop's `is_due`/`record_write` check — produces only the leading-edge write; a single trailing check after the interval flushes the rest, for ≤2 total writes (and ≥1), and nothing is due once flushed.
 - **Does not assert:** the production interval value, real wall-clock timing, or that the on-disk file content is correct (covered by `session/save/001`–`002`).
 - **Platform coverage:** mac+linux+windows.
+
+##### session/save/004 — Opening an orchestration tab captures its orchestration metadata into the saved-session snapshot (PRD #89 Phase 2b M2b.3 capture).
+- **Layer:** L2 (real-binary PTY; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path).
+- **Agent:** none (the `orch-deck` fixture's `demo-orch` roles run `cat`; no LLM).
+- **Asserts:** opening the fixture orchestration via the new-pane form (a Phase 1 M1.1 meaningful state change that flushes the coalesced snapshot) — and NOT quitting — writes a `session.toml` carrying a `[panes.orchestration]` block that records the resolved `config_name` (`demo-orch`), the roles (`orchestrator`, `worker`) in display order, and the `start_role_index` (`0`, the `start = true` orchestrator), so the daemon-empty restore path (`session/restore/008`) can rebuild the tab.
+- **Does not assert:** the restore branch that consumes the metadata (`session/restore/008`–`009`); the serde round-trip of the schema in isolation (`config/saved-session/001`); the coalescing window (`session/save/003`).
+- **Platform coverage:** mac+linux.
 
 ### Saved-session schema (orchestration metadata, PRD #89 Phase 2b)
 

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -1345,6 +1345,13 @@ without depending on the config struct API.
 - **Does not assert:** the daemon-with-agents-wins precedence (deferred to Phase 2 M2.2); the snapshot-restore path (covered by `session/restore/001`).
 - **Platform coverage:** mac+linux.
 
+##### session/restore/007 — A warm daemon carrying an orchestration hydrates the orchestrator + role panes in their saved order (PRD #89 Phase 2b M2b.1).
+- **Layer:** in-process (real in-process attach daemon over a Unix socket; `EmbeddedPaneController::hydrate_from_daemon`; no real binary, no PTY drive). Runs in the fast tier.
+- **Agent:** none (each role agent runs `sh -c 'sleep 30'`; no LLM).
+- **Asserts:** spawning three orchestration role agents (orchestrator + coder + reviewer), each tagged with its `TabMembership::Orchestration` `role_index` / `role_name` / `is_start_role`, then hydrating a fresh controller from the warm daemon reproduces every role as a pane; placing each hydrated pane at its `role_index` yields the panes in their saved display order; and the start (orchestrator) role — the `start_role_index` cursor — is recoverable from `is_start_role`. Regression guard that warm-daemon orchestration hydration (PRD #76 M2.12 + #111) survives detach/reattach so M2b.3's snapshot fallback is only needed when the daemon is empty.
+- **Does not assert:** the daemon-empty snapshot-fallback rebuild (`session/restore/008`); the orchestrator-prompt replay (intentionally NOT replayed on warm reconnect — `src/tab.rs` design decision 3); the full `OrchestrationConfig` re-resolution (the partition + `resolve_orch_config_for_hydration` path, exercised elsewhere).
+- **Platform coverage:** mac+linux (Unix-only; `#![cfg(unix)]`).
+
 ### Session save (snapshot freshness, PRD #89 Phase 1)
 
 These entries cover PRD #89 Phase 1: the saved-session snapshot must be kept continuously fresh — written on meaningful TUI state changes and on detach — not only at clean teardown/quit.
@@ -1370,6 +1377,19 @@ These entries cover PRD #89 Phase 1: the saved-session snapshot must be kept con
 - **Agent:** none.
 - **Asserts:** driving the coalescer (750 ms-style interval) with 50 rapid `mark_dirty` notifications observed at one instant — each followed by the loop's `is_due`/`record_write` check — produces only the leading-edge write; a single trailing check after the interval flushes the rest, for ≤2 total writes (and ≥1), and nothing is due once flushed.
 - **Does not assert:** the production interval value, real wall-clock timing, or that the on-disk file content is correct (covered by `session/save/001`–`002`).
+- **Platform coverage:** mac+linux+windows.
+
+### Saved-session schema (orchestration metadata, PRD #89 Phase 2b)
+
+This entry covers PRD #89 Phase 2b M2b.2: the saved-pane schema gains an `Option<OrchestrationSnapshot>` (role order, `start_role_index`, `orchestrator_prompt`, resolved config name + project path, `version`, and which roles were started) so the daemon-empty restore path can rebuild an orchestration tab. The field is `Option` + `#[serde(default)]` so old `session.toml` files still parse.
+
+#### config/saved-session
+
+##### config/saved-session/001 — An `OrchestrationSnapshot` on a saved pane round-trips through TOML, and a legacy snapshot without the field still parses (PRD #89 Phase 2b M2b.2).
+- **Layer:** pure-data (in-crate `#[cfg(test)]` unit test on `config::SavedSession` / `SavedPane` / `OrchestrationSnapshot`; no TUI harness, no I/O).
+- **Agent:** none.
+- **Asserts:** (a) a `SavedSession` whose pane carries an `OrchestrationSnapshot` (version, role order in display order, `start_role_index`, `orchestrator_prompt`, `config_name`, `project_path`, `started_role_indices`) serializes to TOML and deserializes back with every field intact; (b) a legacy `session.toml` string with no `orchestration` key parses with `orchestration == None` — the `#[serde(default)]` forward-compat guarantee for snapshots written before the field existed.
+- **Does not assert:** the snapshot-fallback restore branch that consumes the metadata (M2b.3 / `session/restore/008`–`009`); capture (populating the field when writing the snapshot); any TUI rendering.
 - **Platform coverage:** mac+linux+windows.
 
 ### CLI surface (PRD #89 Phase 3)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -319,11 +319,11 @@ impl TuiDeck {
             }
         }
 
-        // Write the saved-session file the deck reads under `--continue`,
-        // if the test asked for one. The pane runs `command` in the
-        // tempdir's working directory so the agent has a real cwd to
-        // operate against (the deck's restore path skips panes whose
-        // `dir` doesn't exist on disk).
+        // Write the saved-session file the deck auto-restores on startup
+        // (PRD #89: no `--continue` flag anymore), if the test asked for one.
+        // The pane runs `command` in the tempdir's working directory so the
+        // agent has a real cwd to operate against (the deck's restore path
+        // skips panes whose `dir` doesn't exist on disk).
         let session_toml_path = work.join("session.toml");
         if let Some(cs) = &builder.continue_session {
             write_continue_session_file(&session_toml_path, &work, &cs.pane_name, &cs.command)
@@ -351,11 +351,10 @@ impl TuiDeck {
         let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
         let mut cmd = CommandBuilder::new(bin);
         cmd.cwd(&work);
-        // Pass `--continue` when a saved session was staged so the deck
-        // auto-opens the chain-smoke pane on launch.
-        if builder.continue_session.is_some() {
-            cmd.arg("--continue");
-        }
+        // PRD #89: the `--continue` flag was removed — auto-restore is now the
+        // default. A staged saved session (pointed at by `DOT_AGENT_DECK_SESSION`
+        // below) is restored unconditionally on launch when the daemon is empty,
+        // so no flag is passed here.
         // M2.1 auditor S2: portable-pty 0.8 unconditionally env_clears
         // on Unix before applying our `cmd.env(...)` calls, but the old
         // comment claimed env_clear was avoided. Make the scrub
@@ -420,7 +419,7 @@ impl TuiDeck {
             final_env.insert((*k).into(), (*v).into());
         }
         // Point the deck's saved-session reader at our staged file so
-        // `--continue` picks up exactly the chain-smoke pane and
+        // auto-restore picks up exactly the chain-smoke pane and
         // nothing from the developer's real session.toml.
         if builder.continue_session.is_some() {
             final_env.insert(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -712,6 +712,80 @@ impl TuiDeck {
         }
     }
 
+    /// Like [`wait_for_strings_in_order`], but tolerant of a one-shot
+    /// agent that completes and exits before a stable terminal frame is
+    /// ever rendered.
+    ///
+    /// `prefix` needles are matched STRICTLY in order against the
+    /// rolling byte history (so the test still proves the live
+    /// lifecycle ran); then ANY one of `terminal_alternatives`,
+    /// appearing AFTER the last prefix needle, satisfies the terminal
+    /// condition.
+    ///
+    /// This exists for the chain-smoke path. A `claude -p` print-mode
+    /// agent COMPLETES and EXITS the instant it finishes responding, so
+    /// the pane can jump from `Working`/`Bash` straight to the stable
+    /// "No agent" / "Launch an agent to get started" placeholder before
+    /// a rendered `Idle` frame survives a ~20 ms poll (a pre-existing
+    /// PRD #77 timing fragility — the agent demonstrably reaches
+    /// Thinking → Working → Bash, only the terminal `Idle` observation
+    /// races the exit). Accepting that clean exit as equivalent to a
+    /// captured `Idle` keeps the terminal assertion robust to the
+    /// print-mode lifecycle without weakening the strict prefix that
+    /// proves the agent traversed the working lifecycle.
+    ///
+    /// Searching the terminal alternatives only after the prefix cursor
+    /// is deliberate: a restored session renders a default `Idle` (and
+    /// may render the placeholder) *before* the agent starts, so an
+    /// early occurrence must not count — only a terminal state reached
+    /// AFTER the working lifecycle does.
+    pub fn wait_for_strings_in_order_then_any(
+        &self,
+        prefix: &[&str],
+        terminal_alternatives: &[&str],
+    ) {
+        let start_idx = self.byte_history.lock().unwrap().len();
+        let deadline = Instant::now() + WAIT_TIMEOUT;
+        loop {
+            let snapshot: Vec<u8> = {
+                let hist = self.byte_history.lock().unwrap();
+                if hist.len() > start_idx {
+                    hist[start_idx..].to_vec()
+                } else {
+                    Vec::new()
+                }
+            };
+            let (matched, terminal_found) =
+                match_prefix_then_terminal(&snapshot, prefix, terminal_alternatives);
+            if matched == prefix.len() && terminal_found {
+                return;
+            }
+            if Instant::now() > deadline {
+                let grid = self.snapshot_grid();
+                if matched < prefix.len() {
+                    let so_far = prefix[..matched].join(", ");
+                    let next = prefix[matched];
+                    panic!(
+                        "did not see prefix needle `{next}` (#{} of {} — already \
+                         matched in order: [{so_far}]) within {WAIT_TIMEOUT:?}.\n\
+                         Final grid:\n{grid}",
+                        matched + 1,
+                        prefix.len(),
+                    );
+                } else {
+                    let alts = terminal_alternatives.join("` | `");
+                    let pfx = prefix.join(", ");
+                    panic!(
+                        "matched the full prefix [{pfx}] but saw none of the \
+                         terminal alternatives [`{alts}`] after it within \
+                         {WAIT_TIMEOUT:?}.\nFinal grid:\n{grid}"
+                    );
+                }
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
     /// Send raw bytes to the deck as if typed at the terminal. Writes
     /// to the PTY master so the spawned binary reads them on stdin and
     /// `crossterm` decodes them into key events. Callers pass the
@@ -986,6 +1060,40 @@ fn match_needles_in_order(haystack: &[u8], needles: &[&str]) -> usize {
         }
     }
     matched
+}
+
+/// Match `prefix` needles strictly in order against `haystack`, then
+/// check whether ANY of `terminals` appears AFTER the matched prefix.
+///
+/// Returns `(prefix_matched, terminal_found)`:
+/// - `prefix_matched` — how many prefix needles were found in order,
+///   advancing a cursor past each (the exact in-order semantics of
+///   [`match_needles_in_order`]). A value below `prefix.len()` means
+///   the prefix is incomplete, and `terminal_found` is then `false`.
+/// - `terminal_found` — once the full prefix matched, whether at least
+///   one terminal alternative occurs in the bytes AFTER the prefix's
+///   end cursor. Searching only after the prefix is what stops a stale
+///   pre-lifecycle status (e.g. a restored session's default `Idle`
+///   rendered *before* `Thinking`) from satisfying the terminal check.
+fn match_prefix_then_terminal(
+    haystack: &[u8],
+    prefix: &[&str],
+    terminals: &[&str],
+) -> (usize, bool) {
+    let text = String::from_utf8_lossy(haystack);
+    let mut cursor = 0usize;
+    let mut matched = 0usize;
+    for needle in prefix {
+        match text[cursor..].find(needle) {
+            Some(rel_idx) => {
+                cursor += rel_idx + needle.len();
+                matched += 1;
+            }
+            None => return (matched, false),
+        }
+    }
+    let terminal_found = terminals.iter().any(|t| text[cursor..].contains(t));
+    (matched, terminal_found)
 }
 
 fn locate_fixture(name: &str) -> PathBuf {
@@ -2454,7 +2562,7 @@ pub fn process_running(pid: i32) -> bool {
         Ok(stat) => match stat.rfind(')') {
             // `/proc/<pid>/stat` is `pid (comm) STATE ...`; comm may contain
             // spaces/parens, so the state char follows the last ')'.
-            Some(idx) => stat[idx + 1..].trim_start().chars().next() != Some('Z'),
+            Some(idx) => !stat[idx + 1..].trim_start().starts_with('Z'),
             None => true,
         },
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -2600,5 +2708,64 @@ mod harness_unit_tests {
         let needles = ["Thinking", "Working", "Bash", "Idle"];
         let matched = match_needles_in_order(haystack, &needles);
         assert_eq!(matched, 2);
+    }
+
+    #[test]
+    fn match_prefix_then_terminal_accepts_idle_after_prefix() {
+        // prd-77 chain-smoke: full prefix in order, then a rendered
+        // Idle — the classic happy path. Terminal is satisfied.
+        let haystack = b"Thinking... Working with `Bash` then Idle now";
+        let (matched, terminal) =
+            match_prefix_then_terminal(haystack, &["Thinking", "Working", "Bash"], &["Idle"]);
+        assert_eq!(matched, 3);
+        assert!(terminal);
+    }
+
+    #[test]
+    fn match_prefix_then_terminal_accepts_placeholder_when_idle_absent() {
+        // print-mode lifecycle: the agent exits before any Idle
+        // frame, so the pane falls back to the placeholder. The
+        // placeholder alternative (seen AFTER Bash) satisfies the
+        // terminal even though `Idle` never appears.
+        let haystack =
+            b"Thinking... Working with `Bash`, agent exited, Launch an agent to get started";
+        let (matched, terminal) = match_prefix_then_terminal(
+            haystack,
+            &["Thinking", "Working", "Bash"],
+            &["Idle", "Launch an agent to get started"],
+        );
+        assert_eq!(matched, 3);
+        assert!(terminal);
+    }
+
+    #[test]
+    fn match_prefix_then_terminal_ignores_terminal_before_prefix_completes() {
+        // A restored session renders its default `Idle` (and may show
+        // the placeholder) BEFORE the agent starts. That stale early
+        // terminal must NOT count: searching only after the prefix
+        // cursor means a pre-lifecycle Idle is rejected.
+        let haystack = b"Idle (restored) then Thinking... Working with `Bash`, nothing after";
+        let (matched, terminal) = match_prefix_then_terminal(
+            haystack,
+            &["Thinking", "Working", "Bash"],
+            &["Idle", "Launch an agent to get started"],
+        );
+        assert_eq!(matched, 3);
+        assert!(!terminal);
+    }
+
+    #[test]
+    fn match_prefix_then_terminal_reports_incomplete_prefix() {
+        // Bash never shows up: prefix stalls at 2 and terminal is
+        // forced false, so the timeout path points at the missing
+        // prefix needle rather than the terminal alternatives.
+        let haystack = b"Thinking happened then Working took over, then Idle, no tool used";
+        let (matched, terminal) = match_prefix_then_terminal(
+            haystack,
+            &["Thinking", "Working", "Bash"],
+            &["Idle", "Launch an agent to get started"],
+        );
+        assert_eq!(matched, 2);
+        assert!(!terminal);
     }
 }

--- a/tests/e2e_chain_smoke_claude.rs
+++ b/tests/e2e_chain_smoke_claude.rs
@@ -27,10 +27,13 @@ const PINNED_MODEL: &str = "claude-haiku-4-5-20251001";
 /// `claude -p "…use the Bash tool to run pwd…" --model
 /// claude-haiku-4-5-20251001 --allowedTools Bash`, then launch the
 /// deck with `--continue` so the agent process auto-starts. As the
-/// real Claude run unfolds, the deck's hook plugin posts events
-/// that drive the card through Thinking → Working → Idle, with the
-/// `Bash` tool name visible on the card during Working. Runs against
-/// the real Anthropic API; cost is bounded at one Haiku invocation.
+/// real Claude run unfolds, the deck's hook plugin posts events that
+/// drive the card through Thinking → Working (with the `Bash` tool
+/// name visible) and on to a terminal state — either a rendered
+/// `Idle` or, because the one-shot print-mode agent exits the instant
+/// it finishes, the stable "Launch an agent" placeholder the pane
+/// falls back to once the process is gone. Runs against the real
+/// Anthropic API; cost is bounded at one Haiku invocation.
 #[spec("chain-smoke/claude/001")]
 #[test]
 fn claude_001_thinking_working_idle() {
@@ -65,18 +68,30 @@ fn claude_001_thinking_working_idle() {
     // anchor and uses no LLM tokens.
     deck.wait_for_string("claude-smoke");
 
-    // Catalog assertion: status traverses Thinking → Working → Idle,
-    // and the Bash tool name appears on the card during Working.
+    // Catalog assertion: status traverses Thinking → Working (with the
+    // Bash tool name on the card) → a terminal state.
     //
-    // M4.6 P1: `wait_for_strings_in_order` walks the rolling byte
-    // history rather than the live vt100 grid, so two consecutive
-    // status transitions rendered in the same polling window (a
-    // realistic outcome on a fast Haiku response — Thinking →
-    // Working can both land in the same ~20 ms window) both stay
-    // matchable. The previous shape — four sequential
+    // M4.6 P1: the wait walks the rolling byte history rather than the
+    // live vt100 grid, so two consecutive status transitions rendered
+    // in the same polling window (a realistic outcome on a fast Haiku
+    // response — Thinking → Working can both land in the same ~20 ms
+    // window) both stay matchable. The previous shape — four sequential
     // `wait_for_string` calls against the current grid — could spin
     // past `Thinking` if `Working` had already overwritten the card
     // before the first poll, and would then timeout (Decision 9:
     // flake = bug).
-    deck.wait_for_strings_in_order(&["Thinking", "Working", "Bash", "Idle"]);
+    //
+    // prd-77 flake hardening: the strict prefix Thinking → Working →
+    // Bash still proves the live lifecycle ran, but the terminal needle
+    // is print-mode tolerant. A `claude -p` agent COMPLETES AND EXITS
+    // the instant it finishes responding, so the pane can jump from
+    // Bash straight to the stable "No agent" / "Launch an agent to get
+    // started" placeholder before a rendered `Idle` frame survives a
+    // ~20 ms poll. Either a captured `Idle` OR that clean-exit
+    // placeholder (observed AFTER the working lifecycle) satisfies the
+    // terminal condition — both mean the agent ran to completion.
+    deck.wait_for_strings_in_order_then_any(
+        &["Thinking", "Working", "Bash"],
+        &["Idle", "Launch an agent to get started"],
+    );
 }

--- a/tests/e2e_cli_continue_removed.rs
+++ b/tests/e2e_cli_continue_removed.rs
@@ -1,0 +1,106 @@
+#![cfg(feature = "e2e")]
+
+//! PRD #89 Phase 3 — the `--continue` flag is removed from the CLI surface
+//! (M3.1) and invoking it is rejected with a guiding message (M3.4).
+//!
+//! Thin real-binary spawn test — no PTY drive. It runs `dot-agent-deck --help`
+//! and `dot-agent-deck --continue` as plain subprocesses and asserts the flag
+//! is gone from `--help` and rejected (non-zero exit) on use. RED today:
+//! `--continue` is still a declared `clap` argument, so `--help` advertises it
+//! and `dot-agent-deck --continue` is accepted (it exits 0 — the flag parses,
+//! then terminal init fails in a worker without a TTY, but the process still
+//! exits successfully).
+//!
+//! Decision 6: gated behind the `e2e` feature so `cargo test-fast` never
+//! compiles it.
+
+mod common;
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use spec::spec;
+
+/// Path to the freshly-built binary under test (Cargo sets this at
+/// integration-test build time).
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_dot-agent-deck")
+}
+
+/// Run the binary with `args` under an isolated, scrubbed environment so the
+/// spawn can neither read the developer's real session/config nor leak a
+/// long-lived daemon: a per-call tempdir HOME + sockets + state dir, a short
+/// idle-shutdown, and the test max-lifetime backstop. stdin is `/dev/null`;
+/// stdout/stderr are captured. Returns the captured `Output` (combined stdout +
+/// stderr text and the exit status).
+fn run_isolated(args: &[&str]) -> (std::process::Output, String) {
+    let home = common::race_safe_tempdir();
+    let h: &Path = home.path();
+    let mut cmd = Command::new(bin());
+    cmd.args(args);
+    cmd.env_clear();
+    if let Ok(path) = std::env::var("PATH") {
+        cmd.env("PATH", path);
+    }
+    cmd.env("HOME", h);
+    cmd.env("TERM", "xterm-256color");
+    cmd.env("DOT_AGENT_DECK_SOCKET", h.join("hook.sock"));
+    cmd.env("DOT_AGENT_DECK_ATTACH_SOCKET", h.join("attach.sock"));
+    cmd.env("DOT_AGENT_DECK_STATE_DIR", h.join("state"));
+    // Reap any daemon this spawn lazily starts quickly (no clients/agents) and
+    // cap its lifetime as a backstop.
+    cmd.env("DOT_AGENT_DECK_IDLE_SHUTDOWN_SECS", "1");
+    cmd.env("DOT_AGENT_DECK_TEST_MAX_LIFETIME_SECS", "30");
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let out = cmd.output().expect("spawn dot-agent-deck");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Keep `home` alive until after the child has fully exited.
+    drop(home);
+    (out, combined)
+}
+
+/// Scenario: Run `dot-agent-deck --help` and assert its output no longer
+/// advertises `--continue`, then run `dot-agent-deck --continue` and assert the
+/// process exits non-zero with a message that references the flag (guiding the
+/// user toward the new auto-restore default). RED today on both counts:
+/// `--help` still lists `--continue` ("Restore pane session from last exit"),
+/// and `dot-agent-deck --continue` is an accepted flag so the process exits 0
+/// rather than being rejected.
+#[spec("cli/continue-removed/001")]
+#[test]
+fn continue_removed_001_flag_gone_from_cli_surface() {
+    // --- `--help` must no longer advertise the removed flag. ---
+    let (help_out, help_text) = run_isolated(&["--help"]);
+    assert!(
+        help_out.status.success(),
+        "`dot-agent-deck --help` should exit 0, got {:?}.\noutput:\n{help_text}",
+        help_out.status.code()
+    );
+    assert!(
+        !help_text.contains("--continue"),
+        "PRD #89 M3.1: `--continue` must be removed from the CLI surface, but \
+         `dot-agent-deck --help` still lists it. RED until the `clap` argument is deleted \
+         from `Cli`.\n--help output:\n{help_text}"
+    );
+
+    // --- Invoking the removed flag must be rejected, not accepted. ---
+    let (cont_out, cont_text) = run_isolated(&["--continue"]);
+    assert!(
+        !cont_out.status.success(),
+        "PRD #89 M3.4: `dot-agent-deck --continue` must exit non-zero once the flag is \
+         removed (clap rejects the unknown argument). RED today: the flag is still accepted, \
+         so it parses and the process exits successfully (exit {:?}).\noutput:\n{cont_text}",
+        cont_out.status.code()
+    );
+    assert!(
+        cont_text.to_lowercase().contains("continue"),
+        "the rejection should reference the removed `--continue` flag so the user is guided \
+         toward the new auto-restore default, but the error did not mention it.\noutput:\n{cont_text}"
+    );
+}

--- a/tests/e2e_session_restore.rs
+++ b/tests/e2e_session_restore.rs
@@ -1,0 +1,144 @@
+#![cfg(feature = "e2e")]
+
+//! PRD #89 Phase 2 — L2 (real-binary PTY) coverage for *auto-restore on
+//! startup*.
+//!
+//! Phase 1 made the saved-session snapshot continuously fresh; Phase 2 makes
+//! restoring it UNCONDITIONAL on every TUI startup — no `--continue` flag.
+//! Precedence: try daemon hydration first; if hydration produced any panes the
+//! daemon state wins and snapshot restore is skipped; if hydration produced
+//! zero panes (fresh daemon / crash recovery), load and apply the disk
+//! snapshot; if both are empty, land at an empty dashboard.
+//!
+//! These tests drive the REAL binary through a PTY with `DOT_AGENT_DECK_SESSION`
+//! redirected to a test-owned path. No LLM tokens are spent — restored/spawned
+//! panes run `sleep 600` (Agent: none).
+//!
+//! Decision 6: gated behind the `e2e` feature so `cargo test-fast` never
+//! compiles it.
+
+mod common;
+
+use std::path::Path;
+use std::time::Duration;
+
+use common::TuiDeck;
+use spec::spec;
+
+/// Stage a saved-session `session.toml` at `session_file` describing each
+/// `(name, command)` pane, all rooted at `dir` (which must already exist on
+/// disk so the restore path's dir-exists check does not skip them). Hand-rolled
+/// TOML mirroring `dot_agent_deck::config::SavedPane` — the multi-pane analogue
+/// of the harness's private `write_continue_session_file`, but usable WITHOUT
+/// `--continue` (we write only the file; the launch passes no flag).
+fn stage_session_snapshot(session_file: &Path, dir: &Path, panes: &[(&str, &str)]) {
+    let dir = dir.to_str().expect("snapshot dir is UTF-8");
+    let mut s = String::new();
+    for (name, command) in panes {
+        s.push_str("[[panes]]\n");
+        s.push_str(&format!("dir = \"{}\"\n", toml_basic_escape(dir)));
+        s.push_str(&format!("name = \"{}\"\n", toml_basic_escape(name)));
+        s.push_str(&format!("command = \"{}\"\n\n", toml_basic_escape(command)));
+    }
+    std::fs::write(session_file, s).expect("write staged session.toml");
+}
+
+/// Minimal TOML basic-string escape for the values we embed (filesystem paths
+/// and short ASCII names) — backslash and double-quote only, which is all a
+/// Linux tempdir path or a `restored-*` name can contain here.
+fn toml_basic_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Scenario: Stage a `session.toml` describing two dashboard panes
+/// (`restored-alpha`, `restored-beta`, both `sleep 600`) at the path
+/// `DOT_AGENT_DECK_SESSION` points to, then launch the deck against a fresh
+/// (empty) daemon with NO `--continue` flag. Auto-restore must recreate both
+/// saved panes as dashboard cards without any flag. RED today: the snapshot
+/// load is gated behind `if continue_session` in `run_tui`, so with no flag the
+/// block never runs and neither saved pane appears — the dashboard stays at
+/// "No active sessions".
+#[spec("session/restore/001")]
+#[test]
+fn restore_001_no_flag_startup_restores_panes_from_snapshot() {
+    // A test-owned snapshot dir the deck's `session_path()` reads via
+    // `DOT_AGENT_DECK_SESSION`. It also doubles as the restored panes' working
+    // directory — it exists on disk, so the restore path's `dir.is_dir()` guard
+    // keeps both panes (rather than skipping them as missing-dir).
+    let session_dir = common::race_safe_tempdir();
+    let session_file = session_dir.path().join("session.toml");
+    stage_session_snapshot(
+        &session_file,
+        session_dir.path(),
+        &[
+            ("restored-alpha", "sleep 600"),
+            ("restored-beta", "sleep 600"),
+        ],
+    );
+
+    // No `--continue` — `launch_with_fixture` only passes the flag when a
+    // `with_continue_session(...)` was staged, which it was not. The daemon
+    // this deck lazy-spawns is brand new (empty), so hydration yields nothing
+    // and the disk snapshot is the only possible source of panes.
+    let deck = TuiDeck::builder()
+        .with_env(
+            "DOT_AGENT_DECK_SESSION",
+            session_file.to_str().expect("session path is UTF-8"),
+        )
+        .launch_with_fixture("modes");
+
+    // After Phase 2, both saved panes auto-restore as dashboard cards. Their
+    // saved names appear in the card title rows (e.g. "1 restored-alpha").
+    let restored = common::wait_until(Duration::from_secs(10), || {
+        let grid = deck.snapshot_grid();
+        grid.contains("restored-alpha") && grid.contains("restored-beta")
+    });
+    assert!(
+        restored,
+        "PRD #89 M2.1: launching with NO --continue and a 2-pane snapshot on disk must \
+         auto-restore BOTH saved panes (`restored-alpha`, `restored-beta`) as dashboard \
+         cards, but they never appeared. RED until the snapshot-load block in `run_tui` \
+         is made unconditional (today it is gated on `continue_session`).\nFinal grid:\n{}",
+        deck.snapshot_grid()
+    );
+}
+
+/// Scenario: Launch the deck against a fresh (empty) daemon with NO snapshot on
+/// disk and NO `--continue` flag — the both-empty case. The deck must land on a
+/// clean empty dashboard ("No active sessions") with no restore warning, and
+/// remain interactive (Ctrl+N opens the new-pane directory picker). This locks
+/// the post-Phase-2 invariant that making restore unconditional must still fall
+/// through cleanly when there is nothing to restore from either source.
+#[spec("session/restore/006")]
+#[test]
+fn restore_006_empty_daemon_and_no_snapshot_lands_on_clean_dashboard() {
+    let session_dir = common::race_safe_tempdir();
+    let session_file = session_dir.path().join("session.toml");
+    // Nothing staged → `SavedSession::load()` returns the empty default.
+    assert!(
+        !session_file.exists(),
+        "no snapshot must exist for the both-empty case, but one was found at {session_file:?}"
+    );
+
+    let deck = TuiDeck::builder()
+        .with_env(
+            "DOT_AGENT_DECK_SESSION",
+            session_file.to_str().expect("session path is UTF-8"),
+        )
+        .launch_with_fixture("modes");
+
+    // Empty daemon + empty snapshot → the empty-dashboard placeholder.
+    deck.wait_for_string("No active sessions");
+
+    // No restore warning should be surfaced when there is nothing to restore.
+    let grid = deck.snapshot_grid();
+    assert!(
+        !grid.contains("Warning:"),
+        "the both-empty startup must not surface any restore warning, but the dashboard \
+         shows one.\nFinal grid:\n{grid}"
+    );
+
+    // Interactive: the global Ctrl+N opens the new-pane directory picker.
+    deck.send_keys(b"\x0e");
+    deck.wait_for_string("Select Directory");
+}

--- a/tests/e2e_session_restore.rs
+++ b/tests/e2e_session_restore.rs
@@ -50,6 +50,128 @@ fn toml_basic_escape(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
+/// Hand-stage a `session.toml` describing a SINGLE saved pane that carries an
+/// `[panes.orchestration]` block, using the EXACT serialized key names the coder
+/// pinned for `OrchestrationSnapshot` (`version` / `roles` / `start_role_index`
+/// / `orchestrator_prompt` / `config_name` / `project_path` /
+/// `started_role_indices`). The daemon-empty restore path consumes this to
+/// rebuild the orchestration tab (008) or to detect drift and fall back (009).
+#[allow(clippy::too_many_arguments)]
+fn stage_orchestration_snapshot(
+    session_file: &Path,
+    dir: &Path,
+    pane_name: &str,
+    command: &str,
+    roles: &[&str],
+    start_role_index: usize,
+    orchestrator_prompt: &str,
+    config_name: &str,
+    project_path: &Path,
+    started_role_indices: &[usize],
+) {
+    let dir = dir.to_str().expect("snapshot dir is UTF-8");
+    let project_path = project_path.to_str().expect("project_path is UTF-8");
+    let roles_list = roles
+        .iter()
+        .map(|r| format!("\"{}\"", toml_basic_escape(r)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let started_list = started_role_indices
+        .iter()
+        .map(|i| i.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let mut s = String::new();
+    s.push_str("[[panes]]\n");
+    s.push_str(&format!("dir = \"{}\"\n", toml_basic_escape(dir)));
+    s.push_str(&format!("name = \"{}\"\n", toml_basic_escape(pane_name)));
+    s.push_str(&format!("command = \"{}\"\n\n", toml_basic_escape(command)));
+    s.push_str("[panes.orchestration]\n");
+    s.push_str("version = 1\n");
+    s.push_str(&format!("roles = [{roles_list}]\n"));
+    s.push_str(&format!("start_role_index = {start_role_index}\n"));
+    s.push_str(&format!(
+        "orchestrator_prompt = \"{}\"\n",
+        toml_basic_escape(orchestrator_prompt)
+    ));
+    s.push_str(&format!(
+        "config_name = \"{}\"\n",
+        toml_basic_escape(config_name)
+    ));
+    s.push_str(&format!(
+        "project_path = \"{}\"\n",
+        toml_basic_escape(project_path)
+    ));
+    s.push_str(&format!("started_role_indices = [{started_list}]\n"));
+    std::fs::write(session_file, s).expect("write staged orchestration session.toml");
+}
+
+/// Write an orchestration `.dot-agent-deck.toml` into `project_dir`: a single
+/// `[[orchestrations]]` named `config_name` whose roles are `(name, command)`
+/// pairs in order, with the role at `start_idx` flagged `start = true`. The
+/// staged snapshot's `config_name` + `project_path` point here so the restore
+/// branch can re-resolve the `OrchestrationConfig` (008), or — when the names
+/// no longer match — detect drift (009).
+fn write_orchestration_config(
+    project_dir: &Path,
+    config_name: &str,
+    roles: &[(&str, &str)],
+    start_idx: usize,
+) {
+    let mut s = String::new();
+    s.push_str("[[orchestrations]]\n");
+    s.push_str(&format!(
+        "name = \"{}\"\n\n",
+        toml_basic_escape(config_name)
+    ));
+    for (i, (name, command)) in roles.iter().enumerate() {
+        s.push_str("[[orchestrations.roles]]\n");
+        s.push_str(&format!("name = \"{}\"\n", toml_basic_escape(name)));
+        s.push_str(&format!("command = \"{}\"\n", toml_basic_escape(command)));
+        if i == start_idx {
+            s.push_str("start = true\n");
+        }
+        s.push('\n');
+    }
+    std::fs::write(project_dir.join(".dot-agent-deck.toml"), s)
+        .expect("write orchestration .dot-agent-deck.toml");
+}
+
+/// Write a recorder "agent" script into `project_dir` and return its ABSOLUTE
+/// path (to use as a role command). The script records that it started, self-
+/// posts a synthetic `SessionStart` via the real `dot-agent-deck hook` path (the
+/// readiness signal the orchestrator-prompt delivery gate waits on), then
+/// appends every stdin line it receives to an ABSOLUTE `record-<role>.log` under
+/// `project_dir` — so a replayed prompt surfaces as a recorded line, immune to
+/// PTY echo AND independent of the role pane's working directory. Mirrors the
+/// proven recorder pattern in `e2e_mode_seed_prompt.rs`.
+fn write_recorder_agent(project_dir: &Path, role: &str) -> String {
+    let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
+    let script_path = project_dir.join(format!("agent-{role}.sh"));
+    let started = project_dir.join(format!("started-{role}.log"));
+    let record = project_dir.join(format!("record-{role}.log"));
+    let body = format!(
+        "#!/bin/sh\n\
+         echo started >> \"{started}\"\n\
+         printf '%s' '{{\"hook_event_name\":\"SessionStart\",\"session_id\":\"restore-{role}\"}}' \
+         | \"{bin}\" hook claude-code >/dev/null 2>&1\n\
+         while IFS= read -r l; do printf '%s\\n' \"$l\" >> \"{record}\"; done\n",
+        started = started.display(),
+        record = record.display(),
+    );
+    std::fs::write(&script_path, body).expect("write recorder agent script");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod recorder agent script");
+    }
+    script_path
+        .to_str()
+        .expect("recorder script path is UTF-8")
+        .to_string()
+}
+
 /// Scenario: Stage a `session.toml` describing two dashboard panes
 /// (`restored-alpha`, `restored-beta`, both `sleep 600`) at the path
 /// `DOT_AGENT_DECK_SESSION` points to, then launch the deck against a fresh
@@ -141,4 +263,187 @@ fn restore_006_empty_daemon_and_no_snapshot_lands_on_clean_dashboard() {
     // Interactive: the global Ctrl+N opens the new-pane directory picker.
     deck.send_keys(b"\x0e");
     deck.wait_for_string("Select Directory");
+}
+
+/// Scenario: Stage an orchestration `.dot-agent-deck.toml` (`tdd-cycle` with an
+/// `orchestrator`+`coder`+`reviewer` set, the orchestrator a recorder agent) in
+/// a test-owned project dir, then hand-stage a `session.toml` whose single pane
+/// carries a `[panes.orchestration]` block pointing `config_name`/`project_path`
+/// at that dir (with `orchestrator_prompt = "Build the feature end to end"`,
+/// `start_role_index = 0`). Launch against a fresh (empty) daemon with NO flag.
+/// The daemon-empty restore must rebuild the orchestration tab: the `coder` and
+/// `reviewer` role panes appear as deck cards in their saved order, and — unlike
+/// warm hydration — the saved `orchestrator_prompt` is replayed to the start
+/// (orchestrator) role, which the recorder captures (echo-immune). RED today:
+/// there is no snapshot-fallback orchestration restore branch, so the saved pane
+/// comes back as a single plain dashboard card and neither the role panes nor
+/// the prompt replay ever materialize.
+#[spec("session/restore/008")]
+#[test]
+fn restore_008_daemon_empty_snapshot_rebuilds_orchestration_tab() {
+    // The orchestration config + the orchestrator recorder live in a test-owned
+    // project dir the staged snapshot references, so `OrchestrationConfig`
+    // re-resolution succeeds independently of the deck's own (fixture) cwd.
+    let project_dir = common::race_safe_tempdir();
+    let orchestrator_cmd = write_recorder_agent(project_dir.path(), "orchestrator");
+    write_orchestration_config(
+        project_dir.path(),
+        "tdd-cycle",
+        &[
+            ("orchestrator", orchestrator_cmd.as_str()),
+            ("coder", "sleep 600"),
+            ("reviewer", "sleep 600"),
+        ],
+        0,
+    );
+
+    let session_dir = common::race_safe_tempdir();
+    let session_file = session_dir.path().join("session.toml");
+    stage_orchestration_snapshot(
+        &session_file,
+        project_dir.path(),
+        "orchestrator",
+        &orchestrator_cmd,
+        &["orchestrator", "coder", "reviewer"],
+        0,
+        "Build the feature end to end",
+        "tdd-cycle",
+        project_dir.path(),
+        &[0, 1],
+    );
+
+    // No `--continue` flag; the lazy-spawned daemon is brand new (empty), so the
+    // disk snapshot is the only possible source — the snapshot-fallback path.
+    let deck = TuiDeck::builder()
+        .with_env(
+            "DOT_AGENT_DECK_SESSION",
+            session_file.to_str().expect("session path is UTF-8"),
+        )
+        .launch_with_fixture("minimal");
+
+    // The orchestration tab must be rebuilt AND shown (start cursor): its
+    // non-start role panes render as deck cards by role name, in saved order.
+    let rebuilt = common::wait_until(Duration::from_secs(15), || {
+        let g = deck.snapshot_grid();
+        g.contains("coder") && g.contains("reviewer")
+    });
+    assert!(
+        rebuilt,
+        "PRD #89 M2b.3: a daemon-empty launch with an orchestration snapshot on disk must \
+         REBUILD the orchestration tab — the `coder` and `reviewer` role panes must appear as \
+         deck cards — but they never did.\nFinal grid:\n{}",
+        deck.snapshot_grid()
+    );
+
+    // Saved display order: `coder` precedes `reviewer` in the role deck.
+    let grid = deck.snapshot_grid();
+    let coder_row = deck.find_in_grid("coder").map(|(_, r)| r);
+    let reviewer_row = deck.find_in_grid("reviewer").map(|(_, r)| r);
+    assert!(
+        matches!((coder_row, reviewer_row), (Some(c), Some(rv)) if c < rv),
+        "the rebuilt role panes must appear in the SAVED order (coder before reviewer), but \
+         found coder at row {coder_row:?} and reviewer at row {reviewer_row:?}.\nFinal grid:\n{grid}"
+    );
+
+    // start_role_index honored + orchestrator_prompt replayed: the saved prompt
+    // is delivered to the START (orchestrator) role pane and recorded. The
+    // snapshot-fallback path replays it (M2b.3), unlike warm hydration
+    // (session/restore/007), so this line proves both the prompt replay and that
+    // the start role was identified from `start_role_index`.
+    let record = project_dir.path().join("record-orchestrator.log");
+    let replayed = common::wait_for_file_substr_count(
+        &record,
+        "Build the feature end to end",
+        1,
+        Duration::from_secs(15),
+    );
+    assert!(
+        replayed,
+        "PRD #89 M2b.3: the saved `orchestrator_prompt` must be replayed to the start \
+         (orchestrator) role on the snapshot-fallback path, but it was never delivered \
+         (no recorded line at {record:?}).\nFinal grid:\n{}",
+        deck.snapshot_grid()
+    );
+}
+
+/// Scenario: Stage an orchestration `.dot-agent-deck.toml` whose orchestration is
+/// named `renamed-orch`, then hand-stage a `session.toml` whose
+/// `[panes.orchestration]` block still references the OLD `config_name =
+/// "tdd-cycle"` (a config-drift: the orchestration was renamed/removed). Launch
+/// against a fresh (empty) daemon with NO flag. The restore must NOT build a
+/// half-broken orchestration tab: the saved pane falls back to a PLAIN dashboard
+/// card (its saved name `orchestrator`, no `coder`/`reviewer` role panes), and a
+/// clear `session_warnings` message NAMING the missing orchestration
+/// (`tdd-cycle`) is surfaced — flushed to stderr at teardown, so we detach-quit
+/// and scan the byte stream. RED today: there is no snapshot-fallback restore
+/// branch, so no drift is detected and no warning is ever emitted.
+#[spec("session/restore/009")]
+#[test]
+fn restore_009_orchestration_config_drift_warns_and_falls_back_to_plain_pane() {
+    let project_dir = common::race_safe_tempdir();
+    // The project config exists, but the orchestration was renamed — so the
+    // snapshot's `config_name = "tdd-cycle"` no longer resolves.
+    write_orchestration_config(
+        project_dir.path(),
+        "renamed-orch",
+        &[("orchestrator", "sleep 600"), ("coder", "sleep 600")],
+        0,
+    );
+
+    let session_dir = common::race_safe_tempdir();
+    let session_file = session_dir.path().join("session.toml");
+    stage_orchestration_snapshot(
+        &session_file,
+        project_dir.path(),
+        "orchestrator",
+        "sleep 600",
+        &["orchestrator", "coder", "reviewer"],
+        0,
+        "Build the feature end to end",
+        "tdd-cycle", // missing now — the config was renamed to `renamed-orch`
+        project_dir.path(),
+        &[0, 1],
+    );
+
+    let deck = TuiDeck::builder()
+        .with_env(
+            "DOT_AGENT_DECK_SESSION",
+            session_file.to_str().expect("session path is UTF-8"),
+        )
+        .launch_with_fixture("minimal");
+
+    // Fallback: the saved orchestrator pane returns as a PLAIN dashboard card
+    // (its saved name), never an orchestration tab.
+    let fell_back = common::wait_until(Duration::from_secs(10), || {
+        deck.snapshot_grid().contains("orchestrator")
+    });
+    assert!(
+        fell_back,
+        "PRD #89 M2b.3 drift: a snapshot whose orchestration no longer resolves must restore \
+         the saved pane as a PLAIN dashboard card (`orchestrator`), but it never appeared.\n\
+         Final grid:\n{}",
+        deck.snapshot_grid()
+    );
+
+    // It must be a PLAIN pane, NOT a half-broken orchestration tab: the other
+    // roles must not have been spawned.
+    let grid = deck.snapshot_grid();
+    assert!(
+        !grid.contains("reviewer"),
+        "config drift must fall back to a plain pane, never a half-broken orchestration tab — \
+         but a `reviewer` role pane was rebuilt.\nFinal grid:\n{grid}"
+    );
+
+    // The drift must surface a clear warning NAMING the missing orchestration.
+    // `session_warnings` are flushed to stderr at teardown, so detach-quit and
+    // scan the cumulative byte stream. RED today: no drift branch → no warning.
+    //
+    // The restored pane auto-focuses (PaneInput), where Ctrl+C is forwarded to
+    // the pane; detach to Normal mode first so Ctrl+C reaches the global quit.
+    deck.send_keys(b"\x04"); // Ctrl+D → detach to Normal mode
+    deck.wait_for_absence("[Detach Ctrl+D]"); // pane no longer focused
+    deck.send_keys(b"\x03"); // Ctrl+C → quit-confirm modal
+    deck.wait_for_string("Quit dot-agent-deck?");
+    deck.send_keys(b"\r"); // Enter → Detach (default) → clean teardown + flush
+    deck.wait_for_stream_string("tdd-cycle");
 }

--- a/tests/e2e_session_restore.rs
+++ b/tests/e2e_session_restore.rs
@@ -68,6 +68,13 @@ fn stage_orchestration_snapshot(
     config_name: &str,
     project_path: &Path,
     started_role_indices: &[usize],
+    // PRD #89 review-fix F4: an optional user-typed orchestration tab title
+    // (`Tab::Orchestration.name`). `OrchestrationSnapshot` carries no
+    // `display_title` field yet, but it sets no `#[serde(deny_unknown_fields)]`,
+    // so an extra key here parses (ignored) today and is consumed once the coder
+    // adds the field + capture + restore threading. `None` omits the key (the
+    // pre-F4 behavior the existing callers rely on).
+    display_title: Option<&str>,
 ) {
     let dir = dir.to_str().expect("snapshot dir is UTF-8");
     let project_path = project_path.to_str().expect("project_path is UTF-8");
@@ -103,6 +110,12 @@ fn stage_orchestration_snapshot(
         toml_basic_escape(project_path)
     ));
     s.push_str(&format!("started_role_indices = [{started_list}]\n"));
+    if let Some(title) = display_title {
+        s.push_str(&format!(
+            "display_title = \"{}\"\n",
+            toml_basic_escape(title)
+        ));
+    }
     std::fs::write(session_file, s).expect("write staged orchestration session.toml");
 }
 
@@ -135,6 +148,25 @@ fn write_orchestration_config(
     }
     std::fs::write(project_dir.join(".dot-agent-deck.toml"), s)
         .expect("write orchestration .dot-agent-deck.toml");
+}
+
+/// Write an orchestration `.dot-agent-deck.toml` whose single orchestration
+/// `config_name` has an EXPLICIT empty role list (`roles = []`). Unlike
+/// [`write_orchestration_config`], which emits `[[orchestrations.roles]]`
+/// array-of-tables (so an empty slice would omit the required `roles` key and
+/// fail to deserialize), this writes the inline empty array so the config LOADS
+/// with zero roles — `load_project_config` runs no `config_validation`, so the
+/// re-resolved `OrchestrationConfig` is structurally valid but role-less. That
+/// is exactly the un-validated, whittled-down config the F2 restore path must
+/// survive (drift + plain-pane fallback) instead of indexing an empty
+/// `role_pane_ids` at the start-role cursor and panicking at startup.
+fn write_zero_role_orchestration_config(project_dir: &Path, config_name: &str) {
+    let mut s = String::new();
+    s.push_str("[[orchestrations]]\n");
+    s.push_str(&format!("name = \"{}\"\n", toml_basic_escape(config_name)));
+    s.push_str("roles = []\n");
+    std::fs::write(project_dir.join(".dot-agent-deck.toml"), s)
+        .expect("write zero-role orchestration .dot-agent-deck.toml");
 }
 
 /// Write a recorder "agent" script into `project_dir` and return its ABSOLUTE
@@ -310,6 +342,7 @@ fn restore_008_daemon_empty_snapshot_rebuilds_orchestration_tab() {
         "tdd-cycle",
         project_dir.path(),
         &[0, 1],
+        None,
     );
 
     // No `--continue` flag; the lazy-spawned daemon is brand new (empty), so the
@@ -403,6 +436,7 @@ fn restore_009_orchestration_config_drift_warns_and_falls_back_to_plain_pane() {
         "tdd-cycle", // missing now — the config was renamed to `renamed-orch`
         project_dir.path(),
         &[0, 1],
+        None,
     );
 
     let deck = TuiDeck::builder()
@@ -446,4 +480,339 @@ fn restore_009_orchestration_config_drift_warns_and_falls_back_to_plain_pane() {
     deck.wait_for_string("Quit dot-agent-deck?");
     deck.send_keys(b"\r"); // Enter → Detach (default) → clean teardown + flush
     deck.wait_for_stream_string("tdd-cycle");
+}
+
+/// Scenario: Stage an orchestration `.dot-agent-deck.toml` that still defines
+/// `tdd-cycle` but with an EXPLICIT empty role set (`roles = []`), then hand-stage
+/// a `session.toml` whose `[panes.orchestration]` block has an empty saved role
+/// list (so the name+order drift guard passes — saved `[]` equals current `[]`)
+/// but a `start_role_index` of 0 that is out of range for a role-less config.
+/// Launch against a fresh (empty) daemon with NO flag. The restore must NOT
+/// reach into the empty `role_pane_ids` at the start cursor and panic
+/// (startup crash-loop): it must treat the zero-role re-resolution as drift,
+/// restore the saved pane as a PLAIN dashboard card (`orchestrator`), and surface
+/// a `session_warnings` message naming the orchestration (`tdd-cycle`), flushed
+/// to stderr on a clean detach-quit. RED today: `resolve_orchestration_for_restore`
+/// only compares names (it passes for `[] == []`) and `load_project_config` runs
+/// no validation, so the rebuild proceeds and `role_pane_ids[start_idx]` indexes
+/// an empty vec — panicking at startup before any fallback pane appears.
+#[spec("session/restore/010")]
+#[test]
+fn restore_010_zero_role_reresolved_orchestration_falls_back_without_panic() {
+    let project_dir = common::race_safe_tempdir();
+    // The project config still names `tdd-cycle`, but its role set was whittled
+    // to empty — load_project_config does not run config_validation, so this
+    // re-resolves to a structurally valid yet role-less OrchestrationConfig.
+    write_zero_role_orchestration_config(project_dir.path(), "tdd-cycle");
+
+    let session_dir = common::race_safe_tempdir();
+    let session_file = session_dir.path().join("session.toml");
+    // Empty saved role set → the name+order drift guard passes (saved [] ==
+    // current []), so the rebuild proceeds into the start-role index path; the
+    // saved start cursor (0) is out of range for a zero-role config.
+    stage_orchestration_snapshot(
+        &session_file,
+        project_dir.path(),
+        "orchestrator",
+        "sleep 600",
+        &[], // zero saved roles — matches the whittled config
+        0,   // start cursor 0 — out of range for an empty role set
+        "Build the feature end to end",
+        "tdd-cycle",
+        project_dir.path(),
+        &[],
+        None,
+    );
+
+    let deck = TuiDeck::builder()
+        .with_env(
+            "DOT_AGENT_DECK_SESSION",
+            session_file.to_str().expect("session path is UTF-8"),
+        )
+        .launch_with_fixture("minimal");
+
+    // No panic / crash-loop: the saved pane returns as a PLAIN dashboard card
+    // (its saved name `orchestrator`). RED today: the startup panic prevents any
+    // pane from ever rendering, so this times out — the final grid captures the
+    // `index out of bounds` panic text rather than a dashboard.
+    let fell_back = common::wait_until(Duration::from_secs(10), || {
+        deck.snapshot_grid().contains("orchestrator")
+    });
+    assert!(
+        fell_back,
+        "PRD #89 review-fix F2: a snapshot re-resolving to a zero-role orchestration must \
+         fall back to a PLAIN dashboard pane (`orchestrator`) WITHOUT panicking, but the \
+         pane never appeared — the restore path likely panicked indexing an empty \
+         role_pane_ids at startup.\nFinal grid:\n{}",
+        deck.snapshot_grid()
+    );
+
+    // The drift must surface a clear warning NAMING the orchestration, flushed
+    // to stderr at clean teardown — which a panicked process can never reach.
+    // The restored pane auto-focuses (PaneInput); detach to Normal mode first so
+    // Ctrl+C reaches the global quit (mirrors session/restore/009).
+    deck.send_keys(b"\x04"); // Ctrl+D → detach to Normal mode
+    deck.wait_for_absence("[Detach Ctrl+D]"); // pane no longer focused
+    deck.send_keys(b"\x03"); // Ctrl+C → quit-confirm modal
+    deck.wait_for_string("Quit dot-agent-deck?");
+    deck.send_keys(b"\r"); // Enter → Detach (default) → clean teardown + flush
+    deck.wait_for_stream_string("tdd-cycle");
+}
+
+/// Scenario: Stage an orchestration `.dot-agent-deck.toml` named `tdd-cycle`
+/// whose CONFIG default start role is `orchestrator` (index 0, `start = true`),
+/// with a recorder agent on BOTH roles (`orchestrator` at 0, `coder` at 1). Then
+/// hand-stage a `session.toml` whose `[panes.orchestration]` block saves a
+/// `start_role_index` of 1 (`coder`) — a cursor that DIFFERS from the config
+/// default. Launch against a fresh (empty) daemon with NO flag. The saved start
+/// cursor must be HONORED: the replayed `orchestrator_prompt` must land on the
+/// role at the SAVED index (`coder`, index 1) and be recorded there, NOT on the
+/// config-default start role (`orchestrator`, index 0). RED today: the restore
+/// branch recomputes the start from the live config
+/// (`roles.iter().position(|r| r.start)`) and never reads `snap.start_role_index`,
+/// so the prompt is delivered to `orchestrator` and `coder` never receives it.
+#[spec("session/restore/011")]
+#[test]
+fn restore_011_saved_start_role_index_is_honored_over_config_default() {
+    let project_dir = common::race_safe_tempdir();
+    let orchestrator_cmd = write_recorder_agent(project_dir.path(), "orchestrator");
+    let coder_cmd = write_recorder_agent(project_dir.path(), "coder");
+    // Config default start = `orchestrator` (index 0). The snapshot will point
+    // the saved cursor at `coder` (index 1) instead.
+    write_orchestration_config(
+        project_dir.path(),
+        "tdd-cycle",
+        &[
+            ("orchestrator", orchestrator_cmd.as_str()),
+            ("coder", coder_cmd.as_str()),
+        ],
+        0, // start = true on `orchestrator` — the CONFIG DEFAULT cursor
+    );
+
+    let session_dir = common::race_safe_tempdir();
+    let session_file = session_dir.path().join("session.toml");
+    stage_orchestration_snapshot(
+        &session_file,
+        project_dir.path(),
+        "orchestrator",
+        &orchestrator_cmd,
+        &["orchestrator", "coder"],
+        1, // SAVED start cursor = `coder` (index 1), NOT the config default
+        "Build the feature end to end",
+        "tdd-cycle",
+        project_dir.path(),
+        &[1],
+        None,
+    );
+
+    let deck = TuiDeck::builder()
+        .with_env(
+            "DOT_AGENT_DECK_SESSION",
+            session_file.to_str().expect("session path is UTF-8"),
+        )
+        .launch_with_fixture("minimal");
+
+    // The orchestration tab rebuilds: the non-start role renders as a deck card.
+    let rebuilt = common::wait_until(Duration::from_secs(15), || {
+        let g = deck.snapshot_grid();
+        g.contains("orchestrator") && g.contains("coder")
+    });
+    assert!(
+        rebuilt,
+        "the orchestration tab must rebuild (orchestrator + coder role panes) before the \
+         start-cursor delivery can be observed.\nFinal grid:\n{}",
+        deck.snapshot_grid()
+    );
+
+    // HONORED: the role at the SAVED index (1 = `coder`) receives the replayed
+    // prompt. RED today: restore uses the config-default start (0 = orchestrator),
+    // so the coder recorder never sees the prompt and this times out.
+    let coder_record = project_dir.path().join("record-coder.log");
+    let honored = common::wait_for_file_substr_count(
+        &coder_record,
+        "Build the feature end to end",
+        1,
+        Duration::from_secs(15),
+    );
+    assert!(
+        honored,
+        "PRD #89 review-fix F3: the SAVED `start_role_index` (1 = coder) must be honored on \
+         restore — the orchestrator_prompt must be replayed to the role at the saved index — \
+         but `coder` never received it (no recorded line at {coder_record:?}). The restore \
+         path recomputes the start from the config default instead.\nFinal grid:\n{}",
+        deck.snapshot_grid()
+    );
+
+    // And the config-default start role (0 = `orchestrator`) must NOT have
+    // received it — proving the SAVED cursor, not the config `start` flag, drove
+    // delivery. (Single-shot delivery: once `coder` got it, this stays empty.)
+    let orchestrator_record = project_dir.path().join("record-orchestrator.log");
+    assert!(
+        !common::wait_for_file_substr_count(
+            &orchestrator_record,
+            "Build the feature end to end",
+            1,
+            Duration::from_secs(2),
+        ),
+        "the config-default start role (`orchestrator`, index 0) must NOT receive the prompt \
+         when the saved cursor points elsewhere — but it did, at {orchestrator_record:?}."
+    );
+}
+
+/// Scenario: Stage TWO directories — a legitimate saved working dir (no
+/// orchestration config) and a SEPARATE planted dir whose `.dot-agent-deck.toml`
+/// defines a `tdd-cycle` orchestration with a uniquely-named `phantom-reviewer`
+/// role. Hand-stage a `session.toml` whose saved pane `dir` points at the saved
+/// dir while its `[panes.orchestration]` `project_path` points at the planted
+/// dir (a DIVERGENCE: capture always writes them equal, so this only happens via
+/// tampering). Launch against a fresh (empty) daemon with NO flag. The divergent
+/// `project_path` config must NOT be auto-run: the planted `phantom-reviewer`
+/// role must never materialize as a deck card; the saved pane must still restore
+/// as a PLAIN card. RED today: restore re-resolves the OrchestrationConfig from
+/// the un-cross-checked `project_path` and auto-runs the planted config, spawning
+/// `phantom-reviewer`.
+#[spec("session/restore/012")]
+#[test]
+fn restore_012_divergent_project_path_does_not_auto_run_planted_config() {
+    // The legitimate saved working directory — what `saved_pane.dir` records. It
+    // holds NO orchestration config, so a re-resolution from HERE correctly
+    // drifts to a plain pane.
+    let saved_dir = common::race_safe_tempdir();
+
+    // A separate, attacker-influenced directory whose planted config defines a
+    // uniquely-named `phantom-reviewer` role. The snapshot's `project_path`
+    // points HERE while `saved_pane.dir` points at `saved_dir`.
+    let planted_dir = common::race_safe_tempdir();
+    write_orchestration_config(
+        planted_dir.path(),
+        "tdd-cycle",
+        &[
+            ("orchestrator", "sleep 600"),
+            ("phantom-reviewer", "sleep 600"),
+        ],
+        0,
+    );
+
+    let session_dir = common::race_safe_tempdir();
+    let session_file = session_dir.path().join("session.toml");
+    // `dir` (saved_pane.dir) = saved_dir; `project_path` = planted_dir — the
+    // divergence. The saved role set matches the planted config so today's
+    // name+order drift guard passes and the planted config would auto-run.
+    stage_orchestration_snapshot(
+        &session_file,
+        saved_dir.path(), // saved_pane.dir — the legitimate working dir
+        "orchestrator",
+        "sleep 600",
+        &["orchestrator", "phantom-reviewer"],
+        0,
+        "Build the feature end to end",
+        "tdd-cycle",
+        planted_dir.path(), // project_path — DIVERGES from saved_pane.dir
+        &[0],
+        None,
+    );
+
+    let deck = TuiDeck::builder()
+        .with_env(
+            "DOT_AGENT_DECK_SESSION",
+            session_file.to_str().expect("session path is UTF-8"),
+        )
+        .launch_with_fixture("minimal");
+
+    // The divergent-path config must NOT be executed: poll for its uniquely-named
+    // `phantom-reviewer` role to (wrongly) appear. `true` means the bug
+    // reproduced — RED today, since restore auto-runs the planted config.
+    let auto_ran = common::wait_until(Duration::from_secs(10), || {
+        deck.snapshot_grid().contains("phantom-reviewer")
+    });
+    assert!(
+        !auto_ran,
+        "PRD #89 review-fix F1: a snapshot whose `project_path` diverges from `saved_pane.dir` \
+         must NOT auto-run the config planted at `project_path`, but the `phantom-reviewer` \
+         role from {planted} was executed.\nFinal grid:\n{grid}",
+        planted = planted_dir.path().display(),
+        grid = deck.snapshot_grid()
+    );
+
+    // Positive guard: restore still ran — the saved pane returns as a PLAIN card
+    // (`orchestrator`), proving the test asserted a refusal, not a no-op load.
+    let restored = common::wait_until(Duration::from_secs(10), || {
+        deck.snapshot_grid().contains("orchestrator")
+    });
+    assert!(
+        restored,
+        "the saved pane must still restore (as a plain card `orchestrator`) when the \
+         divergent planted config is refused.\nFinal grid:\n{}",
+        deck.snapshot_grid()
+    );
+}
+
+/// Scenario: Stage an orchestration `.dot-agent-deck.toml` (`tdd-cycle` with an
+/// `orchestrator`+`coder` set) and hand-stage a `session.toml` whose
+/// `[panes.orchestration]` block carries a custom `display_title`
+/// (`MYDECKTITLE`) distinct from the canonical config name. Launch against a
+/// fresh (empty) daemon with NO flag. The rebuilt orchestration tab must show the
+/// user's saved title in the tab bar — not the canonical `tdd-cycle` config/cwd
+/// name. RED today (RED-pending-schema): `OrchestrationSnapshot` has no
+/// `display_title` field and restore passes `None` to `open_orchestration_tab`,
+/// so the staged key is dropped on load and the tab comes back titled
+/// `tdd-cycle`. Goes GREEN once the coder adds the field, captures it, and
+/// threads it through restore.
+#[spec("session/restore/013")]
+#[test]
+fn restore_013_custom_orchestration_tab_title_is_preserved_on_restore() {
+    let project_dir = common::race_safe_tempdir();
+    write_orchestration_config(
+        project_dir.path(),
+        "tdd-cycle",
+        &[("orchestrator", "sleep 600"), ("coder", "sleep 600")],
+        0,
+    );
+
+    let session_dir = common::race_safe_tempdir();
+    let session_file = session_dir.path().join("session.toml");
+    stage_orchestration_snapshot(
+        &session_file,
+        project_dir.path(),
+        "orchestrator",
+        "sleep 600",
+        &["orchestrator", "coder"],
+        0,
+        "Build the feature end to end",
+        "tdd-cycle",
+        project_dir.path(),
+        &[0],
+        Some("MYDECKTITLE"), // custom user title, distinct from `tdd-cycle`
+    );
+
+    let deck = TuiDeck::builder()
+        .with_env(
+            "DOT_AGENT_DECK_SESSION",
+            session_file.to_str().expect("session path is UTF-8"),
+        )
+        .launch_with_fixture("minimal");
+
+    // The tab rebuilds (non-start role card appears), so a title exists to check.
+    let rebuilt = common::wait_until(Duration::from_secs(15), || {
+        deck.snapshot_grid().contains("coder")
+    });
+    assert!(
+        rebuilt,
+        "the orchestration tab must rebuild before its title can be observed.\nFinal grid:\n{}",
+        deck.snapshot_grid()
+    );
+
+    // The rebuilt tab must carry the user's saved title in the tab bar. RED
+    // today: the title is the canonical `tdd-cycle` because `display_title` is
+    // not yet part of the snapshot schema (RED-pending-schema).
+    let titled = common::wait_until(Duration::from_secs(5), || {
+        deck.snapshot_grid().contains("MYDECKTITLE")
+    });
+    assert!(
+        titled,
+        "PRD #89 review-fix F4: a custom orchestration tab `display_title` (`MYDECKTITLE`) \
+         saved in the snapshot must be preserved on restore — the rebuilt tab must show the \
+         user title, not the canonical config/cwd name (`tdd-cycle`).\nFinal grid:\n{}",
+        deck.snapshot_grid()
+    );
 }

--- a/tests/e2e_session_save.rs
+++ b/tests/e2e_session_save.rs
@@ -155,3 +155,87 @@ fn save_002_detach_path_writes_snapshot() {
         session_file.exists()
     );
 }
+
+/// Drive the new-pane dialog to open the single orchestration in the `orch-deck`
+/// fixture. With no `[[modes]]` defined the Mode chip row is `[No mode] [Orch:
+/// demo-orch] [schedule]`, so ONE Right selects the orchestration; selecting an
+/// orchestration HIDES the Command field, so a second Enter submits the form.
+/// Mirrors `e2e_dashboard_selection`'s `open_orchestration`.
+fn open_orchestration(deck: &TuiDeck) {
+    deck.send_keys(b"\x0e"); // Ctrl+n → directory picker
+    deck.send_keys(b" "); // Space → confirm current dir → new-pane form
+    deck.wait_for_string("No mode"); // form up, Mode field focused at "No mode"
+    deck.send_keys(b"\x1b[C"); // Right → [Orch: demo-orch]
+    deck.send_keys(b"\r"); // Mode → Name
+    deck.send_keys(b"\r"); // submit (Command hidden for an orchestration)
+}
+
+/// Scenario: Launch the deck against the `orch-deck` fixture (one orchestration
+/// `demo-orch` with `orchestrator`+`worker` `cat` roles) with
+/// `DOT_AGENT_DECK_SESSION` redirected to a test-owned path, then open the
+/// orchestration via the new-pane form (Ctrl+N → Right → Enter → Enter) and DO
+/// NOT quit. Opening an orchestration tab is a meaningful state change (Phase 1
+/// M1.1), so the coalescer flushes a fresh snapshot — and that snapshot must
+/// capture the orchestration metadata (a `[panes.orchestration]` block carrying
+/// the resolved `config_name`, the roles in display order, and the
+/// `start_role_index`) so the daemon-empty restore path can later rebuild the
+/// tab. RED today: the snapshot builder never populates `SavedPane.orchestration`
+/// (it writes `orchestration = None`) and the orchestration SpawnPane path
+/// records no `pane_metadata` for the role panes, so no `[panes.orchestration]`
+/// block is ever written.
+#[spec("session/save/004")]
+#[test]
+fn save_004_orchestration_tab_capture_writes_orchestration_metadata() {
+    let session_dir = common::race_safe_tempdir();
+    let session_file = session_dir.path().join("session.toml");
+
+    let deck = TuiDeck::builder()
+        .with_env(
+            "DOT_AGENT_DECK_SESSION",
+            session_file.to_str().expect("session path is UTF-8"),
+        )
+        .launch_with_fixture("orch-deck");
+    deck.wait_for_string("No active sessions");
+
+    // Open the orchestration tab; its two `cat` role panes render as deck cards.
+    open_orchestration(&deck);
+    deck.wait_for_string("worker"); // the 2nd role card → orchestration tab is up
+
+    // The flushed snapshot MUST carry the orchestration metadata. RED today:
+    // capture is deferred to Step 2, so the `[panes.orchestration]` block never
+    // appears (the snapshot has empty `pane_metadata` for orchestration panes,
+    // so it is cleared rather than written with the block).
+    let captured = common::wait_for_file_substr_count(
+        &session_file,
+        "[panes.orchestration]",
+        1,
+        Duration::from_secs(10),
+    );
+    assert!(
+        captured,
+        "opening an orchestration tab must capture orchestration metadata into the snapshot \
+         (PRD #89 M2b.2/M2b.3 capture): a `[panes.orchestration]` block must be written to \
+         {session_file:?} WITHOUT quitting, but none appeared.\nFile contents: {:?}",
+        std::fs::read_to_string(&session_file).ok()
+    );
+
+    // The captured block must name the resolved orchestration config, its roles
+    // (in display order), and the start cursor so the restore branch can rebuild
+    // the tab faithfully.
+    let toml = std::fs::read_to_string(&session_file).unwrap_or_default();
+    assert!(
+        toml.contains("config_name = \"demo-orch\""),
+        "the captured orchestration block must record the resolved config name \
+         (`config_name = \"demo-orch\"`).\nFile contents:\n{toml}"
+    );
+    assert!(
+        toml.contains("orchestrator") && toml.contains("worker"),
+        "the captured orchestration block must record both fixture roles \
+         (`orchestrator`, `worker`).\nFile contents:\n{toml}"
+    );
+    assert!(
+        toml.contains("start_role_index = 0"),
+        "the captured orchestration block must record the start cursor \
+         (`start_role_index = 0`, the `start = true` orchestrator at index 0).\nFile contents:\n{toml}"
+    );
+}

--- a/tests/e2e_session_save.rs
+++ b/tests/e2e_session_save.rs
@@ -1,0 +1,157 @@
+#![cfg(feature = "e2e")]
+
+//! PRD #89 Phase 1 — L2 (real-binary PTY) coverage for *snapshot freshness*.
+//!
+//! Today the saved-session snapshot is written ONLY at clean teardown/quit
+//! (`run_tui`'s pre-teardown `config::SavedSession::snapshot(...)` block). PRD
+//! #89 Phase 1 makes it continuously fresh: the snapshot must also be written
+//! on meaningful TUI state changes (M1.2 — new pane, rename, tab open/close…)
+//! and on the detach paths (M1.3 — Ctrl+W close-pane, disconnect, detach from
+//! the quit dialog), coalesced so a burst of changes is one or two writes.
+//!
+//! These two tests drive the REAL binary through a PTY with
+//! `DOT_AGENT_DECK_SESSION` redirected to a test-owned path, perform a state
+//! change / detach WITHOUT quitting, and assert the snapshot file on disk
+//! reflects it. They are RED until M1.2/M1.3 land: the only writer today is
+//! teardown, which these tests never reach.
+//!
+//! No LLM tokens are spent — the panes run `sleep 600` (Agent: none).
+//!
+//! Decision 6: gated behind the `e2e` feature so `cargo test-fast` never
+//! compiles it.
+
+mod common;
+
+use std::time::Duration;
+
+use common::TuiDeck;
+use spec::spec;
+
+/// Create a plain dashboard pane (no mode) running `command` via the new-pane
+/// flow, then wait until it has spawned and auto-focused (PaneInput → the
+/// bottom bar shows `[Detach Ctrl+D]`). Mirrors `e2e_dashboard_selection`'s
+/// `spawn_mode` minus the mode-selection Right(s): Ctrl+N → dir-picker (Space
+/// confirms the cwd) → form (Enter past Mode, Enter past the default Name, type
+/// the command, Enter submits). The leading Ctrl+D guarantees we drive the
+/// global Ctrl+N from Normal mode even when a previously spawned pane left us in
+/// PaneInput (a no-op when already Normal).
+fn spawn_plain_pane(deck: &TuiDeck, command: &str) {
+    deck.send_keys(b"\x04"); // Ctrl+D → Normal mode (no-op if already Normal)
+    deck.send_keys(b"\x0e"); // Ctrl+N → directory picker
+    deck.wait_for_string("Select Directory");
+    deck.send_keys(b" "); // Space → confirm current dir → new-pane form
+    deck.wait_for_string("No mode"); // form up, Mode field focused at "No mode"
+    deck.send_keys(b"\r"); // Mode → Name
+    deck.send_keys(b"\r"); // Name (default) → Command
+    deck.send_keys(command.as_bytes());
+    deck.send_keys(b"\r"); // submit
+    deck.wait_for_string("[Detach Ctrl+D]"); // pane spawned & auto-focused
+}
+
+/// Scenario: Launch the deck with `DOT_AGENT_DECK_SESSION` redirected to a
+/// test-owned path that has NO prior snapshot, then create a new dashboard pane
+/// running `sleep 600` via the new-pane flow (Ctrl+N → Space → form → submit)
+/// and DO NOT quit. The new pane is a meaningful TUI state change, so a fresh
+/// `session.toml` must be written to that path containing the new pane's
+/// `sleep 600` command. RED today: the snapshot is only written at clean
+/// teardown/quit, which this test never reaches — so the file never appears.
+#[spec("session/save/001")]
+#[test]
+fn save_001_new_pane_state_change_writes_snapshot() {
+    // A test-owned snapshot path the deck's `session_path()` will read/write
+    // (via the `DOT_AGENT_DECK_SESSION` env). Kept alive for the whole test so
+    // the dir is not reaped early.
+    let session_dir = common::race_safe_tempdir();
+    let session_file = session_dir.path().join("session.toml");
+
+    let deck = TuiDeck::builder()
+        .with_env(
+            "DOT_AGENT_DECK_SESSION",
+            session_file.to_str().expect("session path is UTF-8"),
+        )
+        .launch_with_fixture("modes");
+    deck.wait_for_string("No active sessions");
+
+    // Precondition: a fresh launch (no `--continue`, restore not yet wired)
+    // must not have written any snapshot yet — the RED signal below is purely
+    // "the state change wrote nothing".
+    assert!(
+        !session_file.exists(),
+        "no prior snapshot must exist at launch, but one was found at {session_file:?}"
+    );
+
+    // Meaningful state change WITHOUT quitting: create a new dashboard pane.
+    spawn_plain_pane(&deck, "sleep 600");
+
+    // The snapshot must now reflect the new pane. RED today (only teardown
+    // writes the snapshot; we never quit), so the file never appears.
+    let written =
+        common::wait_for_file_substr_count(&session_file, "sleep 600", 1, Duration::from_secs(10));
+    assert!(
+        written,
+        "creating a new dashboard pane is a meaningful state change (PRD #89 M1.2): a fresh \
+         snapshot containing the pane's `sleep 600` command must be written to \
+         {session_file:?} WITHOUT quitting, but no such snapshot appeared.\nFile exists: {}",
+        session_file.exists()
+    );
+}
+
+/// Scenario: Launch the deck with `DOT_AGENT_DECK_SESSION` redirected to a
+/// test-owned path, create two `sleep 600` dashboard panes, detach to Normal
+/// mode and arm the dashboard selection (`j` → `▸`), then DELETE any snapshot
+/// already on disk and close the selected pane with Ctrl+W. Closing a pane is a
+/// detach path that must flush a fresh snapshot reflecting the (still non-empty)
+/// workspace — so a new `session.toml` containing a surviving `sleep 600` pane
+/// must reappear, without quitting. RED today: Ctrl+W tears the pane down but
+/// writes no snapshot (only clean teardown does), so the deleted file never
+/// comes back.
+#[spec("session/save/002")]
+#[test]
+fn save_002_detach_path_writes_snapshot() {
+    let session_dir = common::race_safe_tempdir();
+    let session_file = session_dir.path().join("session.toml");
+
+    let deck = TuiDeck::builder()
+        .with_env(
+            "DOT_AGENT_DECK_SESSION",
+            session_file.to_str().expect("session path is UTF-8"),
+        )
+        .launch_with_fixture("modes");
+    deck.wait_for_string("No active sessions");
+
+    // Two dashboard panes present → a real workspace to detach from.
+    spawn_plain_pane(&deck, "sleep 600");
+    spawn_plain_pane(&deck, "sleep 600");
+
+    // Detach to Normal mode and confirm both panes registered as cards.
+    deck.send_keys(b"\x04"); // Ctrl+D → Normal mode / Dashboard
+    deck.wait_for_string("2 session(s)");
+
+    // Arm the dashboard selection so Ctrl+W has a concrete card to close
+    // (PRD #113: the destructive close is a no-op on an unarmed dashboard).
+    deck.send_keys(b"j");
+    deck.wait_for_string("\u{25b8}"); // ▸ — a card is highlighted
+
+    // Remove any snapshot already written by the new-pane state changes (M1.2)
+    // so the assertion below is provably driven by the detach path (M1.3), not
+    // a stale earlier write.
+    let _ = std::fs::remove_file(&session_file);
+
+    // Detach path: close the selected pane with Ctrl+W. One card remains, so
+    // the workspace is still non-empty.
+    deck.send_keys(b"\x17"); // Ctrl+W → CloseSelected
+    deck.wait_for_string("1 session(s)"); // close took effect
+
+    // The detach must have flushed a fresh snapshot reflecting the surviving
+    // workspace. RED today: Ctrl+W writes no snapshot (only clean teardown
+    // does), so the deleted file never reappears.
+    let written =
+        common::wait_for_file_substr_count(&session_file, "sleep 600", 1, Duration::from_secs(10));
+    assert!(
+        written,
+        "closing a pane with Ctrl+W is a detach path (PRD #89 M1.3): a fresh snapshot \
+         reflecting the surviving `sleep 600` workspace must be flushed to {session_file:?} \
+         WITHOUT quitting, but no such snapshot reappeared after the close.\nFile exists: {}",
+        session_file.exists()
+    );
+}

--- a/tests/e2e_session_snapshot.rs
+++ b/tests/e2e_session_snapshot.rs
@@ -1,0 +1,194 @@
+#![cfg(feature = "e2e")]
+
+//! PRD #89 Phase 4 — the two *fresh-start escape hatches*.
+//!
+//! Auto-restore is now the default (Phase 2/2b), so a user who wants to start
+//! clean needs one obvious action. There are two:
+//!
+//!   * **Local (M4.2):** a NEW `dot-agent-deck snapshot clear` subcommand deletes
+//!     the local saved-session snapshot. `snapshot` is a subcommand GROUP with a
+//!     `clear` action (decided in `.dot-agent-deck/prd-89-context.md`; NOT
+//!     `reset`/`--reset`). It does not exist yet.
+//!   * **Remote / per-deck (M4.1):** removing a registered deck
+//!     (`dot-agent-deck remote remove <name>`) should also clear that deck's
+//!     saved state.
+//!
+//! Both are thin real-binary subprocess spawns — no PTY drive is needed. Each
+//! redirects `DOT_AGENT_DECK_SESSION` to a test-owned snapshot path (and
+//! `DOT_AGENT_DECK_REMOTES` to a test-owned registry) so the spawn never reads
+//! or mutates the developer's real session/registry, and so nothing escapes the
+//! per-call tempdir.
+//!
+//! Decision 6: gated behind the `e2e` feature so `cargo test-fast` never
+//! compiles it.
+
+mod common;
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use spec::spec;
+
+/// Path to the freshly-built binary under test (Cargo sets this at
+/// integration-test build time).
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_dot-agent-deck")
+}
+
+/// Run the binary with `args` under an isolated, scrubbed environment so the
+/// spawn can neither read the developer's real session/config/registry nor leak
+/// a long-lived daemon: a per-call tempdir HOME + sockets + state dir, a short
+/// idle-shutdown, and the test max-lifetime backstop. `extra_env` adds the
+/// test-owned `DOT_AGENT_DECK_SESSION` / `DOT_AGENT_DECK_REMOTES` overrides.
+/// stdin is `/dev/null`; stdout/stderr are captured. Returns the captured
+/// `Output` (combined stdout + stderr text and the exit status). Mirrors
+/// `e2e_cli_continue_removed.rs`'s `run_isolated`, generalized over env.
+fn run_isolated(args: &[&str], extra_env: &[(&str, &Path)]) -> (std::process::Output, String) {
+    let home = common::race_safe_tempdir();
+    let h: &Path = home.path();
+    let mut cmd = Command::new(bin());
+    cmd.args(args);
+    cmd.env_clear();
+    if let Ok(path) = std::env::var("PATH") {
+        cmd.env("PATH", path);
+    }
+    cmd.env("HOME", h);
+    cmd.env("TERM", "xterm-256color");
+    cmd.env("DOT_AGENT_DECK_SOCKET", h.join("hook.sock"));
+    cmd.env("DOT_AGENT_DECK_ATTACH_SOCKET", h.join("attach.sock"));
+    cmd.env("DOT_AGENT_DECK_STATE_DIR", h.join("state"));
+    // Reap any daemon this spawn lazily starts quickly (no clients/agents) and
+    // cap its lifetime as a backstop.
+    cmd.env("DOT_AGENT_DECK_IDLE_SHUTDOWN_SECS", "1");
+    cmd.env("DOT_AGENT_DECK_TEST_MAX_LIFETIME_SECS", "30");
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let out = cmd.output().expect("spawn dot-agent-deck");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    // Keep `home` alive until after the child has fully exited.
+    drop(home);
+    (out, combined)
+}
+
+/// Stage a non-empty saved-session `session.toml` at `session_file` describing a
+/// single dashboard pane, so the "is the snapshot gone afterward?" assertions
+/// have a real file to clear (not a no-op on an absent file).
+fn stage_nonempty_snapshot(session_file: &Path, dir: &Path) {
+    let dir = dir.to_str().expect("snapshot dir is UTF-8");
+    let s = format!(
+        "[[panes]]\ndir = \"{}\"\nname = \"restored-pane\"\ncommand = \"sleep 600\"\n",
+        dir.replace('\\', "\\\\").replace('"', "\\\"")
+    );
+    std::fs::write(session_file, s).expect("write staged session.toml");
+}
+
+/// Scenario: Stage a non-empty `session.toml` at the path
+/// `DOT_AGENT_DECK_SESSION` points to, then run `dot-agent-deck snapshot clear`
+/// as a plain subprocess. The new local fresh-start escape hatch must exit 0 and
+/// delete the snapshot file, so a subsequent no-flag startup would land on an
+/// empty dashboard. RED today: the `snapshot` subcommand group does not exist, so
+/// `clap` rejects `snapshot` as an unrecognized subcommand (non-zero exit) and
+/// the staged file is left untouched.
+#[spec("session/snapshot/001")]
+#[test]
+fn snapshot_001_snapshot_clear_deletes_local_snapshot() {
+    let session_dir = common::race_safe_tempdir();
+    let session_file = session_dir.path().join("session.toml");
+    stage_nonempty_snapshot(&session_file, session_dir.path());
+
+    // Precondition: a real snapshot is on disk before we clear it.
+    assert!(
+        session_file.exists(),
+        "the staged snapshot must exist before `snapshot clear`, but none was found at \
+         {session_file:?}"
+    );
+
+    let (out, text) = run_isolated(
+        &["snapshot", "clear"],
+        &[("DOT_AGENT_DECK_SESSION", session_file.as_path())],
+    );
+
+    // The new subcommand must succeed. RED today: `snapshot` is not a declared
+    // subcommand, so `clap` rejects it and the process exits non-zero.
+    assert!(
+        out.status.success(),
+        "PRD #89 M4.2: `dot-agent-deck snapshot clear` must exit 0, but it exited {:?}. \
+         RED until the `snapshot` subcommand group (with a `clear` action) is added to the \
+         CLI — today `clap` rejects `snapshot` as an unrecognized subcommand.\noutput:\n{text}",
+        out.status.code()
+    );
+
+    // …and it must actually delete the local snapshot (the fresh-start payoff).
+    assert!(
+        !session_file.exists(),
+        "PRD #89 M4.2: `dot-agent-deck snapshot clear` must DELETE the local snapshot at \
+         {session_file:?}, but the file is still present afterward.\noutput:\n{text}"
+    );
+}
+
+/// Stage a `remotes.toml` registry at `remotes_file` carrying a single entry
+/// named `name`, so `dot-agent-deck remote remove <name>` has a deck to remove
+/// (the command errors on an unknown name). Hand-rolled TOML mirroring
+/// `dot_agent_deck::remote::RemoteEntry`'s serialized shape.
+fn stage_remote_registry(remotes_file: &Path, name: &str) {
+    let s = format!(
+        "[[remotes]]\nname = \"{name}\"\ntype = \"ssh\"\nhost = \"example.com\"\nport = 22\n\
+         version = \"0.1.0\"\nadded_at = \"2026-06-14T00:00:00Z\"\n"
+    );
+    std::fs::write(remotes_file, s).expect("write staged remotes.toml");
+}
+
+/// Scenario: Register a remote deck `myhost` in a test-owned `remotes.toml`
+/// (`DOT_AGENT_DECK_REMOTES`) and stage a non-empty `session.toml`
+/// (`DOT_AGENT_DECK_SESSION`), then run `dot-agent-deck remote remove myhost`.
+/// Removing a deck is the per-deck fresh-start escape hatch (M4.1), so it must
+/// exit 0 AND clear that deck's saved state — the snapshot must be gone
+/// afterward. RED today: `remote remove` only edits the registry file; it never
+/// touches the saved-session snapshot, so the staged `session.toml` survives the
+/// removal.
+#[spec("session/snapshot/002")]
+#[test]
+fn snapshot_002_remote_remove_clears_deck_saved_state() {
+    let session_dir = common::race_safe_tempdir();
+    let session_file = session_dir.path().join("session.toml");
+    stage_nonempty_snapshot(&session_file, session_dir.path());
+
+    let remotes_dir = common::race_safe_tempdir();
+    let remotes_file = remotes_dir.path().join("remotes.toml");
+    stage_remote_registry(&remotes_file, "myhost");
+
+    let (out, text) = run_isolated(
+        &["remote", "remove", "myhost"],
+        &[
+            ("DOT_AGENT_DECK_SESSION", session_file.as_path()),
+            ("DOT_AGENT_DECK_REMOTES", remotes_file.as_path()),
+        ],
+    );
+
+    // The removal itself succeeds today (it edits the registry); that is not the
+    // behavior under test — keep it as a sanity guard so an unrelated failure is
+    // not silently read as the missing snapshot-clear.
+    assert!(
+        out.status.success(),
+        "`dot-agent-deck remote remove myhost` should exit 0 (the registry entry exists), \
+         but it exited {:?}.\noutput:\n{text}",
+        out.status.code()
+    );
+
+    // The escape-hatch behavior: removing the deck must clear that deck's saved
+    // state. RED today: `remote remove` leaves the snapshot in place.
+    assert!(
+        !session_file.exists(),
+        "PRD #89 M4.1: removing a deck (`dot-agent-deck remote remove myhost`) must clear that \
+         deck's saved state — the snapshot at {session_file:?} must be gone afterward — but it \
+         is still present. RED until `remote remove` clears the saved session.\noutput:\n{text}"
+    );
+}

--- a/tests/e2e_session_snapshot.rs
+++ b/tests/e2e_session_snapshot.rs
@@ -5,13 +5,15 @@
 //! Auto-restore is now the default (Phase 2/2b), so a user who wants to start
 //! clean needs one obvious action. There are two:
 //!
-//!   * **Local (M4.2):** a NEW `dot-agent-deck snapshot clear` subcommand deletes
-//!     the local saved-session snapshot. `snapshot` is a subcommand GROUP with a
-//!     `clear` action (decided in `.dot-agent-deck/prd-89-context.md`; NOT
-//!     `reset`/`--reset`). It does not exist yet.
-//!   * **Remote / per-deck (M4.1):** removing a registered deck
-//!     (`dot-agent-deck remote remove <name>`) should also clear that deck's
-//!     saved state.
+//!   * **Local / global (M4.2):** a `dot-agent-deck snapshot clear` subcommand
+//!     deletes the local saved-session snapshot. `snapshot` is a subcommand GROUP
+//!     with a `clear` action (decided in `.dot-agent-deck/prd-89-context.md`; NOT
+//!     `reset`/`--reset`). The snapshot is a SINGLE GLOBAL file, so this is the one
+//!     fresh-start action.
+//!   * **Remote remove is registry-only (M4.1):** removing a registered deck
+//!     (`dot-agent-deck remote remove <name>`) edits ONLY the remote registry and
+//!     intentionally does NOT touch the global snapshot (decided Option 1 — there
+//!     is no per-deck saved state to clear). The 002 guard pins exactly that.
 //!
 //! Both are thin real-binary subprocess spawns — no PTY drive is needed. Each
 //! redirects `DOT_AGENT_DECK_SESSION` to a test-owned snapshot path (and
@@ -149,17 +151,21 @@ fn stage_remote_registry(remotes_file: &Path, name: &str) {
 /// Scenario: Register a remote deck `myhost` in a test-owned `remotes.toml`
 /// (`DOT_AGENT_DECK_REMOTES`) and stage a non-empty `session.toml`
 /// (`DOT_AGENT_DECK_SESSION`), then run `dot-agent-deck remote remove myhost`.
-/// Removing a deck is the per-deck fresh-start escape hatch (M4.1), so it must
-/// exit 0 AND clear that deck's saved state — the snapshot must be gone
-/// afterward. RED today: `remote remove` only edits the registry file; it never
-/// touches the saved-session snapshot, so the staged `session.toml` survives the
-/// removal.
+/// The snapshot is a single GLOBAL file, so `remote remove` is registry-only
+/// (decided Option 1): it must exit 0 AND LEAVE the global snapshot intact —
+/// same path, same contents — because there is no per-deck saved state to
+/// clear. The one fresh-start action is `snapshot clear` (covered by 001).
 #[spec("session/snapshot/002")]
 #[test]
-fn snapshot_002_remote_remove_clears_deck_saved_state() {
+fn snapshot_002_remote_remove_is_registry_only_leaves_snapshot_intact() {
     let session_dir = common::race_safe_tempdir();
     let session_file = session_dir.path().join("session.toml");
     stage_nonempty_snapshot(&session_file, session_dir.path());
+
+    // Capture the staged snapshot's exact contents so we can prove `remote
+    // remove` left it byte-for-byte untouched, not merely that some file exists.
+    let before =
+        std::fs::read_to_string(&session_file).expect("read staged snapshot before remove");
 
     let remotes_dir = common::race_safe_tempdir();
     let remotes_file = remotes_dir.path().join("remotes.toml");
@@ -173,9 +179,8 @@ fn snapshot_002_remote_remove_clears_deck_saved_state() {
         ],
     );
 
-    // The removal itself succeeds today (it edits the registry); that is not the
-    // behavior under test — keep it as a sanity guard so an unrelated failure is
-    // not silently read as the missing snapshot-clear.
+    // The removal succeeds (the registry entry exists). This is a sanity guard so
+    // an unrelated failure is not silently read as "snapshot preserved".
     assert!(
         out.status.success(),
         "`dot-agent-deck remote remove myhost` should exit 0 (the registry entry exists), \
@@ -183,12 +188,21 @@ fn snapshot_002_remote_remove_clears_deck_saved_state() {
         out.status.code()
     );
 
-    // The escape-hatch behavior: removing the deck must clear that deck's saved
-    // state. RED today: `remote remove` leaves the snapshot in place.
+    // The decided behavior (Option 1): `remote remove` is registry-only and must
+    // LEAVE the global snapshot intact — the file is still present afterward…
     assert!(
-        !session_file.exists(),
-        "PRD #89 M4.1: removing a deck (`dot-agent-deck remote remove myhost`) must clear that \
-         deck's saved state — the snapshot at {session_file:?} must be gone afterward — but it \
-         is still present. RED until `remote remove` clears the saved session.\noutput:\n{text}"
+        session_file.exists(),
+        "PRD #89 M4.1 (Option 1): `dot-agent-deck remote remove myhost` is registry-only and must \
+         LEAVE the global snapshot at {session_file:?} intact, but the file is gone afterward. \
+         There is no per-deck saved state to clear; `snapshot clear` is the one fresh-start \
+         action.\noutput:\n{text}"
+    );
+
+    // …with its contents unchanged: remove never reads or rewrites the snapshot.
+    let after = std::fs::read_to_string(&session_file).expect("read snapshot after remove");
+    assert_eq!(
+        before, after,
+        "PRD #89 M4.1 (Option 1): `remote remove` must not modify the global snapshot, but its \
+         contents at {session_file:?} changed.\noutput:\n{text}"
     );
 }

--- a/tests/rehydration.rs
+++ b/tests/rehydration.rs
@@ -40,6 +40,7 @@ use dot_agent_deck::state::AppState;
 use dot_agent_deck::ui::{
     dead_slot_pane_id, fill_dead_slots_with_placeholders, is_dead_slot_pane_id,
 };
+use spec::spec;
 
 // `bind_attach_listener` flips the process-global umask while binding; share
 // the lock with the other M-series tests so concurrent tempdir creation
@@ -1136,4 +1137,149 @@ async fn hydrate_sizes_parser_to_daemon_reported_pty_dims() {
 
     drop(ctrl);
     let _ = server.registry.close_agent(&agent_id);
+}
+
+// ---------------------------------------------------------------------------
+// PRD #89 M2b.1 — warm-daemon orchestration-tab hydration regression guard.
+// ---------------------------------------------------------------------------
+// The snapshot-fallback restore branch (M2b.3) rebuilds an orchestration tab
+// from the disk snapshot only when the daemon is EMPTY. The warm-daemon case
+// is already covered by the PRD #76 M2.12 + #111 hydration path: each role
+// agent carries `TabMembership::Orchestration` and `hydrate_from_daemon`
+// echoes it back, so the TUI can place every role pane at its `role_index`
+// and recover the start-role cursor. This test pins that end-to-end so a
+// regression in warm-daemon orchestration hydration fails here rather than
+// silently shifting work onto the snapshot path.
+//
+// Written as a sync `#[test]` driving an explicit multi-thread runtime rather
+// than `#[tokio::test]`: the linkage-check (PRD #77 Decision 17) ties each
+// `#[spec(...)]` to the next `fn` definition and the function-name prefix, and
+// its scanner only recognises a plain `fn` (not `async fn`). `block_on` keeps
+// the async daemon/hydrate flow intact while exposing a sync `fn` to the gate.
+
+/// Scenario: Spawn three orchestration role agents (orchestrator + coder +
+/// reviewer) on a warm in-process daemon, each tagged with its
+/// `TabMembership::Orchestration` role_index / role_name / is_start_role, then
+/// build a fresh controller and hydrate. Asserts warm-daemon hydration
+/// reproduces every role as a pane, that placing each hydrated pane at its
+/// `role_index` yields the orchestrator + role panes in their saved display
+/// order, and that the start (orchestrator) role — i.e. the `start_role_index`
+/// cursor — is recoverable from `is_start_role`.
+#[spec("session/restore/007")]
+#[test]
+fn restore_007_warm_daemon_hydrates_orchestration_roles_in_order() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("build multi-thread runtime");
+    rt.block_on(restore_007_warm_daemon_hydrates_orchestration_roles_in_order_inner());
+}
+
+async fn restore_007_warm_daemon_hydrates_orchestration_roles_in_order_inner() {
+    let server = start_real_server().await;
+    let client = DaemonClient::new(server.path.clone());
+
+    let orchestration_name = "tdd-cycle";
+    let cwd = server._dir.path().to_string_lossy().into_owned();
+    let role_names = ["orchestrator", "coder", "reviewer"];
+    let mut spawned_ids: Vec<String> = Vec::new();
+    for (role_index, role_name) in role_names.iter().enumerate() {
+        let pane_env = format!("pane-{role_name}");
+        let id = client
+            .start_agent(StartAgentOptions {
+                command: Some("sh -c 'sleep 30'".to_string()),
+                cwd: Some(cwd.clone()),
+                display_name: Some((*role_name).to_string()),
+                env: vec![("DOT_AGENT_DECK_PANE_ID".to_string(), pane_env)],
+                tab_membership: Some(TabMembership::Orchestration {
+                    name: orchestration_name.to_string(),
+                    role_index,
+                    role_name: (*role_name).to_string(),
+                    is_start_role: role_index == 0,
+                    orchestration_cwd: Some(cwd.clone()),
+                    display_title: None,
+                }),
+                ..Default::default()
+            })
+            .await
+            .expect("start_agent should succeed");
+        spawned_ids.push(id);
+    }
+
+    let ctrl = Arc::new(EmbeddedPaneController::new(
+        server.path.clone(),
+        tokio::runtime::Handle::current(),
+    ));
+    let hydrated = {
+        let ctrl = ctrl.clone();
+        tokio::task::spawn_blocking(move || ctrl.hydrate_from_daemon())
+            .await
+            .unwrap()
+    };
+
+    assert_eq!(
+        hydrated.len(),
+        role_names.len(),
+        "every orchestration role should hydrate as a pane; got {hydrated:?}"
+    );
+
+    // Place each hydrated pane at its role_index, exactly as the production
+    // hydration loop in ui.rs does, then assert the orchestrator + role panes
+    // come back in their saved display order with the start role recoverable.
+    let mut role_pane_ids: Vec<Option<String>> = vec![None; role_names.len()];
+    let mut role_name_by_index: Vec<Option<String>> = vec![None; role_names.len()];
+    let mut start_role_index: Option<usize> = None;
+    for h in &hydrated {
+        let Some(TabMembership::Orchestration {
+            name,
+            role_index,
+            role_name,
+            is_start_role,
+            ..
+        }) = &h.tab_membership
+        else {
+            panic!("hydrated pane lost its Orchestration tab membership: {h:?}");
+        };
+        assert_eq!(
+            name, orchestration_name,
+            "hydrated pane must carry the orchestration name"
+        );
+        assert!(
+            *role_index < role_names.len(),
+            "role_index {role_index} out of range"
+        );
+        role_pane_ids[*role_index] = Some(h.pane_id.clone());
+        role_name_by_index[*role_index] = Some(role_name.clone());
+        if *is_start_role {
+            start_role_index = Some(*role_index);
+        }
+    }
+
+    // Every role slot is filled — no gaps in the orchestrator + role panes.
+    assert!(
+        role_pane_ids.iter().all(Option::is_some),
+        "every role slot must be filled by hydration; got {role_pane_ids:?}"
+    );
+    // The role names land back in their saved display order.
+    let recovered_order: Vec<String> = role_name_by_index
+        .into_iter()
+        .map(|n| n.expect("each filled slot has a role name"))
+        .collect();
+    let expected_order: Vec<String> = role_names.iter().map(|s| s.to_string()).collect();
+    assert_eq!(
+        recovered_order, expected_order,
+        "warm-daemon hydration must reproduce the role panes in saved order"
+    );
+    // The start_role_index cursor (orchestrator at index 0) is recoverable.
+    assert_eq!(
+        start_role_index,
+        Some(0),
+        "the start (orchestrator) role must be recoverable from is_start_role"
+    );
+
+    drop(ctrl);
+    for id in &spawned_ids {
+        let _ = server.registry.close_agent(id);
+    }
 }

--- a/tests/session_restore_precedence.rs
+++ b/tests/session_restore_precedence.rs
@@ -1,0 +1,49 @@
+//! PRD #89 M2.2 — daemon-vs-snapshot restore precedence (in-process).
+//!
+//! Auto-restore on startup tries daemon hydration first; if hydration produced
+//! any panes the daemon state wins and the disk snapshot is skipped, otherwise
+//! the snapshot is applied. The decision is a pure, structural check on
+//! `AppState.managed_pane_ids` exposed as `ui::should_apply_snapshot`, so it can
+//! be pinned in-process here without the cross-deck PTY hydration primitive an
+//! end-to-end L2 would need (see the tester handoff for `session/restore/005`).
+//!
+//! This is an in-crate integration test (style of `tests/rehydration.rs`): it
+//! runs in the fast tier (`cargo test-fast`), not the `e2e` PTY suite.
+
+use dot_agent_deck::state::AppState;
+use dot_agent_deck::ui::should_apply_snapshot;
+use spec::spec;
+
+/// Scenario: Drive the `should_apply_snapshot` precedence seam directly. With a
+/// fresh `AppState` that has no hydrated managed panes (the daemon-empty case),
+/// it must return `true` so the disk snapshot is applied. After registering a
+/// single hydrated managed pane id (simulating one pane produced by daemon
+/// hydration), it must return `false` so the snapshot restore is skipped and the
+/// daemon state wins — pinning the M2.2 precedence without double-restoring.
+#[spec("session/restore/005")]
+#[test]
+fn restore_005_daemon_hydration_wins_over_snapshot() {
+    // Zero hydrated managed panes → daemon empty → apply the disk snapshot.
+    let mut state = AppState::default();
+    assert!(
+        should_apply_snapshot(&state),
+        "PRD #89 M2.2: with no hydrated managed panes the daemon is empty, so the disk \
+         snapshot must be applied (should_apply_snapshot == true)"
+    );
+
+    // At least one hydrated managed pane id present → daemon owns the workspace
+    // → snapshot restore is skipped so panes are not double-restored.
+    state.register_pane("agent-hydrated-1".to_string());
+    assert!(
+        !should_apply_snapshot(&state),
+        "PRD #89 M2.2: once daemon hydration registered a managed pane the daemon state \
+         wins, so the snapshot must be skipped (should_apply_snapshot == false)"
+    );
+
+    // Additional hydrated panes do not flip the decision back.
+    state.register_pane("agent-hydrated-2".to_string());
+    assert!(
+        !should_apply_snapshot(&state),
+        "PRD #89 M2.2: multiple hydrated managed panes must still skip the snapshot"
+    );
+}

--- a/tests/snapshots/render_keybindings__help_001_overlay_reflects_active_bindings.snap
+++ b/tests/snapshots/render_keybindings__help_001_overlay_reflects_active_bindings.snap
@@ -37,8 +37,8 @@ expression: text
         │  F1                 Toggle this help                                                                │         
         │                                                     Session                                         │         
         │                                                                                                     │         
-        │                                                     Panes auto-saved on exit.                       │         
-        │                                                     Restore: dot-agent-deck --continue              │         
+        │                                                     Panes auto-saved continuously.                  │         
+        │                                                     Restored automatically on launch.               │         
         │  [Close]                                                                                            │         
         │  Press ? or Esc to close                                                                            │         
         └─────────────────────────────────────────────────────────────────────────────────────────────────────┘

--- a/xtask/linkage-check/m2.allowlist
+++ b/xtask/linkage-check/m2.allowlist
@@ -107,7 +107,6 @@ resize/layout/001
 resize/sigwinch/001
 resize/sigwinch/002
 resize/sigwinch/003
-session/restore/001
 session/restore/002
 session/restore/003
 session/restore/004


### PR DESCRIPTION
## Summary

Closes #89

This PR unifies the TUI restore model: running `dot-agent-deck` now restores the previous workspace automatically, and the `--continue` flag is removed. This is a **breaking change** (documented in `changelog.d/89.breaking.md`).

### What ships

- **Auto-restore on every startup** — daemon hydration wins; if the daemon is empty (crash recovery / fresh machine), the disk snapshot is applied; if both are empty, the dashboard starts empty as before.
- **Continuous snapshot freshness** — the saved-session snapshot is written on every meaningful state change (new pane, rename, close, agent stop/restart, orchestration changes) and on detach, via a 750 ms leading-edge coalescer. No longer written only at clean quit.
- **Orchestration-tab restore on the snapshot-fallback path** — when the daemon is empty, orchestration tabs are rebuilt from snapshot metadata (role order, orchestrator prompt, `start_role_index`). Config drift surfaces a warning and falls back to a plain pane.
- **`--continue` removed** — clap rejects the flag; a custom error message explains that auto-restore is now the default.
- **`dot-agent-deck snapshot clear`** — new subcommand that deletes the global snapshot (`~/.config/dot-agent-deck/session.toml`) for a clean fresh start.
- **Docs updated** — `docs/getting-started.md` and `docs/session-management.md` reflect the new model and document the escape hatch.

### Breaking change

`dot-agent-deck` (no flag) previously started an empty session. It now restores the previous workspace. **Migration:** remove `--continue` from any wrapper scripts or aliases — auto-restore is now the default.

### Test coverage

- 16 commits; 1292/1292 tests green (full `cargo test-e2e` pre-push).
- New tests: snapshot freshness (M1.x), auto-restore precedence (M2.x), orchestration capture/restore (M2b.x), fresh-start escape hatch (M4.x), Phase 3 `--continue` removal.
- All: `cargo fmt --check` clean, `cargo clippy -D warnings` clean, `cargo test-fast` 757/757 passed.