### PR TITLE
fix: swallow mouse wheel in the Scheduled Tasks manager dialog

### DIFF
--- a/changelog.d/142.bugfix.md
+++ b/changelog.d/142.bugfix.md
@@ -1,0 +1,5 @@
+## Scheduled Tasks Dialog Now Captures the Mouse Wheel
+
+The Scheduled Tasks manager dialog no longer leaks mouse-wheel scrolling to the pane behind it. Previously, scrolling the wheel while the dialog was open scrolled the mode-tab pane underneath instead of the dialog itself, forcing users to scroll blind or fall back to the keyboard.
+
+The wheel now scrolls the task list in the dialog directly, matching the existing j/k keyboard navigation.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5310,6 +5310,23 @@ fn handle_help_key(key: KeyEvent, ui: &mut UiState) -> Action {
     Action::Continue
 }
 
+/// Issue #142: one step of the Scheduled Tasks manager selection, WRAPPING at
+/// both ends. Extracted so the mouse wheel and the keyboard (`j`/Down,
+/// `k`/Up) share one definition of "next/previous row" and cannot drift apart —
+/// the wheel has no independent scroll offset, it moves `scheduled_selected` and
+/// the rendered viewport follows via [`visible_window`]. An empty list returns
+/// `selected` unchanged, so it neither panics nor underflows on `len - 1`.
+fn step_scheduled_selection(selected: usize, len: usize, forward: bool) -> usize {
+    if len == 0 {
+        return selected;
+    }
+    if forward {
+        (selected + 1) % len
+    } else {
+        (selected + len - 1) % len
+    }
+}
+
 /// PRD #127 M3.3: key handling for the "Scheduled Tasks" manager dialog.
 /// Read-only-plus-actions: `j`/`k` move the selection, `a` adds, `Enter`/`e`
 /// edits the selected row (both spawn the seeded authoring agent), `d` asks to
@@ -5348,15 +5365,11 @@ fn handle_scheduled_tasks_key(key: KeyEvent, ui: &mut UiState) -> Action {
             Action::Continue
         }
         KeyCode::Char('j') | KeyCode::Down => {
-            if len > 0 {
-                ui.scheduled_selected = (ui.scheduled_selected + 1) % len;
-            }
+            ui.scheduled_selected = step_scheduled_selection(ui.scheduled_selected, len, true);
             Action::Continue
         }
         KeyCode::Char('k') | KeyCode::Up => {
-            if len > 0 {
-                ui.scheduled_selected = (ui.scheduled_selected + len - 1) % len;
-            }
+            ui.scheduled_selected = step_scheduled_selection(ui.scheduled_selected, len, false);
             Action::Continue
         }
         // Add: PRD #170 (unify) — reuse the `Ctrl+n` flow. Open the directory
