### PR TITLE
chore(devbox): drop kubernetes-helm — nothing in this repo runs helm

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -3,7 +3,6 @@
   "packages": [
     "vals@0.44.5",
     "go-task@3.48.0",
-    "kubernetes-helm@4.2.3",
     "git@2.55.0",
     "upcloud-cli@3.29.0",
     "gh@2.96.0",

--- a/devbox.lock
+++ b/devbox.lock
@@ -703,44 +703,6 @@
         }
       }
     },
-    "kubernetes-helm@4.2.3": {
-      "last_modified": "2026-07-23T05:10:05Z",
-      "resolved": "github:NixOS/nixpkgs/7525d999cd850b9a488817abc89c75dc733acf17#kubernetes-helm",
-      "source": "devbox-search",
-      "version": "4.2.3",
-      "systems": {
-        "aarch64-darwin": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/pskv3khyizrc09rnqrp6d0wn5pllripx-kubernetes-helm-4.2.3",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/pskv3khyizrc09rnqrp6d0wn5pllripx-kubernetes-helm-4.2.3"
-        },
-        "aarch64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/k99lgyz9k814kr389jirpim37nqpi7qp-kubernetes-helm-4.2.3",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/k99lgyz9k814kr389jirpim37nqpi7qp-kubernetes-helm-4.2.3"
-        },
-        "x86_64-linux": {
-          "outputs": [
-            {
-              "name": "out",
-              "path": "/nix/store/n1rbyfp9sn0r0gzx4z9lniisiad9h5yq-kubernetes-helm-4.2.3",
-              "default": true
-            }
-          ],
-          "store_path": "/nix/store/n1rbyfp9sn0r0gzx4z9lniisiad9h5yq-kubernetes-helm-4.2.3"
-        }
-      }
-    },
     "ripgrep@15.2.0": {
       "last_modified": "2026-07-23T05:10:05Z",
       "resolved": "github:NixOS/nixpkgs/7525d999cd850b9a488817abc89c75dc733acf17#ripgrep",


### PR DESCRIPTION
#281 bumped `kubernetes-helm` 3.20.2 → 4.2.3 earlier today — a major — which prompted asking what it was actually for. Answer: nothing.

## The audit

A grep for `helm (template|install|upgrade|package|push|lint|dep|repo)` across every workflow, script and Taskfile returns **nothing**. Every `helm` reference outside `site/helm/` is prose or an example:

| Reference | What it is |
|---|---|
| `docs-publish.yml` | Edits Helm **files** with `yq` (`.image.tag`, `.version`, `.appVersion`). Never shells out to helm. |
| `docs/workspace-modes.md`, `assets/config_gen_prompt.md` | `helm list` / `helm status` as example **patterns** documenting workspace-modes — what a *user* might configure for their own project |
| `dot-ai`, `write-docs` skills | Prose about another project's workflow |

**The chart is rendered by Argo CD**, server-side, with its own bundled Helm — per `publish-docs/SKILL.md` it watches `values.yaml` and syncs. So chart compatibility is governed by Argo's Helm version, never by devbox's.

## Why remove rather than keep

It was a devbox shell convenience nobody used, and its only practical effect was a stream of Renovate PRs — including a major bump that had to be reviewed and reasoned about today. Removing the dependency removes the noise with it.

Reversible with `devbox add kubernetes-helm` if a chart workflow ever needs it locally. **Does not affect the deployed docs site.**

## Note on the diff

`devbox rm` also reflowed an unrelated `codex-big` alias into multi-line form; I reverted that so the diff is only the removal — one line from `devbox.json`, the resolved nixpkgs entry from `devbox.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)