### PR TITLE
fix: keep delegated worker prompt single-line

### DIFF
--- a/changelog.d/187.bugfix.md
+++ b/changelog.d/187.bugfix.md
@@ -1,0 +1,3 @@
+## Delegated Workers Start Without a Manual Enter
+
+Delegating to a worker role now injects a single-line prompt into the worker pane instead of a multi-line block. Previously the multi-line prompt (which carried the `## When done` completion instructions) could land in the worker's input as a compacted bracketed-paste that sat unsubmitted until an operator pressed Enter — stalling unattended orchestration. The completion instructions now live in the worker's task file (`.dot-agent-deck/worker-task-<role>.md`), so the worker still knows to signal back via `dot-agent-deck work-done` once the single-line pointer auto-submits.

--- a/src/state.rs
+++ b/src/state.rs
@@ -125,25 +125,25 @@ pub struct AppState {
 
 pub type SharedState = Arc<RwLock<AppState>>;
 
+const WORK_DONE_FOOTER: &str = "## When done\n\n\
+Signal completion by running this command via Bash:\n\
+```bash\n\
+dot-agent-deck work-done --task \"Brief summary of what you accomplished. Include file paths and outcomes.\"\n\
+```";
+
 /// Compose the prompt that the daemon writes into a worker pane on
-/// delegation: the caller-supplied `task_body` (typically a one-liner
-/// pointing at `.dot-agent-deck/worker-task-{role}.md`), a blank line,
-/// then the work-done footer that reminds the worker to signal
-/// completion via `dot-agent-deck work-done` once they finish.
+/// delegation. In the normal file-backed path this is intentionally only
+/// the one-line pointer to `.dot-agent-deck/worker-task-{role}.md`.
+/// Keeping every injected PTY prompt single-line avoids bracketed paste
+/// and lets the synthetic CR follow the same reliable path as ordinary
+/// typed prompts.
 ///
 /// The footer used to be appended per-role by the TUI's
 /// `OrchestrationConfig.roles[*].prompt_template` wrapping. PRD #93
-/// round-5 moved dispatch into the daemon but left
-/// `OrchestrationConfig` out of scope, so without this helper every
-/// delegated task lost the footer and workers stopped signaling back.
+/// round-5 moved dispatch into the daemon; the durable worker context now
+/// lives in the task file instead of the injected pane prompt.
 pub fn compose_delegate_prompt(task_body: &str) -> String {
-    format!(
-        "{task_body}\n\n## When done\n\n\
-         Signal completion by running this command via Bash:\n\
-         ```bash\n\
-         dot-agent-deck work-done --task \"Brief summary of what you accomplished. Include file paths and outcomes.\"\n\
-         ```"
-    )
+    task_body.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// CodeRabbit (PRD #93 round-9): build the file contents written to
@@ -152,14 +152,15 @@ pub fn compose_delegate_prompt(task_body: &str) -> String {
 /// `## Task` header beneath the template — mirrors the pre-Round-5 TUI
 /// dispatch path that Round 5 lost when it moved orchestration onto
 /// the daemon side without bringing the per-role template wrapping
-/// along. With no template the file content is the raw task; the
-/// PTY-injected one-liner still appends the work-done footer in both
-/// shapes via [`compose_delegate_prompt`].
+/// along. The work-done footer is appended to the file rather than the
+/// PTY-injected pointer so workers still get completion instructions
+/// without forcing a multi-line bracketed-paste write into the agent TUI.
 pub fn compose_worker_task_file(prompt_template: Option<&str>, task: &str) -> String {
-    match prompt_template {
+    let body = match prompt_template {
         Some(tpl) if !tpl.trim().is_empty() => format!("{tpl}\n\n## Task\n\n{task}"),
         _ => task.to_string(),
-    }
+    };
+    format!("{}\n\n{}", body.trim_end(), WORK_DONE_FOOTER)
 }
 
 /// Look up the role config for `role_name` inside the orchestration
@@ -1064,20 +1065,43 @@ mod tests {
     use super::*;
 
     #[test]
-    fn compose_delegate_prompt_appends_work_done_footer() {
+    fn compose_delegate_prompt_is_single_line_file_pointer() {
         let prompt =
             compose_delegate_prompt("Read .dot-agent-deck/worker-task-coder.md for your task.");
-        assert!(
-            prompt.starts_with("Read .dot-agent-deck/worker-task-coder.md for your task.\n\n"),
-            "task body must lead, then a blank line before the footer"
+        assert_eq!(
+            prompt,
+            "Read .dot-agent-deck/worker-task-coder.md for your task."
         );
         assert!(
-            prompt.contains("## When done"),
-            "footer must include the ## When done heading"
+            !prompt.contains('\n'),
+            "pane-injected delegate prompt must stay single-line"
+        );
+    }
+
+    #[test]
+    fn compose_delegate_prompt_normalizes_multiline_input() {
+        let prompt = compose_delegate_prompt("line one\n\nline two\r\nline three");
+        assert_eq!(prompt, "line one line two line three");
+        assert!(
+            !prompt.contains('\n'),
+            "pane-injected delegate prompt must normalize newlines"
+        );
+    }
+
+    #[test]
+    fn compose_worker_task_file_appends_work_done_footer() {
+        let content = compose_worker_task_file(Some("You are coder."), "Implement the thing.");
+        assert!(content.starts_with("You are coder.\n\n## Task\n\nImplement the thing."));
+        assert!(
+            content.contains("## When done"),
+            "task file must include the completion heading"
         );
         assert!(
-            prompt.contains("dot-agent-deck work-done --task"),
-            "footer must instruct the worker to call dot-agent-deck work-done"
+            content.contains("dot-agent-deck work-done --task"),
+            "task file must instruct the worker to call dot-agent-deck work-done"
         );
+
+        let no_template = compose_worker_task_file(None, "Implement the fallback.");
+        assert!(no_template.starts_with("Implement the fallback.\n\n## When done"));
     }
 }

--- a/tests/delegate_prompt_injection.rs
+++ b/tests/delegate_prompt_injection.rs
@@ -1,0 +1,185 @@
+//! Regression guard for #187 / PR #188: a delegated worker pane must
+//! receive a SINGLE-LINE prompt, and the `work-done` completion footer
+//! must live in the worker task FILE rather than in the injected prompt.
+//!
+//! Why this matters: `encode_pane_payload` wraps any payload containing a
+//! newline in bracketed-paste markers (`ESC[200~ … ESC[201~`). In Claude
+//! Code that framing lands as a compacted block the worker never submits
+//! without a manual Enter (#187). The fix keeps the injected delegate
+//! prompt to one line — the single-line pointer at
+//! `.dot-agent-deck/worker-task-<role>.md` — and moves the footer into the
+//! task file.
+//!
+//! Unit tests already cover `compose_delegate_prompt` (single-line) and
+//! `encode_pane_payload` (single-line → no wrap) in isolation. This test
+//! exercises the REAL daemon dispatch wiring end to end — `handle_delegate`
+//! → `dispatch_one_owned` → `compose_delegate_prompt` →
+//! `write_to_pane_and_submit` — and asserts the bytes that actually reach a
+//! worker pane's PTY plus the contents of the generated task file.
+//!
+//! No LLM and no real agent: the worker pane is a `cat` stub whose PTY
+//! echoes whatever the daemon injects, so the snapshot reflects the
+//! delivered bytes. Runs in the fast tier (no `e2e` feature gate).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::broadcast;
+
+use dot_agent_deck::agent_pty::{AgentPtyRegistry, DOT_AGENT_DECK_PANE_ID, SpawnOptions};
+use dot_agent_deck::event::{BroadcastMsg, DelegateSignal};
+use dot_agent_deck::state::AppState;
+
+mod common;
+
+const ORCH_PANE: &str = "orchestrator-pane";
+const WORKER_PANE: &str = "worker-pane";
+const WORKER_ROLE: &str = "coder";
+
+/// Poll the agent's PTY snapshot until `needle` appears or `timeout`
+/// elapses, returning the final snapshot either way so the caller can
+/// assert (and print it on failure).
+async fn wait_for_snapshot_needle(
+    registry: &AgentPtyRegistry,
+    agent_id: &str,
+    needle: &[u8],
+    timeout: Duration,
+) -> Vec<u8> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Ok(snap) = registry.snapshot(agent_id)
+            && snap.windows(needle.len()).any(|w| w == needle)
+        {
+            return snap;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return registry.snapshot(agent_id).unwrap_or_default();
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// Scenario: Register a worker pane (a `cat` stub) and an orchestrator
+/// pane in the same orchestration directly in `AppState`, exactly as a
+/// real orchestration tab would at StartAgent time, then call the daemon's
+/// real `handle_delegate` for a `coder` task. Assert the worker pane's PTY
+/// received the single-line file pointer and NOT the multi-line
+/// `## When done` footer, and that the generated
+/// `.dot-agent-deck/worker-task-coder.md` carries the footer plus the task
+/// body. This is the wiring guard for #187: the footer lives in the file,
+/// the injected pane prompt stays one line.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn delegate_injects_single_line_pointer_and_keeps_footer_in_task_file() {
+    common::init_test_env();
+
+    let cwd = common::race_safe_tempdir();
+    let cwd_str = cwd
+        .path()
+        .to_str()
+        .expect("tempdir path is UTF-8")
+        .to_string();
+
+    let registry = Arc::new(AgentPtyRegistry::new());
+
+    // Worker pane backed by `cat`: the PTY echoes whatever the daemon
+    // injects, so the registry snapshot reflects the delivered bytes.
+    let worker_agent_id = registry
+        .spawn_agent(SpawnOptions {
+            command: Some("cat"),
+            cwd: Some(cwd_str.as_str()),
+            env: vec![(DOT_AGENT_DECK_PANE_ID.to_string(), WORKER_PANE.to_string())],
+            ..SpawnOptions::default()
+        })
+        .expect("spawn worker stub");
+
+    let (event_tx, _event_rx) = broadcast::channel::<BroadcastMsg>(64);
+
+    // Populate the maps `handle_delegate` reads, mirroring what the
+    // StartAgent path records for a live orchestration tab: an
+    // orchestrator pane (the only valid delegate source) and a worker
+    // pane in the SAME orchestration.
+    let orchestration = ("test-orchestration".to_string(), cwd_str.clone());
+    let mut state = AppState::default();
+    state
+        .pane_role_map
+        .insert(ORCH_PANE.to_string(), "orchestrator".to_string());
+    state
+        .pane_role_map
+        .insert(WORKER_PANE.to_string(), WORKER_ROLE.to_string());
+    state.orchestrator_pane_ids.insert(ORCH_PANE.to_string());
+    state
+        .pane_orchestration_map
+        .insert(ORCH_PANE.to_string(), orchestration.clone());
+    state
+        .pane_orchestration_map
+        .insert(WORKER_PANE.to_string(), orchestration.clone());
+    state
+        .pane_cwd_map
+        .insert(WORKER_PANE.to_string(), cwd_str.clone());
+
+    let task = "List the files in the current directory.";
+    let signal = DelegateSignal {
+        pane_id: ORCH_PANE.to_string(),
+        task: task.to_string(),
+        to: vec![WORKER_ROLE.to_string()],
+        timestamp: chrono::Utc::now(),
+    };
+
+    // `handle_delegate` fans the dispatch out onto a `tokio::spawn`d task
+    // and returns immediately; we poll its observable effects below.
+    state.handle_delegate(signal, &registry, &event_tx).await;
+
+    // 1) The injected pane prompt must be the single-line file pointer.
+    let pointer = b"Read .dot-agent-deck/worker-task-coder.md for your task.";
+    let snap =
+        wait_for_snapshot_needle(&registry, &worker_agent_id, pointer, Duration::from_secs(5))
+            .await;
+    let snap_str = String::from_utf8_lossy(&snap);
+    assert!(
+        snap.windows(pointer.len()).any(|w| w == pointer),
+        "worker pane never received the single-line file pointer; snapshot = {snap_str:?}"
+    );
+
+    // 2) The footer must NOT have been injected into the pane. Pre-#187
+    //    the prompt carried the multi-line `## When done` block, which is
+    //    exactly what forced the bracketed-paste path. `## When done` is
+    //    plain ASCII, so PTY echo would surface it verbatim if it were
+    //    present — its absence is the fix.
+    assert!(
+        !snap
+            .windows(b"## When done".len())
+            .any(|w| w == b"## When done"),
+        "worker pane prompt still contains the `## When done` footer (#187 regression); \
+         the footer belongs in the task file, not the injected prompt. snapshot = {snap_str:?}"
+    );
+
+    // 3) The footer (and the task body) must live in the worker task file.
+    let task_file = cwd
+        .path()
+        .join(".dot-agent-deck")
+        .join("worker-task-coder.md");
+    let mut file_body = String::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(s) = std::fs::read_to_string(&task_file) {
+            file_body = s;
+            if file_body.contains("## When done") {
+                break;
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        file_body.contains("## When done") && file_body.contains("dot-agent-deck work-done --task"),
+        "worker task file must carry the work-done footer; got: {file_body:?}"
+    );
+    assert!(
+        file_body.contains(task),
+        "worker task file must contain the delegated task body; got: {file_body:?}"
+    );
+
+    registry.shutdown_all();
+}

--- a/tests/e2e_delegate_work_done_chain.rs
+++ b/tests/e2e_delegate_work_done_chain.rs
@@ -1,0 +1,475 @@
+#![cfg(feature = "e2e")]
+
+//! L2 real-agent chain test for #187 / PR #188.
+//!
+//! The bug: when the orchestrator delegates, the daemon injects a prompt
+//! into the worker pane. Before the fix that prompt was multi-line (it
+//! carried the `## When done` footer), so `encode_pane_payload`
+//! bracketed-paste-wrapped it and Claude Code parked it as a compacted
+//! block awaiting a manual Enter — the worker never started unattended.
+//! The fix keeps the injected prompt to a single-line pointer and moves
+//! the footer into the worker task file.
+//!
+//! This test proves the empirical end of that fix that unit/integration
+//! tests cannot: a real, long-running interactive worker agent
+//! AUTO-SUBMITS the daemon-injected single-line prompt (no human Enter).
+//!
+//! Two arms, each skipped when its CLI/credentials are absent (Decision
+//! 26 runtime-skip), each a cheap single invocation well under Decision
+//! 23's <$0.05/run bound. Local-only (Decision 8): gated behind the `e2e`
+//! feature so CI (`cargo test-fast`) never compiles it.
+//!
+//! - **Claude (Haiku)** runs the FULL loop: real `handle_delegate` →
+//!   single-line pointer injected → Claude auto-submits, reads its task
+//!   file, performs a trivial task, and runs `dot-agent-deck work-done`;
+//!   the observable is the daemon-written `.dot-agent-deck/work-done-*.md`.
+//!
+//! - **OpenCode** confirms only the AUTO-SUBMIT half. OpenCode's own
+//!   permission sandbox gates `.dot-agent-deck` reads / shell runs
+//!   ("Access external directory …"), which is orthogonal to #187 — so
+//!   rather than configure that sandbox, the OpenCode arm injects a
+//!   purely conversational prompt through the SAME
+//!   `write_to_pane_and_submit` primitive the delegate dispatch uses and
+//!   asserts the model's reply renders. (Verified 2026-06-22: OpenCode
+//!   does auto-submit; the only thing that blocked the full loop was its
+//!   tool-permission sandbox, not #187, not the account, not PRD #79.)
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+use tokio::sync::{RwLock, broadcast};
+use tokio::task::JoinHandle;
+
+use dot_agent_deck::agent_pty::{AgentPtyRegistry, DOT_AGENT_DECK_PANE_ID, SpawnOptions};
+use dot_agent_deck::daemon::{Daemon, run_daemon_with};
+use dot_agent_deck::event::{BroadcastMsg, DelegateSignal};
+use dot_agent_deck::state::{AppState, SharedState};
+
+mod common;
+
+/// Serializes the socket-bind window across the harness (mirrors the
+/// pattern in `spawn_time_role_prompt_submit_after_session_start.rs`).
+static HARNESS_BIND_LOCK: Mutex<()> = Mutex::new(());
+
+const ORCH_PANE: &str = "orchestrator-pane";
+const WORKER_PANE: &str = "worker-pane";
+const WORKER_ROLE: &str = "coder";
+const PINNED_CLAUDE_MODEL: &str = "claude-haiku-4-5-20251001";
+
+struct DaemonHandle {
+    _dir: TempDir,
+    state: SharedState,
+    registry: Arc<AgentPtyRegistry>,
+    event_tx: broadcast::Sender<BroadcastMsg>,
+    hook_path: PathBuf,
+    handle: JoinHandle<()>,
+}
+
+impl Drop for DaemonHandle {
+    fn drop(&mut self) {
+        self.handle.abort();
+        self.registry.shutdown_all();
+    }
+}
+
+/// Bring up an in-process daemon whose hook loop will dispatch our
+/// `Delegate` and ingest the worker's `WorkDone`. Returns handles to the
+/// shared state (so the test can populate the orchestration maps), the PTY
+/// registry (to spawn the worker), the broadcast sender, and the hook
+/// socket path (handed to the worker via `DOT_AGENT_DECK_SOCKET`).
+async fn spawn_daemon() -> DaemonHandle {
+    common::init_test_env();
+    let (dir, hook_path, attach_path) = {
+        let _g = HARNESS_BIND_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let dir = common::race_safe_tempdir();
+        let hook = dir.path().join("hook.sock");
+        let attach = dir.path().join("attach.sock");
+        (dir, hook, attach)
+    };
+
+    let state: SharedState = Arc::new(RwLock::new(AppState::default()));
+    let daemon = Daemon::with_attach(state.clone(), attach_path.clone())
+        .with_idle_shutdown(None)
+        .with_lock_dir_override(common::lock_dir_path());
+    let registry = daemon.pty_registry.clone();
+    let event_tx = daemon.event_tx.clone();
+
+    let hook_for_daemon = hook_path.clone();
+    let handle = tokio::spawn(async move {
+        let _ = run_daemon_with(&hook_for_daemon, daemon).await;
+    });
+
+    // Wait until the hook socket accepts connections so the worker's
+    // `work-done` call can't race daemon startup.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut ready = false;
+    while tokio::time::Instant::now() < deadline {
+        if hook_path.exists() && UnixStream::connect(&hook_path).await.is_ok() {
+            ready = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        ready,
+        "daemon hook socket was not accepting connections within 5s"
+    );
+
+    DaemonHandle {
+        _dir: dir,
+        state,
+        registry,
+        event_tx,
+        hook_path,
+        handle,
+    }
+}
+
+/// Poll the worker's PTY snapshot until its length stops growing for
+/// `quiet`, i.e. the agent has finished rendering its initial UI and is
+/// waiting for input. Capped at `timeout`. Delegating only after the
+/// worker is input-ready mirrors production, where delegates target a
+/// long-running worker rather than one mid-boot.
+async fn wait_until_worker_ready(
+    registry: &AgentPtyRegistry,
+    agent_id: &str,
+    quiet: Duration,
+    timeout: Duration,
+) {
+    let start = tokio::time::Instant::now();
+    let deadline = start + timeout;
+    // Don't treat an early boot lull as "ready": a TUI agent can pause
+    // briefly mid-init before its input is interactive, and injecting then
+    // gets the bytes dropped. Require a minimum settle since first output
+    // in addition to the quiet window.
+    let min_since_first_output = Duration::from_secs(6);
+    let mut last_len = 0usize;
+    let mut first_output_at: Option<tokio::time::Instant> = None;
+    let mut stable_since = start;
+    loop {
+        let len = registry.snapshot(agent_id).map(|s| s.len()).unwrap_or(0);
+        if len > 0 && first_output_at.is_none() {
+            first_output_at = Some(tokio::time::Instant::now());
+        }
+        if len != last_len {
+            last_len = len;
+            stable_since = tokio::time::Instant::now();
+        } else if let Some(first) = first_output_at
+            && stable_since.elapsed() >= quiet
+            && first.elapsed() >= min_since_first_output
+        {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Poll for `path` to exist, up to `timeout`.
+async fn wait_for_path(path: &Path, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// Poll the worker pane until its rendered screen contains `needle`,
+/// returning `(found, rendered_screen)`. The PTY byte stream is replayed
+/// through a `vt100` grid so a streamed/redrawn reply (the agent prints
+/// token-by-token with cursor moves) is matched on its final rendered
+/// state rather than on raw, escape-interleaved bytes.
+async fn wait_for_rendered_text(
+    registry: &AgentPtyRegistry,
+    agent_id: &str,
+    needle: &str,
+    timeout: Duration,
+) -> (bool, String) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let snap = registry.snapshot(agent_id).unwrap_or_default();
+        let mut parser = vt100::Parser::new(40, 120, 0);
+        parser.process(&snap);
+        let screen = parser.screen().contents();
+        if screen.contains(needle) {
+            return (true, screen);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return (false, screen);
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Build an isolated `HOME` for a Claude Code worker that (a) carries the
+/// host credentials/onboarding so auth works without a fresh login flow,
+/// and (b) pre-marks `worker_cwd` as a trusted folder so Claude does NOT
+/// show its first-run "Is this a project you trust?" dialog. In production
+/// a worker pane runs in the user's already-trusted repo, so the dialog
+/// never appears; a fresh tempdir cwd would otherwise trip it and swallow
+/// the injected delegate prompt. The returned TempDir must be kept alive
+/// for the worker's lifetime.
+fn prepare_claude_home(worker_cwd: &str) -> TempDir {
+    let host_home = std::env::var("HOME").expect("HOME is set");
+    let home = common::race_safe_tempdir();
+
+    // Carry the host credentials so the worker authenticates as the host
+    // user (mirrors the harness's `with_imported_claude_credentials`).
+    std::fs::create_dir_all(home.path().join(".claude")).expect("mk .claude");
+    std::fs::copy(
+        Path::new(&host_home)
+            .join(".claude")
+            .join(".credentials.json"),
+        home.path().join(".claude").join(".credentials.json"),
+    )
+    .expect("copy claude credentials");
+
+    // Start from the host's global config (preserves oauthAccount +
+    // hasCompletedOnboarding so the worker skips the global onboarding
+    // flow), then add this cwd as a trusted project.
+    let host_cfg_path = Path::new(&host_home).join(".claude.json");
+    let mut cfg: serde_json::Value = std::fs::read_to_string(&host_cfg_path)
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_else(|| serde_json::json!({ "hasCompletedOnboarding": true }));
+    if !cfg["projects"].is_object() {
+        cfg["projects"] = serde_json::json!({});
+    }
+    cfg["projects"][worker_cwd] = serde_json::json!({
+        "hasTrustDialogAccepted": true,
+        "hasCompletedProjectOnboarding": true,
+        "projectOnboardingSeenCount": 1,
+    });
+    std::fs::write(
+        home.path().join(".claude.json"),
+        serde_json::to_string(&cfg).expect("serialize .claude.json"),
+    )
+    .expect("write isolated .claude.json");
+
+    home
+}
+
+/// Shared body for both arms: spawn `worker_command` as a long-running
+/// interactive worker, delegate a trivial task to it, and assert the
+/// daemon writes the work-done file — proving the worker auto-submitted
+/// the single-line prompt and followed the task-file footer.
+async fn run_delegate_work_done_loop(worker_command: &str, seed_claude_trust: bool) {
+    let daemon = spawn_daemon().await;
+
+    let cwd = common::race_safe_tempdir();
+    let cwd_str = cwd
+        .path()
+        .to_str()
+        .expect("worker cwd is UTF-8")
+        .to_string();
+
+    // The worker runs `dot-agent-deck work-done` from the footer, so the
+    // freshly built test binary must be on its PATH, and it needs the hook
+    // socket via DOT_AGENT_DECK_SOCKET. The PTY child inherits the rest of
+    // the environment (HOME → agent credentials), so we only overlay these.
+    let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
+    let bin_dir = Path::new(bin)
+        .parent()
+        .expect("test binary has a parent dir")
+        .to_str()
+        .expect("bin dir is UTF-8");
+    let path_env = format!("{bin_dir}:{}", std::env::var("PATH").unwrap_or_default());
+
+    let mut worker_env = vec![
+        (DOT_AGENT_DECK_PANE_ID.to_string(), WORKER_PANE.to_string()),
+        (
+            "DOT_AGENT_DECK_SOCKET".to_string(),
+            daemon.hook_path.display().to_string(),
+        ),
+        ("PATH".to_string(), path_env),
+    ];
+
+    // For Claude: point the worker at an isolated HOME that pre-trusts the
+    // tempdir cwd, so the first-run trust dialog never appears and the
+    // injected delegate prompt lands in the input box rather than being
+    // consumed answering the dialog. Held alive until the worker exits.
+    let _claude_home = if seed_claude_trust {
+        let home = prepare_claude_home(&cwd_str);
+        worker_env.push((
+            "HOME".to_string(),
+            home.path().to_str().expect("home path UTF-8").to_string(),
+        ));
+        Some(home)
+    } else {
+        None
+    };
+
+    let worker_agent_id = daemon
+        .registry
+        .spawn_agent(SpawnOptions {
+            command: Some(worker_command),
+            cwd: Some(cwd_str.as_str()),
+            rows: 40,
+            cols: 120,
+            env: worker_env,
+            ..SpawnOptions::default()
+        })
+        .expect("spawn worker agent");
+
+    // Register the orchestration maps `handle_delegate`/`handle_work_done`
+    // read, exactly as StartAgent would for a live orchestration tab.
+    {
+        let mut st = daemon.state.write().await;
+        st.pane_role_map
+            .insert(ORCH_PANE.to_string(), "orchestrator".to_string());
+        st.pane_role_map
+            .insert(WORKER_PANE.to_string(), WORKER_ROLE.to_string());
+        st.orchestrator_pane_ids.insert(ORCH_PANE.to_string());
+        let orch = ("test-orchestration".to_string(), cwd_str.clone());
+        st.pane_orchestration_map
+            .insert(ORCH_PANE.to_string(), orch.clone());
+        st.pane_orchestration_map
+            .insert(WORKER_PANE.to_string(), orch);
+        st.pane_cwd_map
+            .insert(WORKER_PANE.to_string(), cwd_str.clone());
+    }
+
+    // Let the interactive agent reach input-readiness before delegating.
+    wait_until_worker_ready(
+        &daemon.registry,
+        &worker_agent_id,
+        Duration::from_millis(1500),
+        Duration::from_secs(30),
+    )
+    .await;
+
+    let signal = DelegateSignal {
+        pane_id: ORCH_PANE.to_string(),
+        task: "List the files in the current directory using the Bash tool (for example `ls -a`). \
+               That is the entire task — do not do anything else."
+            .to_string(),
+        to: vec![WORKER_ROLE.to_string()],
+        timestamp: chrono::Utc::now(),
+    };
+    daemon
+        .state
+        .read()
+        .await
+        .handle_delegate(signal, &daemon.registry, &daemon.event_tx)
+        .await;
+
+    // The work-done file is written by `handle_work_done` only after the
+    // worker auto-submitted the injected prompt and ran the work-done CLI.
+    let work_done = cwd
+        .path()
+        .join(".dot-agent-deck")
+        .join("work-done-coder.md");
+    let ok = wait_for_path(&work_done, Duration::from_secs(120)).await;
+    let snap = daemon
+        .registry
+        .snapshot(&worker_agent_id)
+        .unwrap_or_default();
+    let pane = String::from_utf8_lossy(&snap);
+    // Self-diagnosing failure signal: did the injected prompt reach the
+    // pane, and did the agent surface an API/account error (e.g. quota)?
+    // Distinguishes "fix the test" from "fix the account/credentials".
+    let prompt_reached = pane.contains("worker-task-coder.md");
+    let lower = pane.to_lowercase();
+    let agent_errored = ["quota", "exceeded", "billing", "unauthorized", "rate limit"]
+        .iter()
+        .any(|k| lower.contains(k));
+    assert!(
+        ok,
+        "worker never produced {work_done:?}. prompt_reached_pane={prompt_reached} \
+         agent_api_error_in_pane={agent_errored}. If prompt_reached=true and \
+         agent_api_error=true, the agent's account/quota is the blocker, not the delegate \
+         path.\n=== worker pane AFTER delegate (full) ===\n{pane}\n=== end after ==="
+    );
+}
+
+/// Scenario: Start a real Claude Code (Haiku) worker as a long-running
+/// interactive agent under an in-process daemon, register it as a `coder`
+/// role in an orchestration, then call the daemon's real `handle_delegate`
+/// with a trivial "list the files" task. The single-line file-pointer
+/// prompt is injected into the worker's PTY; the worker must auto-submit
+/// it (no manual Enter), read its task file, list the files, and run
+/// `dot-agent-deck work-done`. Assert the daemon writes
+/// `.dot-agent-deck/work-done-coder.md`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn delegate_work_done_chain_claude() {
+    skip_unless!(common::check_claude_available());
+    let command = format!("claude --model {PINNED_CLAUDE_MODEL} --allowedTools Bash Read");
+    run_delegate_work_done_loop(&command, true).await;
+}
+
+/// Scenario: Confirm a real OpenCode worker AUTO-SUBMITS a daemon-injected
+/// single-line prompt — the exact #187 mechanism, for a second non-Claude
+/// agent (the case PR #188 did not claim). Unlike the Claude arm this does
+/// NOT run the full work-done loop: OpenCode's permission sandbox gates
+/// `.dot-agent-deck` reads and shell runs (it prompts "Access external
+/// directory …" / tool approval), which is orthogonal to #187. Instead we
+/// inject a purely conversational prompt via the SAME
+/// `write_to_pane_and_submit` primitive the delegate dispatch uses, and
+/// assert the model's reply renders — proving the single-line prompt was
+/// submitted without a manual Enter, with no tool permissions involved.
+///
+/// The answer token (`4444`) is absent from the prompt, so finding it in
+/// the rendered pane proves the prompt was submitted and answered, not
+/// merely echoed into the input box.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn opencode_auto_submits_daemon_injected_prompt() {
+    skip_unless!(common::check_opencode_available());
+
+    let registry = Arc::new(AgentPtyRegistry::new());
+    let cwd = common::race_safe_tempdir();
+    let cwd_str = cwd
+        .path()
+        .to_str()
+        .expect("worker cwd is UTF-8")
+        .to_string();
+
+    // OpenCode model ids are provider-qualified (`provider/model`); a bare
+    // `gpt-4o-mini` is rejected as "Invalid model format". A small model is
+    // plenty for a one-line arithmetic reply.
+    let worker_agent_id = registry
+        .spawn_agent(SpawnOptions {
+            command: Some("opencode --model openrouter/openai/gpt-4o-mini"),
+            cwd: Some(cwd_str.as_str()),
+            rows: 40,
+            cols: 120,
+            env: vec![(DOT_AGENT_DECK_PANE_ID.to_string(), WORKER_PANE.to_string())],
+            ..SpawnOptions::default()
+        })
+        .expect("spawn opencode worker");
+
+    wait_until_worker_ready(
+        &registry,
+        &worker_agent_id,
+        Duration::from_millis(1500),
+        Duration::from_secs(30),
+    )
+    .await;
+
+    registry
+        .write_to_pane_and_submit(
+            WORKER_PANE,
+            "Reply with only the number equal to 4000 plus 444.",
+        )
+        .await
+        .expect("inject prompt into opencode worker");
+
+    let (ok, screen) =
+        wait_for_rendered_text(&registry, &worker_agent_id, "4444", Duration::from_secs(90)).await;
+    assert!(
+        ok,
+        "OpenCode did not auto-submit the daemon-injected single-line prompt \
+         (no '4444' reply rendered). Rendered screen:\n{screen}"
+    );
+
+    registry.shutdown_all();
+}


### PR DESCRIPTION
## Summary
- Keep delegated worker pane prompts to a single line by sending only the file-backed task pointer through the PTY.
- Move the `work-done` completion instructions into `.dot-agent-deck/worker-task-<role>.md` instead of appending them to the injected pane prompt.
- Normalize delegate prompt input whitespace so future multiline call sites still produce a single-line pane prompt.

Fixes #187

## Scope / Manual Validation
- The reported workflow was manually validated with Claude Code workers. Codex/OpenCode behavior is not claimed by this PR.
- The change is agent-agnostic at the prompt transport layer: the pane receives one line, while the worker task file keeps the full task and completion instructions.

## Tests
- `rtk cargo fmt --check`
- `rtk cargo clippy -- -D warnings`
- `rtk cargo test -p dot-agent-deck compose_delegate_prompt_is_single_line_file_pointer`
- `rtk cargo test -p dot-agent-deck compose_delegate_prompt_normalizes_multiline_input`
- `rtk cargo test -p dot-agent-deck compose_worker_task_file_appends_work_done_footer`
- `rtk cargo test-fast`
