### PR TITLE
feat(config): add mouse.enabled to opt out of TUI mouse capture

### DIFF
--- a/changelog.d/+mouse-enabled-config.feature.md
+++ b/changelog.d/+mouse-enabled-config.feature.md
@@ -1,0 +1,1 @@
+Add a `mouse.enabled` config option (default `true`). Set it to `false` to disable the TUI's mouse capture so the terminal handles native text selection and copy: `dot-agent-deck config set mouse.enabled false`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,19 @@ dot-agent-deck config get default_command
 
 `default_command` is the agent command pre-filled in the **new-pane form**'s Command field and the value that seeds the **schedule-authoring** agent. Both the new-pane form and the Scheduled Tasks **Add/Edit** flow use the same form — you type the command directly into the **Command** field (it accepts `claude`, `opencode`, a path, or any command), pre-filled from `default_command`. If `default_command` is unset, the schedule-authoring agent falls back to `claude`.
 
+## Mouse
+
+```bash
+# Disable mouse capture so your terminal handles text selection / copy
+dot-agent-deck config set mouse.enabled false
+```
+
+| Key | Default | Description |
+|---|---|---|
+| `mouse.enabled` | `true` | Capture the mouse for in-TUI interaction (click cards/buttons, click-drag to select within a pane, OSC52 copy-to-clipboard). |
+
+When `mouse.enabled` is `true` (the default) dot-agent-deck puts the terminal into mouse-reporting mode, so click/drag is handled by the TUI. Set it to `false` if you prefer your **terminal's own** text selection and copy (select into the primary buffer, middle-click / your terminal's paste): the deck then leaves mouse reporting off entirely. The tradeoff is that the in-app mouse affordances (clickable cards/buttons and the in-pane mouse selection + its clipboard copy) are unavailable while disabled — every action still has a keyboard shortcut (press `?`). Note: with capture **on**, you can still do a one-off native selection in most terminals by holding **Shift** while dragging.
+
 ## Environment Variables
 
 | Variable | Default | Description |

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,10 @@ pub const CONFIG_KEYS: &[(&str, &str)] = &[
     ),
     ("bell.on_error", "Bell on agent error (default: true)"),
     (
+        "mouse.enabled",
+        "Capture the mouse for in-TUI click/drag; set false for native terminal text selection and copy (default: true)",
+    ),
+    (
         "idle_art.enabled",
         "Enable ASCII art in dashboard idle cards (default: false)",
     ),
@@ -151,6 +155,23 @@ impl BellConfig {
     }
 }
 
