### PR TITLE
fix(prd-79): fan out OpenCode plugin install across every existing layout

### DIFF
--- a/changelog.d/79.bugfix.md
+++ b/changelog.d/79.bugfix.md
@@ -1,0 +1,5 @@
+## OpenCode plugin install now refreshes every existing layout
+
+Fixes a silent failure where OpenCode panes showed "No agent" / `Tools: 0` indefinitely on machines that have both `~/.config/opencode/` and `~/.opencode/` present. Previously, `auto_install` and the `install` subcommand wrote the plugin only to whichever root `detect_opencode_root` picked first (XDG wins), leaving the other layout's plugin pointing at a stale binary path. The `execFileSync` call in the stale plugin threw `ENOENT`, was silently swallowed, and no events reached the daemon.
+
+Both `auto_install` (runs on dashboard startup) and `dot-agent-deck install` now fan out and write the plugin into every existing layout root — mirroring how `uninstall` already sweeps all layouts. If only one root exists, only that one is written. If neither exists, `auto_install` remains a no-op and `install` creates the XDG default as before. The dashboard always overwrites the plugin on startup, so manually-edited plugin files in either layout will be replaced.

--- a/src/opencode_manage.rs
+++ b/src/opencode_manage.rs
@@ -48,14 +48,23 @@ fn plugin_dir_for_install() -> PathBuf {
     plugin_subpath(&xdg_default)
 }
 
+/// All candidate OpenCode config roots, XDG first then legacy, **without** checking
+/// existence — that is the caller's job. This is the single source of truth for which
+/// layouts we touch, shared by `existing_plugin_dirs` (uninstall), `auto_install`, and
+/// `install`. Adding a future layout is a one-line change here.
+fn candidate_roots() -> Vec<PathBuf> {
+    let home = home_dir();
+    vec![
+        xdg_config_root(&home).join("opencode"),
+        home.join(".opencode"),
+    ]
+}
+
 /// All plugin dirs that currently exist on disk (XDG and legacy). For uninstall.
 fn existing_plugin_dirs() -> Vec<PathBuf> {
-    let home = home_dir();
-    let xdg = xdg_config_root(&home).join("opencode");
-    let legacy = home.join(".opencode");
-    [xdg, legacy]
-        .into_iter()
-        .map(|r| plugin_subpath(&r))
+    candidate_roots()
+        .iter()
+        .map(|r| plugin_subpath(r))
         .filter(|p| p.exists())
         .collect()
 }
@@ -358,15 +367,16 @@ export default DotAgentDeckPlugin;
     )
 }
 
