### PR TITLE
test: PRD #170 test-hygiene follow-up (lint fix + de-vacuum session_restore + login-path/003)

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -13048,7 +13048,7 @@ mod tests {
         for frame_height in 2u16..=9 {
             let rows = bottom_bar_rows(&ui, 8, frame_height, &tab_view);
             assert!(
-                rows <= frame_height - 1,
+                rows < frame_height,
                 "bottom_bar_rows at frame_height={frame_height} reserved {rows} \
                  rows, leaving no content row (must be <= frame_height - 1)"
             );

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -1018,6 +1018,13 @@ Platform coverage column shorthand: **mac+linux** = macOS and Linux (Windows onc
 - **Does not assert:** prompt delivery to the spawned agent (covered by `scheduler/spawn/004`); the orchestration-vs-card branch (covered by `scheduler/spawn/002`).
 - **Platform coverage:** mac+linux.
 
+##### lifecycle/login-path/003 — The schedule-authoring helper's bare authoring command (living only in the user's login-shell PATH) resolves and spawns when the daemon was launched without that dir on PATH (PRD #170 M1.3 + M2.1, the originally-motivating bug path).
+- **Layer:** L2 (real `dot-agent-deck` binary in a PTY; the deck lazy-spawns its daemon, which inherits the deck's env). Reuses the `login_path_fixture` mechanics (stripped PATH + fake login shell) from `lifecycle/login-path/001`/`002` and the pick-agent modal interaction from `scheduler/manager/002`.
+- **Agent:** none (a synthetic stub binary placed only in a temp dir absent from the inherited PATH; the deck's `$SHELL` is a fake login shell whose `-lc` output adds that dir to PATH). `default_command` is the bare stub, so the pick-agent modal's resolved authoring command defaults to it. A fixture `schedules.toml` supplies one task to edit (its own `cat` run command is irrelevant — the authoring command comes from `default_command`).
+- **Asserts:** opening the Scheduled-Tasks manager (`S`), pressing `e` to edit the auto-selected row opens the pick-agent modal (PRD #170) defaulting to the bare authoring command; confirming with Enter spawns it through the daemon spawn primitive, and the bare command resolves under the daemon's login-shell-enriched PATH — the stub writes an on-disk marker that appears within the wait window. GREEN on write (both M1.3 and M2.1 merged): pins PRD #170's third spawn path (the schedule-authoring helper), which routes through the same daemon spawn primitive as `001`/`002` plus the configurable-command change of `scheduler/manager/002`.
+- **Does not assert:** the authoring seed/prompt delivery to the spawned agent (covered by `scheduler/manager/002`); the modal's preset-selection wiring or Cancel/Esc behavior (covered by `scheduler/manager/009`–`015`); the non-PATH login environment (out of scope per PRD #170).
+- **Platform coverage:** mac+linux.
+
 ### Resize
 
 #### resize/sigwinch

--- a/tests/e2e_login_path.rs
+++ b/tests/e2e_login_path.rs
@@ -15,11 +15,12 @@
 //! daemon's PATH, and the daemon's `$SHELL` is a fake login shell whose
 //! `-lc` output adds that dir to PATH (mirroring how `~/.profile` adds
 //! `~/.local/bin`). A bare reference to the stub therefore resolves ONLY if the
-//! daemon captured the login-shell PATH. Two of PRD #170's three spawn paths are
-//! pinned here — the dashboard new-pane (`001`, real TUI) and a scheduled-task
-//! fire (`002`, headless daemon). The third path (the schedule-authoring helper)
-//! routes through the same daemon spawn primitive and additionally depends on the
-//! configurable-command change pinned by `scheduler/manager/002`.
+//! daemon captured the login-shell PATH. All three of PRD #170's spawn paths are
+//! pinned here — the dashboard new-pane (`001`, real TUI), a scheduled-task fire
+//! (`002`, headless daemon), and the schedule-authoring helper (`003`, the
+//! originally-motivating bug). The authoring-helper path routes through the same
+//! daemon spawn primitive and additionally depends on the configurable-command
+//! change pinned by `scheduler/manager/002`.
 //!
 //! RED today: nothing captures the login-shell PATH, so the daemon's PATH lacks
 //! the stub dir, the bare command is not found, the spawn fails, and the stub's

--- a/tests/e2e_login_path.rs
+++ b/tests/e2e_login_path.rs
@@ -216,3 +216,73 @@ fn login_path_002_scheduled_fire_resolves_login_shell_command() {
          \"$PATH\"'`) at startup so the bare command resolves"
     );
 }
+
+/// Scenario: Launch the deck with `default_command` set to a bare authoring
+/// command that lives ONLY in a dir absent from the inherited PATH, and `$SHELL`
+/// pointed at a fake login shell whose `-lc` output adds that dir to PATH, plus a
+/// fixture `schedules.toml` holding one task. Open the Scheduled-Tasks manager
+/// (`S`), press `e` to edit the auto-selected row — which opens the pick-agent
+/// modal (PRD #170) defaulting to the resolved authoring command (the bare
+/// `default_command`) — and confirm the default selection with Enter. Assert the
+/// bare authoring command resolves and spawns under the daemon's login-shell-
+/// enriched PATH: the stub writes its on-disk marker. This pins PRD #170's THIRD
+/// spawn path (the schedule-authoring helper), the originally-motivating bug —
+/// GREEN now that both the login-shell PATH capture (M1.3) and the configurable
+/// authoring command (M2.1) are merged.
+#[spec("lifecycle/login-path/003")]
+#[test]
+fn login_path_003_schedule_authoring_resolves_login_shell_command() {
+    let fx = login_path_fixture("stub-authoring-agent");
+
+    // One fixture schedule so the manager has a row to edit. The task's OWN run
+    // command (`cat`, on the normal PATH) is irrelevant here — the authoring
+    // helper's command comes from `default_command` (the bare stub), not the task.
+    let sched_dir = tempfile::tempdir().expect("schedules tempdir");
+    let sched_path = sched_dir.path().join("schedules.toml");
+    std::fs::write(
+        &sched_path,
+        format!(
+            "[[scheduled_tasks]]\n\
+             name = \"digest\"\n\
+             cron = \"0 9 * * *\"\n\
+             working_dir = \"{work}\"\n\
+             command = \"cat\"\n\
+             prompt = \"digest prompt\"\n\
+             enabled = true\n",
+            work = fx.work.to_string_lossy(),
+        ),
+    )
+    .expect("write fixture schedules.toml");
+
+    let deck = TuiDeck::builder()
+        .with_env("SHELL", fx.fake_shell.to_string_lossy())
+        .with_env("DOT_AGENT_DECK_CONFIG", fx.config.to_string_lossy())
+        .with_env("DOT_AGENT_DECK_SCHEDULES", sched_path.to_string_lossy())
+        .launch_with_fixture("minimal");
+    deck.wait_for_string("No active sessions");
+
+    // Open the Scheduled-Tasks manager and edit the auto-selected `digest` row,
+    // which opens the pick-agent modal. `NEXT FIRE` is the "dialog is up" signal;
+    // `opencode` (a preset chip) is the "modal is up" signal.
+    deck.send_keys(b"S");
+    deck.wait_for_string("NEXT FIRE");
+    deck.send_keys(b"e"); // edit → opens the pick-agent modal
+    deck.wait_for_string("opencode");
+
+    // The modal's chosen default is the resolved authoring command — the bare
+    // `default_command` (a custom, non-preset command), so Enter confirms it
+    // without moving the preset highlight. Confirming spawns the seeded authoring
+    // agent running the bare stub through the daemon spawn primitive.
+    deck.send_keys(b"\r"); // confirm the default selection → spawn the authoring agent
+
+    assert!(
+        common::wait_for_path(&fx.marker, Duration::from_secs(15)),
+        "the schedule-authoring helper's bare command (a binary living only in the \
+         login-shell PATH) must resolve and spawn under the daemon's login-shell-\
+         enriched PATH, but its marker never appeared — PRD #170's third spawn path \
+         must benefit from the same `$SHELL -lc 'printf %s \"$PATH\"'` capture so the \
+         bare `default_command` resolves"
+    );
+
+    drop(sched_dir);
+}

--- a/tests/e2e_session_restore.rs
+++ b/tests/e2e_session_restore.rs
@@ -475,7 +475,7 @@ fn restore_009_orchestration_config_drift_warns_and_falls_back_to_plain_pane() {
     // The restored pane auto-focuses (PaneInput), where Ctrl+C is forwarded to
     // the pane; detach to Normal mode first so Ctrl+C reaches the global quit.
     deck.send_keys(b"\x04"); // Ctrl+D → detach to Normal mode
-    deck.wait_for_absence("[Detach Ctrl+D]"); // pane no longer focused
+    deck.wait_for_absence("[Command Mode Ctrl+D]"); // pane no longer focused
     deck.send_keys(b"\x03"); // Ctrl+C → quit-confirm modal
     deck.wait_for_string("Quit dot-agent-deck?");
     deck.send_keys(b"\r"); // Enter → Detach (default) → clean teardown + flush
@@ -552,7 +552,7 @@ fn restore_010_zero_role_reresolved_orchestration_falls_back_without_panic() {
     // The restored pane auto-focuses (PaneInput); detach to Normal mode first so
     // Ctrl+C reaches the global quit (mirrors session/restore/009).
     deck.send_keys(b"\x04"); // Ctrl+D → detach to Normal mode
-    deck.wait_for_absence("[Detach Ctrl+D]"); // pane no longer focused
+    deck.wait_for_absence("[Command Mode Ctrl+D]"); // pane no longer focused
     deck.send_keys(b"\x03"); // Ctrl+C → quit-confirm modal
     deck.wait_for_string("Quit dot-agent-deck?");
     deck.send_keys(b"\r"); // Enter → Detach (default) → clean teardown + flush


### PR DESCRIPTION
## Summary

Test-hygiene follow-up to PRD #170 (merged as PR #171). No production-binary changes — all edits are in `#[cfg(test)]` code or test files.

- **`src/ui.rs` (test module):** Fix pre-existing `clippy::int_plus_one` lint in the `bottom_bar_rows` `#[cfg(test)]` block (`x + 1 > y` → `x >= y`). No change to any non-test code path.
- **`tests/e2e_session_restore.rs`:** De-vacuumed two `wait_for_absence` asserts that were checking the now-renamed label `[Detach Ctrl+D]` (renamed to `[Command Mode Ctrl+D]` in PR #171). Retargeted to the current string; both asserts are verified meaningful and stay GREEN.
- **`tests/e2e_login_path.rs`:** Added `lifecycle/login-path/003` — proves the schedule-authoring helper resolves a bare command under a stripped daemon PATH (GREEN on write).

Closes no new issue; related to #170 / PR #171.

## Gate results

- `cargo fmt --check`: clean
- `cargo clippy -- -D warnings`: clean
- `cargo clippy --features e2e --tests -- -D warnings`: clean (the int_plus_one lint was e2e-tests-only)

## Test plan

- [ ] CI green
- [ ] Greptile review settled (rule 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)