+/// Mouse capture for the TUI. When `enabled` is false, dot-agent-deck does NOT
+/// put the terminal into mouse-reporting mode, so the terminal's own text
+/// selection / copy works normally. The tradeoff: the in-app mouse selection
+/// (click/drag a pane, click cards/buttons) and its OSC52 "copy to clipboard"
+/// are unavailable while disabled. Default: true (preserves the click/drag UI).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct MouseConfig {
+    pub enabled: bool,
+}
+
+impl Default for MouseConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct IdleArtConfig {
@@ -178,6 +199,7 @@ impl Default for IdleArtConfig {
 pub struct DashboardConfig {
     pub default_command: String,
     pub bell: BellConfig,
+    pub mouse: MouseConfig,
     pub idle_art: IdleArtConfig,
     pub auto_config_prompt: bool,
 }
@@ -187,6 +209,7 @@ impl Default for DashboardConfig {
         Self {
             default_command: String::new(),
             bell: BellConfig::default(),
+            mouse: MouseConfig::default(),
             idle_art: IdleArtConfig::default(),
             auto_config_prompt: true,
         }
@@ -231,6 +254,7 @@ impl DashboardConfig {
             "bell.on_waiting_for_input" => Ok(self.bell.on_waiting_for_input.to_string()),
             "bell.on_idle" => Ok(self.bell.on_idle.to_string()),
             "bell.on_error" => Ok(self.bell.on_error.to_string()),
+            "mouse.enabled" => Ok(self.mouse.enabled.to_string()),
             "idle_art.enabled" => Ok(self.idle_art.enabled.to_string()),
             "idle_art.provider" => Ok(self.idle_art.provider.clone()),
             "idle_art.model" => Ok(self.idle_art.model.clone()),
@@ -263,6 +287,10 @@ impl DashboardConfig {
             }
             "bell.on_error" => {
                 self.bell.on_error = parse_bool(value)?;
+                Ok(())
+            }
+            "mouse.enabled" => {
+                self.mouse.enabled = parse_bool(value)?;
                 Ok(())
             }
             "idle_art.enabled" => {
@@ -1387,6 +1415,37 @@ on_idle = true
         assert!(!dc.bell.enabled);
         assert!(dc.bell.on_idle);
         assert!(dc.bell.on_waiting_for_input);
+    }
+
+    #[test]
+    fn mouse_config_defaults() {
+        let mc = MouseConfig::default();
+        assert!(mc.enabled);
+    }
+
+    #[test]
+    fn dashboard_config_without_mouse_section() {
+        let dc: DashboardConfig = toml::from_str("default_command = \"x\"").unwrap();
+        assert!(dc.mouse.enabled);
+    }
+
+    #[test]
+    fn dashboard_config_with_mouse_section() {
+        let toml_str = r#"
+[mouse]
+enabled = false
+"#;
+        let dc: DashboardConfig = toml::from_str(toml_str).unwrap();
+        assert!(!dc.mouse.enabled);
+    }
+
+    #[test]
+    fn mouse_enabled_get_set_roundtrip() {
+        let mut dc = DashboardConfig::default();
+        assert_eq!(dc.get_field("mouse.enabled").unwrap(), "true");
+        dc.set_field("mouse.enabled", "false").unwrap();
+        assert_eq!(dc.get_field("mouse.enabled").unwrap(), "false");
+        assert!(!dc.mouse.enabled);
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6285,12 +6285,18 @@ pub fn run_tui(
         original_hook(info);
     }));
 
-    // Enable mouse capture and bracketed paste so events reach our event loop.
+    // Enable bracketed paste so paste events reach our event loop. Mouse capture
+    // is opt-out via `mouse.enabled` (config): when disabled we leave the
+    // terminal's own mouse handling in place so native text selection / copy
+    // works. The teardown DisableMouseCapture stays unconditional -- it is a
+    // harmless no-op when capture was never enabled.
     crossterm::execute!(
         std::io::stdout(),
-        crossterm::event::EnableMouseCapture,
         crossterm::event::EnableBracketedPaste,
     )?;
+    if config.mouse.enabled {
+        crossterm::execute!(std::io::stdout(), crossterm::event::EnableMouseCapture)?;
+    }
 
     let mut terminal = ratatui::init();
     let mut tick: u64 = 0;


### PR DESCRIPTION
## Summary

Add a `mouse.enabled` config option (default `true`) so users can opt out of the
TUI's mouse capture and let their terminal handle native text selection / copy.

`run_tui` enabled mouse capture unconditionally, putting the terminal into
mouse-reporting mode and preventing native select/copy. This makes it a config
toggle, mirroring the existing `bell` / `idle_art` config.

## Changes

- **config** (`src/config.rs`): `MouseConfig { enabled: bool = true }` wired into
  `CONFIG_KEYS` / `get_field` / `set_field`, with unit tests (defaults, `[mouse]`
  section parse, get/set roundtrip).
- **ui** (`src/ui.rs`): gate `EnableMouseCapture` on `config.mouse.enabled`.
  Bracketed paste and the teardown `DisableMouseCapture` stay unconditional (the
  latter is a no-op when capture was never enabled).
- **docs** (`docs/configuration.md`): new "Mouse" section.
- **changelog**: feature fragment.

## Behavior / compatibility

- Default `true` → **no behavior change** for existing users; click/drag UI and
  OSC52 copy keep working.
- `mouse.enabled = false` → terminal owns the mouse (native select/copy); in-app
  mouse affordances are inert, but every action still has a keyboard shortcut.
- Set via: `dot-agent-deck config set mouse.enabled false`

## Testing

`cargo test` — adds 4 unit tests: `mouse_config_defaults`,
`dashboard_config_without_mouse_section`, `dashboard_config_with_mouse_section`,
`mouse_enabled_get_set_roundtrip`.

Closes #197