### PR TITLE
fix(tests): un-orphan two catalog entries, and make CI actually run linkage-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,15 @@ jobs:
       # neither of those was, and makes "green locally" mean the same thing as
       # "green in CI".
       - run: cargo nextest run
+      # CLAUDE.md rule 7 has always SAID this runs in CI ("CI's linkage-check
+      # rule 7 fails the build if the Scenario comment is missing or the
+      # generator fails"), and the build-macos/build-windows comment says these
+      # steps "stay on the Linux job" — but no such step existed, so nothing
+      # enforced either claim. Added 2026-07-30 after a revert removed two
+      # `#[spec]`-annotated tests and left their tests/CATALOG.md entries
+      # orphaned: linkage-check was failing on main and no gate noticed, because
+      # it only ever ran when somebody invoked it by hand.
+      - run: cargo xtask linkage-check
 
   # PRD #42 M8 — native Windows (x86_64-pc-windows-msvc) compile + clippy +
   # unit-test gate, running parallel to the Linux `build` job so a Windows-only

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -441,20 +441,6 @@ Demo-reel eligibility marker: a trailing ` [reel]` on an entry's `##### <id> —
 - **Does not assert:** stdout classification or socket transport (covered by `codex/wrap/001`).
 - **Platform coverage:** mac+linux+windows.
 
-##### status/agent-event/005 — A respawned agent whose first event is NOT a `SessionStart` still retires the previous card, so one pane keeps one card.
-- **Layer:** L1 (two `SyntheticAgent` generations on one pane, applied through `AppState::apply_event`).
-- **Agent:** synthetic Pi identity (the only shipped agent with no `SessionStart`).
-- **Asserts:** after a `clear = true` respawn mints a new `agent_id`, the outgoing generation's card is retired by the incoming generation's first `agent-event` (`Thinking`), leaving exactly one session on the pane, carrying the new `agent_id`.
-- **Does not assert:** the orchestration deck's rendering of the duplicate (the unreachable-highlight consequence is pinned by the `sync_and_derive_selection` unit tests in `src/tab.rs`); the Pi extension's own state mapping (TS unit tests).
-- **Platform coverage:** mac+linux+windows.
-
-##### status/agent-event/006 — A delayed event from the OUTGOING agent does not retire the incoming agent's live card.
-- **Layer:** L1 (out-of-order `AgentEvent` timestamps applied through `AppState::apply_event`).
-- **Agent:** synthetic Pi identity.
-- **Asserts:** once the incoming generation has established its card, an older-timestamped event from the previous `agent_id` leaves that live card intact — the monotonicity guard that makes retiring on a non-`SessionStart` event safe.
-- **Does not assert:** that the stale event is dropped entirely (it may still surface its own card; what must hold is that the LIVE card survives).
-- **Platform coverage:** mac+linux+windows.
-
 ### Agent protocol
 
 #### protocol/live-target


### PR DESCRIPTION
**`linkage-check` has been failing on `main`** and nothing noticed:

```
catalog ID `status/agent-event/005` has no #[spec(...)]-annotated test
catalog ID `status/agent-event/006` has no #[spec(...)]-annotated test
```

## My fault, and how

`78f92b6` added those two `#[spec]`-annotated tests in `tests/agent_event.rs`. `f1e9f82` — a **different** commit — added their prose to `tests/CATALOG.md`. Reverting `78f92b6` (`8f579dd`) removed the tests but could not remove catalog entries it never added, leaving them orphaned. I ran `linkage-check` *before* that revert and never after.

Both entries describe behaviour that no longer exists — retiring a card on a non-`SessionStart` event, and the monotonicity guard that made it safe. So removing the prose is correct rather than a workaround: the behaviour is gone and is tracked in **#284**, whose checklist already requires restoring the tests. Restoring the catalog prose belongs with them, and this PR is the reason it will be missing when someone gets there.

## The part that actually matters

**Why did nobody find out?** CLAUDE.md rule 7 says:

> *"CI's linkage-check rule 7 fails the build if the Scenario comment is missing or the generator fails."*

And the `build-macos`/`build-windows` comment says these steps *"stay on the Linux job."* **Neither was true.** No workflow ran `cargo xtask linkage-check`, so it only ever ran when somebody invoked it by hand — which is how a broken `main` survived a release, eleven merged PRs, and five CI runs in one day.

The Linux job now runs it. That makes rule 7 accurate instead of aspirational, and turns this class of breakage into a red build rather than a discovery.

## How it surfaced

While checking whether syn v3 (#300) changed `syn::parse_file` behaviour inside `linkage-check` — a question CI cannot answer, since it never ran the tool. **syn v3 is exonerated**: `main` fails identically on syn 2. But the question is what surfaced this.

## Verification

| Gate | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo nextest run` | 1343/1343 |
| `cargo xtask linkage-check` | **ok** — 398 catalog ids, 323 annotations, 101 allowlisted, 7 rules |

🤖 Generated with [Claude Code](https://claude.com/claude-code)