@@ -6009,7 +6022,7 @@ pub fn global_action(kb: &KeybindingConfig, key: &KeyEvent) -> Option<Action> {
 /// destructive, and two of them are the way *out* of a pane.
 ///
 /// PRD #241 review F1: `UiMode::CloseConfirm` claims **nothing** here. The
-/// `blocking_overlay` / `modal_active` guards that make the dialog topmost are
+/// [`overlay_blocks_mouse`] / `modal_active` guards that make the dialog topmost are
 /// mouse-only, and this resolution runs *before* the per-mode key handler — so
 /// `Ctrl+PgUp` / `Ctrl+PgDn` (and `Ctrl+D`/`Ctrl+N`/`Ctrl+T`) still landed while
 /// the modal was up, moving the ground under an open confirmation. The armed
@@ -6198,6 +6211,38 @@ pub fn hit_test_button(button_rects: &[(Action, Rect)], col: u16, row: u16) -> O
     button_rects
         .iter()
         .find_map(|(action, rect)| point_in_rect(rect, col, row).then(|| action.clone()))
+}
+
+/// PRD #80 review FIX 5 / issue #142: whether `mode` puts a **blocking overlay**
+/// (a modal, the directory picker, or the new-pane form) on top of the deck, so
+/// mouse-wheel events must not reach the pane rendered behind it. Scroll in
+/// `Normal` / `PaneInput` stays untouched (pane scroll + child-app forwarding).
+///
+/// Deliberately an EXHAUSTIVE `match` with no `_` arm: this guard was originally
+/// a local `bool` in [`run_tui`], and `ScheduledTasks` — added long after — was
+/// simply forgotten, so wheeling over the Scheduled Tasks dialog scrolled the
+/// mode-tab side pane behind it (issue #142). A wildcard arm would let the next
+/// new `UiMode` repeat that silently; without one, adding a variant fails to
+/// COMPILE until its modality is declared here.
+fn overlay_blocks_mouse(mode: &UiMode) -> bool {
+    match mode {
+        UiMode::QuitConfirm
+        | UiMode::StopConfirm
+        // PRD #241 M3: the close confirmation is a topmost modal too —
+        // scrolling behind it must not reach a pane the user may be about to
+        // destroy.
+        | UiMode::CloseConfirm
+        | UiMode::ConfigGenPrompt
+        | UiMode::StarPrompt
+        | UiMode::Help
+        | UiMode::DirPicker
+        | UiMode::NewPaneForm
+        // Issue #142: the Scheduled Tasks manager is a topmost modal as well.
+        // The wheel over it belongs to ITS list (handled before this guard),
+        // never to whatever pane the centered dialog happens to cover.
+        | UiMode::ScheduledTasks => true,
+        UiMode::Normal | UiMode::Filter | UiMode::Rename | UiMode::PaneInput => false,
+    }
 }
 
 /// Whether the cell `(col, row)` falls inside `rect` (upper bounds exclusive).
@@ -9794,31 +9839,46 @@ pub fn run_tui(
                     crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left)
                 );
 
-                // PRD #80 review FIX 5: when a blocking overlay (any modal, the
-                // directory picker, or the new-pane form) is the topmost layer,
-                // swallow scroll-wheel events so they don't scroll the pane
-                // behind the overlay. Scroll in Normal / PaneInput is left
-                // untouched below (pane scroll + child-app forwarding).
-                let blocking_overlay = matches!(
-                    ui.mode,
-                    UiMode::QuitConfirm
-                        | UiMode::StopConfirm
-                        // PRD #241 M3: the close confirmation is a topmost
-                        // modal too — scrolling behind it must not reach a pane
-                        // the user may be about to destroy.
-                        | UiMode::CloseConfirm
-                        | UiMode::ConfigGenPrompt
-                        | UiMode::StarPrompt
-                        | UiMode::Help
-                        | UiMode::DirPicker
-                        | UiMode::NewPaneForm
-                );
                 let is_scroll = matches!(
                     mouse.kind,
                     crossterm::event::MouseEventKind::ScrollUp
                         | crossterm::event::MouseEventKind::ScrollDown
                 );
