### PR TITLE
fix: show restored agents as Idle before first event

### DIFF
--- a/changelog.d/204.bugfix.md
+++ b/changelog.d/204.bugfix.md
@@ -1,0 +1,5 @@
+## Restored agent panes show Idle immediately
+
+Restored panes whose saved command identifies Claude Code, OpenCode, or Pi now show `Idle` as soon as the agent process starts. Previously, Agent Deck inferred the agent type for the daemon but discarded it from the local dashboard placeholder, so a recognized agent incorrectly appeared as `No agent` until its first lifecycle event.
+
+The inferred type is also retained when a saved mode cannot be rebuilt and falls back to a plain dashboard pane. No configuration changes are required.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7087,10 +7087,9 @@ pub fn run_tui(
             // rounding once every restored pane is in the layout.
             let (rows, cols) =
                 dashboard_restore_pane_dims(&*pane, &tab_manager, terminal.get_frame().area());
-            // PRD #76 M2.13: infer agent_type from the restored command so
-            // the daemon's registry echo on reconnect carries the right
-            // type. Local-mode session card pick-up still happens via the
-            // next `SessionStart` hook.
+            // Infer the agent type once so both the daemon registry and the
+            // local placeholder identify a recognized command immediately.
+            let agent_type = AgentType::from_command(cmd);
             match pane.create_pane_with_options(
                 cmd,
                 Some(&saved_pane.dir),
@@ -7099,7 +7098,7 @@ pub fn run_tui(
                     tab_membership: None,
                     rows,
                     cols,
-                    agent_type: AgentType::from_command(cmd),
+                    agent_type: agent_type.clone(),
                     // PRD #201: single-pane spawn — no native seed.
                     seed: None,
                 },
@@ -7116,15 +7115,10 @@ pub fn run_tui(
                     {
                         let mut st = state.blocking_write();
                         st.register_pane(new_id.clone());
-                        // PRD #76 M2.13: the daemon-bound spawn above tags
-                        // the registry entry with the inferred agent type so
-                        // a later reconnect's hydration knows it; the local
-                        // placeholder stays at `None` until the next
-                        // `SessionStart` hook fires (pre-M2.13 contract).
                         st.insert_placeholder_session(
                             new_id.clone(),
                             Some(saved_pane.dir.clone()),
-                            None,
+                            agent_type,
                             new_agent_id,
                         );
                     }
@@ -7281,7 +7275,7 @@ pub fn run_tui(
                                         st.insert_placeholder_session(
                                             fb_id.clone(),
                                             Some(saved_pane.dir.clone()),
-                                            None,
+                                            fb_agent_type,
                                             fb_agent_id,
                                         );
                                     }
@@ -7348,7 +7342,7 @@ pub fn run_tui(
                                 st.insert_placeholder_session(
                                     fb_id.clone(),
                                     Some(saved_pane.dir.clone()),
-                                    None,
+                                    fb_agent_type,
                                     fb_agent_id,
                                 );
                             }

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -1531,6 +1531,13 @@ without depending on the config struct API.
 - **Does not assert:** the live-path title plumbing (already covered by the new-pane orchestration flow); the serde round-trip of the new field in isolation (a unit test the coder adds with the field).
 - **Platform coverage:** mac+linux.
 
+##### session/restore/014 — A restored pane whose command identifies a supported agent immediately shows that agent as Idle.
+- **Layer:** L2 (real-binary PTY; `DOT_AGENT_DECK_SESSION` redirected to a test-owned path; daemon freshly spawned and empty).
+- **Agent:** none (a test-owned executable named `opencode` runs `sleep 600`; no LLM or OpenCode hook event).
+- **Asserts:** restoring a saved plain pane whose command basename is `opencode` immediately renders an `Idle` card and never requires a hook event to replace the `No agent` placeholder identity.
+- **Does not assert:** OpenCode plugin delivery or later working/waiting transitions; restore fallback paths after a mode-tab failure.
+- **Platform coverage:** mac+linux.
+
 ### Live session status on reconnect (PRD #162)
 
 These entries cover PRD #162: on TUI reconnect the daemon's `ListAgents` must attach the live, event-derived session state (a `SessionSnapshot` on each `AgentRecord`) so reconnected cards show real status instead of `Idle`/"No agent". The data already exists in `AppState.sessions` (built by `apply_event`, unchanged); this PRD only exposes it. The wire field `live: Option<SessionSnapshot>` is additive/optional — no `PROTOCOL_VERSION` bump.

--- a/tests/e2e_session_restore.rs
+++ b/tests/e2e_session_restore.rs
@@ -855,7 +855,11 @@ fn restore_014_recognized_agent_is_idle_before_first_hook() {
     deck.wait_for_string("restored-opencode");
     let idle = common::wait_until(Duration::from_secs(10), || {
         let grid = deck.snapshot_grid();
-        grid.contains("Idle") && !grid.contains("No agent")
+        grid.lines().any(|line| {
+            line.contains("restored-opencode")
+                && line.contains("Idle")
+                && !line.contains("No agent")
+        })
     });
     assert!(
         idle,

--- a/tests/e2e_session_restore.rs
+++ b/tests/e2e_session_restore.rs
@@ -816,3 +816,51 @@ fn restore_013_custom_orchestration_tab_title_is_preserved_on_restore() {
         deck.snapshot_grid()
     );
 }
+
+/// Scenario: Stage a saved plain pane whose test-owned command is an executable
+/// named `opencode`, then launch against an empty daemon without emitting any
+/// hook event. The restored card must immediately identify the agent and render
+/// `Idle`, rather than showing `No agent` until the first prompt.
+#[spec("session/restore/014")]
+#[test]
+fn restore_014_recognized_agent_is_idle_before_first_hook() {
+    let session_dir = common::race_safe_tempdir();
+    let fake_opencode = session_dir.path().join("opencode");
+    std::fs::write(&fake_opencode, "#!/bin/sh\nsleep 600\n")
+        .expect("write fake opencode executable");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&fake_opencode, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod fake opencode executable");
+    }
+
+    let session_file = session_dir.path().join("session.toml");
+    stage_session_snapshot(
+        &session_file,
+        session_dir.path(),
+        &[(
+            "restored-opencode",
+            fake_opencode.to_str().expect("command path is UTF-8"),
+        )],
+    );
+
+    let deck = TuiDeck::builder()
+        .with_env(
+            "DOT_AGENT_DECK_SESSION",
+            session_file.to_str().expect("session path is UTF-8"),
+        )
+        .launch_with_fixture("minimal");
+
+    deck.wait_for_string("restored-opencode");
+    let idle = common::wait_until(Duration::from_secs(10), || {
+        let grid = deck.snapshot_grid();
+        grid.contains("Idle") && !grid.contains("No agent")
+    });
+    assert!(
+        idle,
+        "a restored command already recognized as OpenCode must render Idle before any hook \
+         event, not No agent.\nFinal grid:\n{}",
+        deck.snapshot_grid()
+    );
+}


### PR DESCRIPTION
## Summary

- seed restored dashboard placeholders with the same command-inferred agent type sent to the daemon
- preserve the inferred type in both mode-restore fallback paths
- add an L2 regression proving a restored OpenCode command renders `Idle` before any hook event
- add a bugfix changelog fragment for #204

## Why

Saved panes already infer `OpenCode`, `ClaudeCode`, or `Pi` when spawning the daemon-side process, but the local placeholder discarded that value and rendered `No agent` until the first lifecycle event. Reusing the same inferred value makes the initial card accurately render `Idle`.

## Tests

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test-fast` (1013 passed)
- `cargo test-e2e restore_014`
- full `cargo test-e2e`: 1792/1796 passed, including `restore_014`; four unrelated baseline/environment failures remained (`write_to_pane_notice_skips_submit_delay`, `dispatch_005_respects_max_per_run`, `new_pane_008_schedule_authoring_opens_as_dashboard_card` because `claude` is unavailable, and `opencode_auto_submits_daemon_injected_prompt` against OpenCode 1.18.3)
- `cargo xtask linkage-check` reaches the existing four forbidden-sleep findings in unchanged `tests/e2e_delegate_work_done_chain.rs`

No TUI-daemon wire shape or semantics changed; no protocol version bump is required.

Refs #204