-fn install_impl(dir: &PathBuf, binary_path: &str) -> std::io::Result<()> {
+/// Ensure `dir` exists and (over)write `index.js` with a plugin pinned to `binary_path`.
+/// Returns the path written. Shared by every install path (auto + explicit + test seam).
+fn write_plugin(dir: &Path, binary_path: &str) -> std::io::Result<PathBuf> {
     std::fs::create_dir_all(dir)?;
 
     let path = dir.join("index.js");
     let content = plugin_template(binary_path);
     std::fs::write(&path, content)?;
 
-    println!("Installed OpenCode plugin: {}", path.display());
-    Ok(())
+    Ok(path)
 }
 
 fn uninstall_impl(dir: &PathBuf) -> std::io::Result<()> {
@@ -381,31 +391,79 @@ fn uninstall_impl(dir: &PathBuf) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Silently install OpenCode plugin if OpenCode is detected.
+/// Fan-out core for auto-install: for every candidate root that exists, refresh the
+/// plugin under `plugin/dot-agent-deck/`. Roots that don't exist are skipped — no
+/// speculative directory creation. Per-target failures are logged via `tracing::warn!`
+/// and never abort the remaining targets. Silent on stdout (dashboard startup path).
+fn auto_install_to(roots: &[PathBuf], binary_path: &str) {
+    for root in roots {
+        if !root.exists() {
+            continue;
+        }
+        let dir = plugin_subpath(root);
+        match write_plugin(&dir, binary_path) {
+            Ok(path) => tracing::info!("auto-installed OpenCode plugin: {}", path.display()),
+            Err(e) => tracing::warn!(
+                "auto-install: failed to write OpenCode plugin to {}: {e}",
+                dir.display()
+            ),
+        }
+    }
+}
+
+/// Fan-out core for explicit install: write the plugin into every candidate root that
+/// exists; if none exist, fall back to `fallback_dir` (the XDG-default plugin dir),
+/// creating it — the first-time-install behavior. Each successful write emits one
+/// `Installed OpenCode plugin: <path>` line to `out`. Every target is attempted even if
+/// an earlier one fails; the first error (if any) is returned so the caller surfaces it.
+fn install_to_roots(
+    roots: &[PathBuf],
+    fallback_dir: &Path,
+    binary_path: &str,
+    out: &mut impl std::io::Write,
+) -> std::io::Result<()> {
+    let mut targets: Vec<PathBuf> = Vec::new();
+    for root in roots {
+        if root.exists() {
+            targets.push(plugin_subpath(root));
+        }
+    }
+    if targets.is_empty() {
+        targets.push(fallback_dir.to_path_buf());
+    }
+
+    let mut first_err: Option<std::io::Error> = None;
+    for dir in &targets {
+        match write_plugin(dir, binary_path) {
+            Ok(path) => {
+                let _ = writeln!(out, "Installed OpenCode plugin: {}", path.display());
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "install: failed to write OpenCode plugin to {}: {e}",
+                    dir.display()
+                );
+                if first_err.is_none() {
+                    first_err = Some(e);
+                }
+            }
+        }
+    }
+
+    match first_err {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+/// Silently install OpenCode plugin into every existing layout.
 /// Intended for dashboard startup — never prints to stdout.
 pub fn auto_install() {
-    let Some(root) = detect_opencode_root() else {
-        return;
-    };
-
     let binary_path = std::env::current_exe()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "dot-agent-deck".into());
 
-    let dir = plugin_subpath(&root);
-    if let Err(e) = std::fs::create_dir_all(&dir) {
-        tracing::warn!("auto-install: failed to create OpenCode plugin dir: {e}");
-        return;
-    }
-
-    let path = dir.join("index.js");
-    let content = plugin_template(&binary_path);
-    if let Err(e) = std::fs::write(&path, content) {
-        tracing::warn!("auto-install: failed to write OpenCode plugin: {e}");
-        return;
-    }
-
-    tracing::info!("auto-installed OpenCode plugin: {}", path.display());
+    auto_install_to(&candidate_roots(), &binary_path);
 }
 
 pub fn install() -> std::io::Result<()> {
@@ -413,7 +471,12 @@ pub fn install() -> std::io::Result<()> {
         .map(|p| p.display().to_string())
         .unwrap_or_else(|_| "dot-agent-deck".into());
 
-    install_impl(&plugin_dir_for_install(), &binary_path)
+    install_to_roots(
+        &candidate_roots(),
+        &plugin_dir_for_install(),
+        &binary_path,
+        &mut std::io::stdout(),
+    )
 }
 
 pub fn uninstall() -> std::io::Result<()> {
@@ -430,8 +493,10 @@ pub fn uninstall() -> std::io::Result<()> {
 
 // --- Testable versions that accept a custom path ---
 
-pub fn install_to(dir: &PathBuf, binary_path: &str) -> std::io::Result<()> {
-    install_impl(dir, binary_path)
+pub fn install_to(dir: &Path, binary_path: &str) -> std::io::Result<()> {
+    let path = write_plugin(dir, binary_path)?;
+    println!("Installed OpenCode plugin: {}", path.display());
+    Ok(())
 }
 
 pub fn uninstall_from(dir: &PathBuf) -> std::io::Result<()> {
@@ -466,5 +531,212 @@ mod tests {
             plugin_subpath(&root),
             PathBuf::from("/some/opencode/plugin/dot-agent-deck")
         );
+    }
+
+    /// Read the installed plugin under `root` and assert its `BINARY_PATH` matches.
+    fn assert_plugin_binary(root: &Path, binary_path: &str) {
+        let index = plugin_subpath(root).join("index.js");
+        let content = std::fs::read_to_string(&index)
+            .unwrap_or_else(|e| panic!("expected plugin at {}: {e}", index.display()));
+        assert!(
+            content.contains(&format!(r#"BINARY_PATH = "{binary_path}""#)),
+            "plugin at {} should pin BINARY_PATH = {binary_path:?}",
+            index.display()
+        );
+    }
+
+    #[test]
+    fn auto_install_writes_to_both_existing_roots() {
+        let tmp = tempfile::tempdir().unwrap();
+        let xdg_root = tmp.path().join(".config").join("opencode");
+        let legacy_root = tmp.path().join(".opencode");
+        std::fs::create_dir_all(&xdg_root).unwrap();
+        std::fs::create_dir_all(&legacy_root).unwrap();
+
+        auto_install_to(&[xdg_root.clone(), legacy_root.clone()], "/bin/deck-both");
+
+        assert_plugin_binary(&xdg_root, "/bin/deck-both");
+        assert_plugin_binary(&legacy_root, "/bin/deck-both");
+    }
+
+    #[test]
+    fn auto_install_only_legacy_present_skips_xdg() {
+        let tmp = tempfile::tempdir().unwrap();
+        let xdg_root = tmp.path().join(".config").join("opencode"); // NOT created
+        let legacy_root = tmp.path().join(".opencode");
+        std::fs::create_dir_all(&legacy_root).unwrap();
+
+        auto_install_to(&[xdg_root.clone(), legacy_root.clone()], "/bin/deck-legacy");
+
+        assert_plugin_binary(&legacy_root, "/bin/deck-legacy");
+        assert!(!xdg_root.exists(), "absent XDG root must not be created");
+        assert!(!plugin_subpath(&xdg_root).exists());
+    }
+
+    #[test]
+    fn auto_install_only_xdg_present_skips_legacy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let xdg_root = tmp.path().join(".config").join("opencode");
+        let legacy_root = tmp.path().join(".opencode"); // NOT created
+        std::fs::create_dir_all(&xdg_root).unwrap();
+
+        auto_install_to(&[xdg_root.clone(), legacy_root.clone()], "/bin/deck-xdg");
+
+        assert_plugin_binary(&xdg_root, "/bin/deck-xdg");
+        assert!(
+            !legacy_root.exists(),
+            "absent legacy root must not be created"
+        );
+        assert!(!plugin_subpath(&legacy_root).exists());
+    }
+
+    #[test]
+    fn auto_install_neither_present_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let xdg_root = tmp.path().join(".config").join("opencode");
+        let legacy_root = tmp.path().join(".opencode");
+        // Neither root created.
+
+        auto_install_to(&[xdg_root.clone(), legacy_root.clone()], "/bin/deck-none");
+
+        assert!(!xdg_root.exists());
+        assert!(!legacy_root.exists());
+        assert!(!plugin_subpath(&xdg_root).exists());
+        assert!(!plugin_subpath(&legacy_root).exists());
+    }
+
+    #[test]
+    fn auto_install_idempotent_overwrites_every_layout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let xdg_root = tmp.path().join(".config").join("opencode");
+        let legacy_root = tmp.path().join(".opencode");
+        std::fs::create_dir_all(&xdg_root).unwrap();
+        std::fs::create_dir_all(&legacy_root).unwrap();
+        let roots = [xdg_root.clone(), legacy_root.clone()];
+
+        auto_install_to(&roots, "/bin/deck-old");
+        auto_install_to(&roots, "/bin/deck-new");
+
+        for root in [&xdg_root, &legacy_root] {
+            let content = std::fs::read_to_string(plugin_subpath(root).join("index.js")).unwrap();
+            assert!(content.contains(r#"BINARY_PATH = "/bin/deck-new""#));
+            assert!(!content.contains(r#"BINARY_PATH = "/bin/deck-old""#));
+        }
+    }
+
+    #[test]
+    fn auto_install_one_layout_failure_still_writes_other() {
+        let tmp = tempfile::tempdir().unwrap();
+        let xdg_root = tmp.path().join(".config").join("opencode");
+        let legacy_root = tmp.path().join(".opencode");
+        std::fs::create_dir_all(&xdg_root).unwrap();
+        std::fs::create_dir_all(&legacy_root).unwrap();
+        // Block the XDG write: a regular file where `plugin/` must be a dir makes
+        // `create_dir_all` fail for the XDG target only.
+        std::fs::write(xdg_root.join("plugin"), b"not a dir").unwrap();
+
+        auto_install_to(&[xdg_root.clone(), legacy_root.clone()], "/bin/deck-resil");
+
+        assert_plugin_binary(&legacy_root, "/bin/deck-resil");
+        assert!(!plugin_subpath(&xdg_root).join("index.js").exists());
+    }
+
+    #[test]
+    fn install_fan_out_writes_every_existing_layout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let xdg_root = tmp.path().join(".config").join("opencode");
+        let legacy_root = tmp.path().join(".opencode");
+        std::fs::create_dir_all(&xdg_root).unwrap();
+        std::fs::create_dir_all(&legacy_root).unwrap();
+        let fallback = plugin_subpath(&tmp.path().join("fallback").join("opencode"));
+
+        let mut out = Vec::new();
+        install_to_roots(
+            &[xdg_root.clone(), legacy_root.clone()],
+            &fallback,
+            "/bin/deck-install",
+            &mut out,
+        )
+        .unwrap();
+
+        assert_plugin_binary(&xdg_root, "/bin/deck-install");
+        assert_plugin_binary(&legacy_root, "/bin/deck-install");
+        // Fallback NOT used because at least one layout existed.
+        assert!(!fallback.join("index.js").exists());
+
+        // Stdout names every written path, one line per layout.
+        let stdout = String::from_utf8(out).unwrap();
+        let lines = stdout
+            .lines()
+            .filter(|l| l.starts_with("Installed OpenCode plugin:"))
+            .count();
+        assert_eq!(lines, 2, "one line per written layout, got: {stdout:?}");
+        let xdg_index = plugin_subpath(&xdg_root)
+            .join("index.js")
+            .display()
+            .to_string();
+        let legacy_index = plugin_subpath(&legacy_root)
+            .join("index.js")
+            .display()
+            .to_string();
+        assert!(stdout.contains(xdg_index.as_str()));
+        assert!(stdout.contains(legacy_index.as_str()));
+    }
+
+    #[test]
+    fn install_falls_back_to_xdg_default_when_no_layout_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let xdg_root = tmp.path().join(".config").join("opencode"); // absent
+        let legacy_root = tmp.path().join(".opencode"); // absent
+        let fallback = plugin_subpath(&tmp.path().join(".config").join("opencode"));
+
+        let mut out = Vec::new();
+        install_to_roots(
+            &[xdg_root.clone(), legacy_root.clone()],
+            &fallback,
+            "/bin/deck-fallback",
+            &mut out,
+        )
+        .unwrap();
+
+        let content = std::fs::read_to_string(fallback.join("index.js")).unwrap();
+        assert!(content.contains(r#"BINARY_PATH = "/bin/deck-fallback""#));
+
+        let stdout = String::from_utf8(out).unwrap();
+        let lines = stdout
+            .lines()
+            .filter(|l| l.starts_with("Installed OpenCode plugin:"))
+            .count();
+        assert_eq!(lines, 1);
+        let fallback_index = fallback.join("index.js").display().to_string();
+        assert!(stdout.contains(fallback_index.as_str()));
+    }
+
+    #[test]
+    fn install_one_layout_failure_still_writes_other_and_surfaces_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let xdg_root = tmp.path().join(".config").join("opencode");
+        let legacy_root = tmp.path().join(".opencode");
+        std::fs::create_dir_all(&xdg_root).unwrap();
+        std::fs::create_dir_all(&legacy_root).unwrap();
+        std::fs::write(xdg_root.join("plugin"), b"not a dir").unwrap(); // block XDG
+
+        let fallback = plugin_subpath(&tmp.path().join("fallback"));
+        let mut out = Vec::new();
+        let result = install_to_roots(
+            &[xdg_root.clone(), legacy_root.clone()],
+            &fallback,
+            "/bin/deck-resil2",
+            &mut out,
+        );
+
+        assert!(
+            result.is_err(),
+            "a failed layout must surface as an io::Result error"
+        );
+        // The other layout is still written despite the failure.
+        assert_plugin_binary(&legacy_root, "/bin/deck-resil2");
+        let stdout = String::from_utf8(out).unwrap();
+        assert!(stdout.contains("Installed OpenCode plugin:"));
     }
 }

--- a/src/opencode_manage.rs
+++ b/src/opencode_manage.rs
@@ -14,35 +14,12 @@ fn xdg_config_root(home: &Path) -> PathBuf {
         .unwrap_or_else(|_| home.join(".config"))
 }
 
-/// Detect the active OpenCode config root, if any. Priority:
-///  1. XDG layout: `$XDG_CONFIG_HOME/opencode` (defaults to `$HOME/.config/opencode`) — used by OpenCode 1.x
-///  2. Legacy layout: `$HOME/.opencode`
-fn detect_opencode_root_in(home: &Path, xdg_config_home: Option<&Path>) -> Option<PathBuf> {
-    let xdg_root = match xdg_config_home {
-        Some(p) => p.join("opencode"),
-        None => home.join(".config").join("opencode"),
-    };
-    if xdg_root.exists() {
-        return Some(xdg_root);
-    }
-    let legacy_root = home.join(".opencode");
-    if legacy_root.exists() {
-        return Some(legacy_root);
-    }
-    None
-}
-
-fn detect_opencode_root() -> Option<PathBuf> {
-    let home = home_dir();
-    let xdg = std::env::var("XDG_CONFIG_HOME").ok().map(PathBuf::from);
-    detect_opencode_root_in(&home, xdg.as_deref())
-}
-
-/// Plugin dir target for explicit install: detected root, falling back to XDG layout.
-fn plugin_dir_for_install() -> PathBuf {
-    if let Some(root) = detect_opencode_root() {
-        return plugin_subpath(&root);
-    }
+/// The XDG-default plugin dir (`$XDG_CONFIG_HOME/opencode/plugin/dot-agent-deck`,
+/// defaulting to `$HOME/.config/opencode/...`). Used as the explicit-install fallback
+/// when no existing layout is found. Deliberately performs **no** existence checks:
+/// it is only ever evaluated after the caller has already determined that none of the
+/// candidate roots exist, so re-detecting them would be dead work.
+fn xdg_default_plugin_dir() -> PathBuf {
     let home = home_dir();
     let xdg_default = xdg_config_root(&home).join("opencode");
     plugin_subpath(&xdg_default)
@@ -475,7 +452,7 @@ pub fn install() -> std::io::Result<()> {
 
     install_to_roots(
         &candidate_roots(),
-        plugin_dir_for_install,
+        xdg_default_plugin_dir,
         &binary_path,
         &mut std::io::stdout(),
     )

--- a/src/opencode_manage.rs
+++ b/src/opencode_manage.rs
@@ -412,13 +412,15 @@ fn auto_install_to(roots: &[PathBuf], binary_path: &str) {
 }
 
 /// Fan-out core for explicit install: write the plugin into every candidate root that
-/// exists; if none exist, fall back to `fallback_dir` (the XDG-default plugin dir),
-/// creating it — the first-time-install behavior. Each successful write emits one
-/// `Installed OpenCode plugin: <path>` line to `out`. Every target is attempted even if
-/// an earlier one fails; the first error (if any) is returned so the caller surfaces it.
+/// exists; if none exist, fall back to `fallback_dir()` (the XDG-default plugin dir),
+/// creating it — the first-time-install behavior. The fallback closure is evaluated
+/// lazily, only when no layout exists, so the common path avoids the extra filesystem
+/// probe. Each successful write emits one `Installed OpenCode plugin: <path>` line to
+/// `out`. Every target is attempted even if an earlier one fails; the first error (if
+/// any) is returned so the caller surfaces it.
 fn install_to_roots(
     roots: &[PathBuf],
-    fallback_dir: &Path,
+    fallback_dir: impl FnOnce() -> PathBuf,
     binary_path: &str,
     out: &mut impl std::io::Write,
 ) -> std::io::Result<()> {
@@ -429,7 +431,7 @@ fn install_to_roots(
         }
     }
     if targets.is_empty() {
-        targets.push(fallback_dir.to_path_buf());
+        targets.push(fallback_dir());
     }
 
     let mut first_err: Option<std::io::Error> = None;
@@ -473,7 +475,7 @@ pub fn install() -> std::io::Result<()> {
 
     install_to_roots(
         &candidate_roots(),
-        &plugin_dir_for_install(),
+        plugin_dir_for_install,
         &binary_path,
         &mut std::io::stdout(),
     )
@@ -492,12 +494,6 @@ pub fn uninstall() -> std::io::Result<()> {
 }
 
 // --- Testable versions that accept a custom path ---
-
-pub fn install_to(dir: &Path, binary_path: &str) -> std::io::Result<()> {
-    let path = write_plugin(dir, binary_path)?;
-    println!("Installed OpenCode plugin: {}", path.display());
-    Ok(())
-}
 
 pub fn uninstall_from(dir: &PathBuf) -> std::io::Result<()> {
     uninstall_impl(dir)
@@ -653,7 +649,7 @@ mod tests {
         let mut out = Vec::new();
         install_to_roots(
             &[xdg_root.clone(), legacy_root.clone()],
-            &fallback,
+            || fallback.clone(),
             "/bin/deck-install",
             &mut out,
         )
@@ -693,7 +689,7 @@ mod tests {
         let mut out = Vec::new();
         install_to_roots(
             &[xdg_root.clone(), legacy_root.clone()],
-            &fallback,
+            || fallback.clone(),
             "/bin/deck-fallback",
             &mut out,
         )
@@ -725,7 +721,7 @@ mod tests {
         let mut out = Vec::new();
         let result = install_to_roots(
             &[xdg_root.clone(), legacy_root.clone()],
-            &fallback,
+            || fallback.clone(),
             "/bin/deck-resil2",
             &mut out,
         );


### PR DESCRIPTION
## Summary

- Fixes silent "No agent" / `Tools: 0" failure when both `~/.config/opencode/` and `~/.opencode/` exist on a machine
- `auto_install` and `dot-agent-deck install` now write the plugin into every existing layout root, mirroring `uninstall` semantics
- If only one root exists, only that one is written; if neither exists, behavior is unchanged

## What shipped

Both `auto_install` (runs on dashboard startup) and the explicit `install` CLI subcommand now enumerate all candidate layout roots and write the plugin to each one whose directory already exists. Previously, only the first root returned by `detect_opencode_root` was written — XDG-first — which left the legacy `~/.opencode/` plugin pointing at a stale `BINARY_PATH`, silently swallowing `ENOENT` and dropping all hook events.

## Gate results

- Reviewer APPROVE (no correctness defects)
- Auditor safe-to-ship (no new vulnerabilities)
- E2E gate green: `DOT_AGENT_DECK_RECORD=1 cargo test-e2e` — 1450 passed, 0 skipped, real-agent claude chain-smoke included

## Versioning

- No daemon/protocol/orchestration/hook changes — `PROTOCOL_VERSION` not bumped
- Plugin template wire contract byte-identical
- No `.breaking.md` fragment (bugfix → PATCH bump)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)