-                if is_scroll && blocking_overlay {
+
+                // Issue #142: the Scheduled Tasks manager owns the wheel while
+                // it is open — handled BEFORE the generic overlay swallow below
+                // so the wheel scrolls the manager's own list instead of merely
+                // being eaten (and instead of leaking to the side pane the
+                // centered dialog covers). The manager has no independent list
+                // offset: one wheel notch moves `scheduled_selected` by one row
+                // exactly like `j`/`k`, and the rendered viewport follows it
+                // through `visible_window`.
+                if is_scroll && ui.mode == UiMode::ScheduledTasks {
+                    // While the delete confirmation is armed it is the only
+                    // input layer (`y`/`n`/Esc) — the wheel must NOT move the
+                    // selection out from under the row being confirmed, so it is
+                    // swallowed without effect.
+                    if !ui.scheduled_delete_confirm {
+                        let forward =
+                            matches!(mouse.kind, crossterm::event::MouseEventKind::ScrollDown);
+                        ui.scheduled_selected = step_scheduled_selection(
+                            ui.scheduled_selected,
+                            ui.scheduled_tasks.len(),
+                            forward,
+                        );
+                    }
+                    if !crossterm::event::poll(std::time::Duration::from_millis(0))? {
+                        break;
+                    }
+                    continue;
+                }
+
+                // PRD #80 review FIX 5: when a blocking overlay (any modal, the
+                // directory picker, or the new-pane form) is the topmost layer,
+                // swallow scroll-wheel events so they don't scroll the pane
+                // behind the overlay. Scroll in Normal / PaneInput is left
+                // untouched below (pane scroll + child-app forwarding).
+                if is_scroll && overlay_blocks_mouse(&ui.mode) {
                     if !crossterm::event::poll(std::time::Duration::from_millis(0))? {
                         break;
                     }
@@ -22416,6 +22476,147 @@ mod tests {
         // Degenerate inputs.
         assert_eq!(visible_window(0, 0, 4), (0, 0));
         assert_eq!(visible_window(5, 0, 0), (0, 0));
+    }
+
+    // Issue #142 — every `UiMode`'s wheel modality is declared explicitly. The
+    // bug was an OMISSION: `ScheduledTasks` was missing from the wheel-blocking
+    // guard, so wheeling over the manager dialog scrolled the mode-tab side pane
+    // behind it. Listing all variants here (paired with the exhaustive `match` in
+    // `overlay_blocks_mouse`, which has no `_` arm) makes a repeat of that
+    // omission fail loudly rather than silently leak.
+    #[test]
+    fn overlay_blocks_mouse_is_declared_for_every_ui_mode() {
+        // Topmost overlays: the wheel must never reach the pane behind them.
+        for mode in [
+            UiMode::QuitConfirm,
+            UiMode::StopConfirm,
+            UiMode::CloseConfirm,
+            UiMode::ConfigGenPrompt,
+            UiMode::StarPrompt,
+            UiMode::Help,
+            UiMode::DirPicker,
+            UiMode::NewPaneForm,
+            UiMode::ScheduledTasks,
+        ] {
+            assert!(
+                overlay_blocks_mouse(&mode),
+                "{mode:?} is a topmost overlay — the wheel must not reach the pane behind it"
+            );
+        }
+
+        // Non-overlay modes keep the ordinary pane scroll / child-app forwarding.
+        for mode in [
+            UiMode::Normal,
+            UiMode::Filter,
+            UiMode::Rename,
+            UiMode::PaneInput,
+        ] {
+            assert!(
+                !overlay_blocks_mouse(&mode),
+                "{mode:?} has no blocking overlay — pane scrolling must stay live"
+            );
+        }
+    }
+
+    // Issue #142 — the wheel and `j`/`k` share one step definition, so the
+    // manager's wheel WRAPS at both ends exactly like the keyboard, and an empty
+    // list can neither panic nor underflow.
+    #[test]
+    fn manager_selection_step_wraps_like_the_keyboard() {
+        assert_eq!(step_scheduled_selection(0, 3, true), 1);
+        assert_eq!(step_scheduled_selection(1, 3, false), 0);
+        // Wrap at both ends, matching `(sel + 1) % len` / `(sel + len - 1) % len`.
+        assert_eq!(step_scheduled_selection(2, 3, true), 0);
+        assert_eq!(step_scheduled_selection(0, 3, false), 2);
+        // Single row: every step is a no-op.
+        assert_eq!(step_scheduled_selection(0, 1, true), 0);
+        assert_eq!(step_scheduled_selection(0, 1, false), 0);
+        // Empty list: `selected` comes back UNCHANGED, no underflow on `len - 1`.
+        // A nonzero input is the only one that proves "unchanged" — `0 -> 0`
+        // would also pass for a helper that clamped everything to zero.
+        assert_eq!(step_scheduled_selection(4, 0, true), 4);
+        assert_eq!(step_scheduled_selection(4, 0, false), 4);
+    }
+
+    // Issue #142 (review finding 3) — pin the KEYBOARD ENTRY POINT, not just the
+    // shared helper: `j`/Down step forward, `k`/Up step back, both wrap at both
+    // ends, and an empty list leaves the selection alone. The helper test above
+    // exercises `step_scheduled_selection` in isolation and the e2e tests drive
+    // the WHEEL, so neither would notice a future edit that unwires one of these
+    // four keys or flips its direction. This test would.
+    #[test]
+    fn manager_keyboard_steps_selection_in_both_directions() {
+        fn press(ui: &mut UiState, code: KeyCode) -> usize {
+            let action = handle_scheduled_tasks_key(KeyEvent::new(code, KeyModifiers::NONE), ui);
+            assert!(
+                matches!(action, Action::Continue),
+                "{code:?} must only move the selection, never emit an action"
+            );
+            assert_eq!(
+                ui.mode,
+                UiMode::ScheduledTasks,
+                "{code:?} must leave the manager dialog open"
+            );
+            ui.scheduled_selected
+        }
+
+        let mut ui = default_ui();
+        ui.mode = UiMode::ScheduledTasks;
+        ui.scheduled_tasks = vec![
+            make_scheduled_task("a", true),
+            make_scheduled_task("b", true),
+            make_scheduled_task("c", true),
+        ];
+        ui.scheduled_selected = 0;
+
+        // Forward: `j` and Down each advance exactly one row...
+        assert_eq!(press(&mut ui, KeyCode::Char('j')), 1, "`j` must move DOWN");
+        assert_eq!(press(&mut ui, KeyCode::Down), 2, "Down must move DOWN");
+        // ...and wrap off the last row back to the first.
+        assert_eq!(
+            press(&mut ui, KeyCode::Char('j')),
+            0,
+            "`j` on the last row must wrap to the first"
+        );
+        assert_eq!(press(&mut ui, KeyCode::Down), 1, "Down must move DOWN");
+        assert_eq!(press(&mut ui, KeyCode::Down), 2, "Down must move DOWN");
+        assert_eq!(
+            press(&mut ui, KeyCode::Down),
+            0,
+            "Down on the last row must wrap to the first"
+        );
+
+        // Backward: `k` and Up each retreat one row, wrapping off the first row
+        // back to the last.
+        assert_eq!(
+            press(&mut ui, KeyCode::Char('k')),
+            2,
+            "`k` on the first row must wrap to the last"
+        );
+        assert_eq!(press(&mut ui, KeyCode::Char('k')), 1, "`k` must move UP");
+        assert_eq!(press(&mut ui, KeyCode::Up), 0, "Up must move UP");
+        assert_eq!(
+            press(&mut ui, KeyCode::Up),
+            2,
+            "Up on the first row must wrap to the last"
+        );
+
+        // Empty list: a NONZERO selection survives every one of the four keys
+        // untouched — no clamp to zero, no underflow on `len - 1`, no panic.
+        ui.scheduled_tasks.clear();
+        ui.scheduled_selected = 4;
+        for code in [
+            KeyCode::Char('j'),
+            KeyCode::Char('k'),
+            KeyCode::Down,
+            KeyCode::Up,
+        ] {
+            assert_eq!(
+                press(&mut ui, code),
+                4,
+                "{code:?} must leave an empty list's selection unchanged"
+            );
+        }
     }
 
     // PRD #127 N2 — the manager dialog stays OPEN after run-now and after a

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -2945,6 +2945,20 @@ Under PRD #13's terminal-relative color model there is no baked light/dark palet
 - **Does not assert:** the whitespace-only variant of the fallback (the same code path); the mode-locked form's render (covered by `scheduler/form/001`).
 - **Platform coverage:** mac+linux.
 
+##### scheduler/manager/016 — Wheel input over the Scheduled Tasks dialog does not scroll a mode-tab side pane behind the modal (issue #142).
+- **Layer:** L2 (real TUI in a PTY; opens a synthetic `scroll` mode tab whose persistent right-hand side pane is filled with deterministic scrollback, then sends precise SGR wheel reports over the overlapping manager dialog).
+- **Agent:** none (the mode side pane runs a synthetic shell command; no LLM is invoked).
+- **Asserts:** after the side pane is scrolled into history and the manager is opened over it, wheel-down must first move the manager selection from `alpha` to `bravo`, then wheel-up must move it back to `alpha`, while the exposed side-pane marker sequence remains unchanged; the modal consumes the wheel events instead of leaking them to the pane behind it.
+- **Does not assert:** focused dashboard-pane wheel behavior; child-app mouse forwarding; the manager list viewport behavior (covered by `scheduler/manager/017`).
+- **Platform coverage:** mac+linux.
+
+##### scheduler/manager/017 — Wheel input over a windowed Scheduled Tasks list moves its selection and derived viewport (issue #142).
+- **Layer:** L2 (real TUI in a constrained-height PTY; a fixture global `schedules.toml` contains 30 distinct tasks, more than the manager can render at once, and the first visible task row supplies the coordinate for precise SGR wheel reports over the list viewport).
+- **Agent:** none (fixture global `schedules.toml` via `DOT_AGENT_DECK_SCHEDULES`).
+- **Asserts:** the first row starts selected and `wheel-task-13` starts below the viewport; twelve wheel-down reports over the list move the `▶` marker to `wheel-task-13`, which drags the selection-derived viewport until that initially hidden row is visible.
+- **Does not assert:** an independent list scroll offset (none exists); wheel-up wrapping at the first row; background side-pane isolation (covered by `scheduler/manager/016`).
+- **Platform coverage:** mac+linux.
+
 #### scheduler/form
 
 ##### scheduler/form/001 — The new-pane form mode-locked to schedule renders ONLY Dir + Command (no Mode cycler, no Name field) and titles itself ` New Schedule ` (Add) / ` Edit Schedule ` (Edit) (PRD #170 unified Add/Edit flow).

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1207,6 +1207,15 @@ impl TuiDeck {
         self.send_bytes(format!("\x1b[<{cb};{cx};{cy}M").as_bytes());
     }
 
+    /// Send `count` mouse wheel notches at the given 0-based grid cell.
+    /// Keeps repeated input emission in the harness so E2E test bodies can
+    /// describe the intended interaction without fixed-count polling loops.
+    pub fn scroll_n(&self, col: u16, row: u16, down: bool, count: usize) {
+        for _ in 0..count {
+            self.scroll(col, row, down);
+        }
+    }
+
     /// Locate the first occurrence of `needle` in the current rendered
     /// grid, returning its 0-based `(col, row)` start cell, or `None` if it
     /// is not on screen. Used by click tests to find a button's on-screen

--- a/tests/e2e_scheduler_manager.rs
+++ b/tests/e2e_scheduler_manager.rs
@@ -675,6 +675,189 @@ fn manager_010_blank_default_command_falls_back_to_claude() {
     drop(scratch);
 }
 
+/// Return the visible synthetic side-pane line markers from a rendered grid.
+/// Comparing the marker sequence isolates pane scrollback from manager-dialog
+/// changes such as moving the selected schedule row.
+fn visible_side_scroll_markers(grid: &str) -> Vec<String> {
+    const PREFIX: &str = "SIDE_SCROLL_LINE_";
+    grid.lines()
+        .filter_map(|line| {
+            let start = line.find(PREFIX)?;
+            line.get(start..start + PREFIX.len() + 3)
+                .map(ToOwned::to_owned)
+        })
+        .collect()
+}
+
+/// Scenario: Open an output-filled mode tab, scroll its right-hand side pane into history, then open Scheduled Tasks and wheel down and up over the dialog where it overlaps that pane. The visible side-pane lines must remain unchanged while the dialog handles the wheel events instead of leaking them to the pane behind it.
+#[spec("scheduler/manager/016")]
+#[test]
+fn manager_016_wheel_over_dialog_does_not_scroll_side_pane() {
+    let (scratch, sched_path) = scratch_with_schedules(
+        "[[scheduled_tasks]]\n\
+         name = \"alpha\"\n\
+         cron = \"0 9 * * *\"\n\
+         working_dir = \"/tmp\"\n\
+         command = \"cat\"\n\
+         prompt = \"alpha prompt\"\n\
+         enabled = true\n\n\
+         [[scheduled_tasks]]\n\
+         name = \"bravo\"\n\
+         cron = \"0 10 * * *\"\n\
+         working_dir = \"/tmp\"\n\
+         command = \"cat\"\n\
+         prompt = \"bravo prompt\"\n\
+         enabled = true\n",
+    );
+
+    let deck = TuiDeck::builder()
+        .with_pty_size(120, 40)
+        .with_env("DOT_AGENT_DECK_SCHEDULES", sched_path.to_string_lossy())
+        .launch_with_fixture("scheduler-manager-scroll");
+    deck.wait_for_string("No active sessions");
+
+    // Open the fixture's `scroll` mode. Its persistent side pane occupies the
+    // right half of the active mode tab, registering the rect that currently
+    // receives wheel events leaked through the manager dialog.
+    deck.send_bytes(b"\x0e"); // Ctrl+N -> directory picker
+    deck.wait_for_string("Select Directory");
+    deck.send_bytes(b" "); // choose current dir -> new-pane form
+    deck.wait_for_string("Mode:");
+    deck.send_bytes(b"\x1b[C"); // No mode -> scroll
+    deck.wait_for_string("scroll mode");
+    let (submit_col, submit_row) = deck
+        .find_in_grid("[Submit]")
+        .expect("new-pane form must render [Submit]");
+    deck.click(submit_col, submit_row);
+    deck.wait_for_string("SIDE_SCROLL_LINE_119");
+    deck.wait_for_string("[Command Mode Ctrl+D]");
+    deck.send_bytes(b"\x04"); // detach to Normal mode on the active mode tab
+    deck.wait_for_absence("[Command Mode Ctrl+D]");
+
+    // Move the side pane away from the bottom so both wheel directions have
+    // room to change its scrollback if the manager lets either event leak.
+    let bottom_markers = visible_side_scroll_markers(&deck.snapshot_grid());
+    assert!(
+        !bottom_markers.is_empty(),
+        "precondition: the mode side pane must visibly contain synthetic scrollback"
+    );
+    for _ in 0..8 {
+        deck.scroll(100, 10, false);
+    }
+    deck.wait_until_grid("side pane scrolled into its history", |grid| {
+        visible_side_scroll_markers(grid) != bottom_markers
+    });
+
+    deck.send_keys(b"s");
+    deck.wait_for_string("NEXT FIRE");
+    let before = visible_side_scroll_markers(&deck.snapshot_grid());
+    assert!(
+        before.len() >= 5,
+        "precondition: several side-pane markers must remain visible around the centered dialog.\nGrid:\n{}",
+        deck.snapshot_grid()
+    );
+
+    // NEXT FIRE sits inside the visible dialog and, in this mode-tab layout,
+    // inside the right-half side-pane rect behind it.
+    let (dialog_col, dialog_row) = deck
+        .find_in_grid("NEXT FIRE")
+        .expect("manager dialog must render the NEXT FIRE header");
+    let wheel_col = dialog_col + "NEXT FIRE".len() as u16 + 2;
+    assert!(
+        wheel_col >= 60,
+        "precondition: the wheel target must overlap the right-half side pane (col {wheel_col})"
+    );
+
+    deck.scroll(wheel_col, dialog_row, true);
+    let selection_moved_down = deck
+        .wait_for_grid_predicate_within(Duration::from_secs(2), |grid| {
+            grid.contains("\u{25b6} bravo")
+        });
+    let after_down_grid = deck.snapshot_grid();
+    let after_down = visible_side_scroll_markers(&after_down_grid);
+    assert!(
+        selection_moved_down,
+        "wheel-down over the Scheduled Tasks dialog must move the selection from `alpha` to `bravo` before wheel-up is sent.\nGrid after wheel-down:\n{after_down_grid}"
+    );
+
+    deck.scroll(wheel_col, dialog_row, false);
+    let selection_moved_up = deck.wait_for_grid_predicate_within(Duration::from_secs(2), |grid| {
+        grid.contains("\u{25b6} alpha")
+    });
+    let after_up_grid = deck.snapshot_grid();
+    let after_up = visible_side_scroll_markers(&after_up_grid);
+    assert!(
+        selection_moved_up,
+        "wheel-up over the Scheduled Tasks dialog must move the selection from `bravo` back to `alpha`.\nGrid after wheel-up:\n{after_up_grid}"
+    );
+
+    assert_eq!(
+        after_down, before,
+        "wheel-down over the Scheduled Tasks dialog leaked into the mode side pane behind it; the visible side-pane scrollback must remain unchanged.\nBefore: {before:?}\nAfter wheel-down: {after_down:?}\nGrid after wheel-down:\n{after_down_grid}"
+    );
+    assert_eq!(
+        after_up, before,
+        "wheel-up over the Scheduled Tasks dialog leaked into the mode side pane behind it; the visible side-pane scrollback must remain unchanged.\nBefore: {before:?}\nAfter wheel-up: {after_up:?}\nGrid after wheel-up:\n{after_up_grid}"
+    );
+    drop(scratch);
+}
+
+/// Scenario: Open Scheduled Tasks in a short PTY with more rows than the manager viewport can show, then send wheel-down reports over the visible list. The selection marker must move from the first task and drag the viewport far enough that the initially hidden thirteenth task becomes visible and selected.
+#[spec("scheduler/manager/017")]
+#[test]
+fn manager_017_wheel_scrolls_windowed_schedule_list() {
+    let mut schedules = String::new();
+    for i in 1..=30 {
+        schedules.push_str(&format!(
+            "[[scheduled_tasks]]\n\
+             name = \"wheel-task-{i:02}\"\n\
+             cron = \"0 9 * * *\"\n\
+             working_dir = \"/tmp\"\n\
+             command = \"cat\"\n\
+             prompt = \"wheel prompt {i:02}\"\n\
+             enabled = true\n\n"
+        ));
+    }
+    let (scratch, sched_path) = scratch_with_schedules(&schedules);
+
+    // At 20 rows the content-sized dialog is capped to 90% of the terminal,
+    // leaving an 11-row schedule viewport for these 30 fixture tasks.
+    let deck = TuiDeck::builder()
+        .with_pty_size(120, 20)
+        .with_env("DOT_AGENT_DECK_SCHEDULES", sched_path.to_string_lossy())
+        .launch_with_fixture("minimal");
+    deck.wait_for_string("No active sessions");
+    deck.send_keys(b"s");
+    deck.wait_for_string("NEXT FIRE");
+
+    let initial = deck.snapshot_grid();
+    assert!(
+        initial.contains("\u{25b6} wheel-task-01"),
+        "precondition: the first schedule must start selected.\nGrid:\n{initial}"
+    );
+    assert!(
+        !initial.contains("wheel-task-13"),
+        "precondition: wheel-task-13 must begin below the constrained manager viewport.\nGrid:\n{initial}"
+    );
+
+    let (list_col, list_row) = deck
+        .find_in_grid("wheel-task-01")
+        .expect("manager dialog must render the first visible task row");
+    for _ in 0..12 {
+        deck.scroll(list_col, list_row, true);
+    }
+
+    let moved_and_revealed = deck.wait_for_grid_predicate_within(Duration::from_secs(2), |grid| {
+        grid.contains("\u{25b6} wheel-task-13") && !grid.contains("\u{25b6} wheel-task-01")
+    });
+    let grid = deck.snapshot_grid();
+    assert!(
+        moved_and_revealed,
+        "wheel-down over the Scheduled Tasks list must move the selection and its derived viewport: expected the initially hidden `wheel-task-13` row to become visible and selected, but the wheel input was a no-op.\nGrid after 12 wheel-down reports:\n{grid}"
+    );
+    drop(scratch);
+}
+
 // ---------------------------------------------------------------------------
 // scheduler/form — the manager Add/Edit now reuse the Ctrl+n dir-picker +
 // new-pane form mode-locked to schedule (PRD #170 unify).

--- a/tests/e2e_scheduler_manager.rs
+++ b/tests/e2e_scheduler_manager.rs
@@ -741,9 +741,7 @@ fn manager_016_wheel_over_dialog_does_not_scroll_side_pane() {
         !bottom_markers.is_empty(),
         "precondition: the mode side pane must visibly contain synthetic scrollback"
     );
-    for _ in 0..8 {
-        deck.scroll(100, 10, false);
-    }
+    deck.scroll_n(100, 10, false, 8);
     deck.wait_until_grid("side pane scrolled into its history", |grid| {
         visible_side_scroll_markers(grid) != bottom_markers
     });
@@ -843,9 +841,7 @@ fn manager_017_wheel_scrolls_windowed_schedule_list() {
     let (list_col, list_row) = deck
         .find_in_grid("wheel-task-01")
         .expect("manager dialog must render the first visible task row");
-    for _ in 0..12 {
-        deck.scroll(list_col, list_row, true);
-    }
+    deck.scroll_n(list_col, list_row, true, 12);
 
     let moved_and_revealed = deck.wait_for_grid_predicate_within(Duration::from_secs(2), |grid| {
         grid.contains("\u{25b6} wheel-task-13") && !grid.contains("\u{25b6} wheel-task-01")

--- a/tests/fixtures/scheduler-manager-scroll/.dot-agent-deck.toml
+++ b/tests/fixtures/scheduler-manager-scroll/.dot-agent-deck.toml
@@ -1,0 +1,11 @@
+# Synthetic mode-tab fixture for scheduler/manager/016. The persistent side
+# pane writes more rows than its PTY can display and then stays alive, providing
+# deterministic scrollback behind the Scheduled Tasks dialog without an LLM.
+[[modes]]
+name = "scroll"
+reactive_panes = 0
+
+[[modes.panes]]
+command = "i=1; while [ \"$i\" -le 120 ]; do printf 'SIDE_SCROLL_LINE_%03d\\n' \"$i\"; i=$((i + 1)); done; sleep 600"
+name = "Scrollback sentinel"
+watch = false


### PR DESCRIPTION
## Description
The Scheduled Tasks manager dialog previously leaked mouse-wheel scroll events to the mode-tab pane behind it instead of scrolling its own task list. This adds a new `overlay_blocks_mouse(&UiMode) -> bool` helper (exhaustive match, no wildcard arm) that replaces an untestable local `blocking_overlay` bool, wires `UiMode::ScheduledTasks` into it so the modal now swallows wheel events, and routes wheel scrolling through a shared `step_scheduled_selection` helper also used by the existing j/k keyboard arms.

## Related Issues
Closes #142

## Changes Made
- `src/ui.rs` — new `overlay_blocks_mouse(&UiMode) -> bool` (exhaustive match) replacing the old `blocking_overlay` bool; `UiMode::ScheduledTasks` now blocks mouse wheel passthrough; new ScheduledTasks wheel branch scrolls the schedule list via a shared `step_scheduled_selection` helper (also used by the pre-existing j/k keyboard arms); 3 new in-crate unit tests.
- `tests/e2e_scheduler_manager.rs` + `tests/CATALOG.md` — two new L2 tests: `scheduler/manager/016` (wheel over the dialog does not scroll the side pane behind it) and `scheduler/manager/017` (wheel moves the windowed list's selection/viewport), plus catalog entries.
- `tests/fixtures/scheduler-manager-scroll/.dot-agent-deck.toml` — new fixture backing the two tests above.
- `changelog.d/142.bugfix.md` — user-facing changelog fragment.

## Testing
- `cargo test-fast`: 1402/1402 passed.
- Full recorded e2e gate: `CARGO_BUILD_JOBS=1 DOT_AGENT_DECK_RECORD=1 cargo test-e2e` => 2718 passed, 0 failed, 0 skipped, no flaky reruns.
- Both new e2e tests were independently proven to FAIL when the `src/ui.rs` fix is removed, confirming they genuinely pin the fix.
- Reviewer: no production blockers; 3 findings raised, all resolved. Auditor: zero findings.

## Documentation
- Changelog fragment added at `changelog.d/142.bugfix.md`.

## Compatibility (CLAUDE.md rule 12)
This change touches no daemon / TUI↔daemon protocol / orchestration / hook surface, so no `PROTOCOL_VERSION` bump, no cross-version manual test, and no `changelog.d/*.breaking.md` fragment are needed. Bump policy: bugfix => patch.