### PR TITLE
ci: run the Linux tier with nextest, like the local gate and the other jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,29 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2 # v2
+      - uses: taiki-e/install-action@nextest
       - run: cargo fmt --check
       - run: cargo clippy -- -D warnings
       - run: cargo build --release
-      - run: cargo test
+      # `cargo nextest run`, NOT `cargo test` — the same runner as the
+      # `cargo test-fast` local gate, and as build-macos/build-windows which
+      # already use it. `cargo test` runs the whole tier in ONE process with
+      # parallel threads; nextest gives each test its own process.
+      #
+      # That difference produced real flakes. On 2026-07-30, two different
+      # timing-sensitive tests failed here and nowhere else:
+      # `delegate_injects_single_line_pointer_and_keeps_footer_in_task_file`
+      # (waiting on a PTY write; task file came back empty) and
+      # `login_shell::tests::captures_path_despite_large_stdout_banner`
+      # (subprocess plus a large stdout drain). Both passed on re-run with no
+      # code change, both passed on macOS and Windows in the SAME runs, and
+      # `cargo nextest run` passed 1343/1343 locally throughout — the three jobs
+      # were a natural experiment and only the `cargo test` one flaked.
+      #
+      # Aligning the runners also makes a CI failure reproducible locally, which
+      # neither of those was, and makes "green locally" mean the same thing as
+      # "green in CI".
+      - run: cargo nextest run
 
   # PRD #42 M8 — native Windows (x86_64-pc-windows-msvc) compile + clippy +
   # unit-test gate, running parallel to the Linux `build` job so a Windows-only


### PR DESCRIPTION
Two different tests flaked in CI today and nowhere else:

| Test | PR | Symptom |
|---|---|---|
| `delegate_injects_single_line_pointer_and_keeps_footer_in_task_file` | #294 | waiting on a PTY write; task file came back empty |
| `login_shell::tests::captures_path_despite_large_stdout_banner` | #291 | subprocess plus a large stdout drain |

Both passed on re-run with **no code change**, and neither PR touched Rust source (#294 was devbox-only, #291 was workflow-only).

## The three build jobs were an unintentional natural experiment

| Job | Runner | Result on both occasions |
|---|---|---|
| `build` (Linux) | `cargo test` | **flaked** |
| `build-macos` | `cargo nextest run` | passed |
| `build-windows` | `cargo nextest run` | passed |
| local `cargo test-fast` | `cargo nextest run` | 1343/1343, repeatedly |

`cargo test` runs the whole tier in **one process with parallel threads**; nextest gives each test **its own process**. These are timing-sensitive tests that spawn PTYs and subprocesses, so sharing a process with ~900 others starves them.

So this isn't a new convention — it brings the **last** job in line with the other two and with the `cargo test-fast` gate contributors actually run.

## What it buys beyond the flakes

- A CI failure becomes **reproducible locally** — neither of today's was.
- "Green locally" and "green in CI" start meaning the same thing.

## What it costs — checked, not assumed

nextest does not run doctests, so I verified what would be dropped:

- `cargo test --doc` → **0 tests**
- The only doc fences in the crate are ```` ```text ```` (`codex_hooks_manage.rs`, `daemon_protocol.rs`) and ```` ```json ```` (`agent_pty.rs`) — non-Rust, so cargo never compiled them

**No coverage lost.** Both previously-flaky tests pass under nextest locally (0.03s each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)