### PR TITLE
fix(prd-311): remove collapsed-pane frames from non-focused Stacked panes

### DIFF
--- a/changelog.d/311.feature.md
+++ b/changelog.d/311.feature.md
@@ -1,0 +1,7 @@
+## The stacked pane layout no longer wastes a row per non-focused pane
+
+In the default `Stacked` pane layout, every non-focused pane used to render as an empty 1-row title-bar frame — a border drawn around nothing. In a 7-role orchestration tab ([#307](https://github.com/vfarcic/dot-agent-deck/issues/307)), that was six rows spent on frames for `developer`, `tester`, `reviewer`, `releaser`, `researcher` and `documenter`, none of which showed anything: on a laptop screen, roughly 13% of the vertical space. The orchestration sidebar already shows each role's live status, tool counts and click-to-focus, so the collapsed frame was a strictly poorer second copy of information already on screen.
+
+Non-focused panes are no longer drawn at all. The focused pane now reclaims every row the collapsed frames used to occupy. Nothing about agent lifecycle changes — every pane's PTY stays open, every agent keeps running, hooks keep arriving, and the sidebar (or dashboard cards) keeps showing live status for all of them. A non-focused pane's PTY is now sized as though it were the focused slot, so switching focus is instant with no resize thrash or reflow.
+
+Mode tabs, which render their two side panes simultaneously by design, are unaffected — they already use a fixed tiled split regardless of the global pane-layout setting.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,7 +44,7 @@ Once the dashboard is running, press `?` inside the app to see all shortcuts. Th
 Running `dot-agent-deck` opens a two-column layout with native embedded terminal panes:
 
 - **Left (1/3)** — the dashboard, displaying a card grid of agent sessions
-- **Right (2/3)** — agent panes where Claude Code, OpenCode, Pi, or Codex instances run (stacked by default, toggle to tiled with `Ctrl+t`)
+- **Right (2/3)** — agent panes where Claude Code, OpenCode, Pi, or Codex instances run (stacked by default — only the focused pane is shown, at full height; toggle to tiled with `Ctrl+t` to see every pane at once)
 
 ![Two-column layout showing the dashboard card on the left and a Claude Code agent pane on the right](./img/getting-started-launching.jpg)
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -22,7 +22,7 @@ All the keyboard shortcuts below continue to work unchanged.
 |---|---|---|
 | `Ctrl+D` | Toggle between command mode and the pane — press it in a pane to reach the dashboard, press it again to go back to the pane you came from | Any mode |
 | `Ctrl+N` | New pane (directory picker, then name + command form) | Any mode |
-| `Ctrl+T` | Toggle stacked / tiled layout | Any mode |
+| `Ctrl+T` | Toggle stacked / tiled layout — stacked shows only the focused pane at full height, tiled shows every pane at once | Any mode |
 | `Ctrl+W` | Close the selected pane on the dashboard, or tear down the entire mode tab (agent + side panes) when used on a mode tab — after a confirmation dialog. The dashboard tab itself cannot be closed. | **Command mode only** |
 
 ### `Ctrl+W` closes only from command mode

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -170,6 +170,8 @@ These work from anywhere, including while typing in a role pane:
 
 The sidebar shows each role's status live (thinking, working, waiting, idle, error) so you can see at a glance who is busy without switching panes.
 
+In the default `Stacked` pane layout, only the focused role's pane is drawn — switching roles swaps which pane is visible, but every other role's agent keeps running underneath, and the sidebar is what tells you it's still busy or idle. Toggle to `Tiled` (`Ctrl+t`) to see every role's pane at once.
+
 ## How delegation works
 
 The orchestrator delegates a task to one or more workers. The deck delivers the task to each worker's pane automatically, including the worker's `prompt_template` as standing context. Each worker works independently, then signals completion. The deck notifies the orchestrator, which reads the summary and decides what to do next.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15931,6 +15931,114 @@ mod tests {
         );
     }
 
+    /// Scenario: Render a 7-role Orchestration tab (mirroring issue #307's
+    /// `orchestrator`/`developer`/`tester`/`reviewer`/`releaser`/`researcher`/
+    /// `documenter` roster) in `PaneLayout::Stacked` through the real
+    /// `compute_frame_layout` + `render_frame` path into a `TestBackend`, with
+    /// no pane explicitly focused (so the first role, `orchestrator`, is the
+    /// resolved expanded slot per `stacked_expanded_index`'s fallback). Assert
+    /// (1) the expanded role's rect height equals the FULL pane-column height —
+    /// no rows ceded to collapsed frames — and (2) none of the other six
+    /// roles' pane ids appear anywhere in the rendered grid, i.e. no collapsed
+    /// `Borders::TOP` title block is drawn for a non-focused pane. PRD #311:
+    /// today `pane_stack_rects` reserves a 1-row title bar per non-focused pane
+    /// (RED on both counts — the expanded rect is short by 6 rows and every
+    /// other role's id shows up in a collapsed frame's title); the fix reclaims
+    /// those rows for the focused pane and stops drawing the collapsed arm.
+    #[spec("orchestration/layout/002")]
+    #[test]
+    fn layout_002_stacked_orchestration_hides_collapsed_frames() {
+        let backend = TestBackend::new(100, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let state = AppState::default();
+        let mut ui = default_ui();
+        let filtered = filter_sessions(&state, &ui);
+
+        let role_names = [
+            "orchestrator",
+            "developer",
+            "tester",
+            "reviewer",
+            "releaser",
+            "researcher",
+            "documenter",
+        ];
+        let pane_ids: Vec<String> = role_names.iter().map(|r| format!("role-{r}")).collect();
+
+        let tab_view = ActiveTabView::Orchestration {
+            role_pane_ids: pane_ids.clone(),
+        };
+        let tab_bar = TabBarInfo {
+            show: true,
+            labels: vec!["seven-roles".into()],
+            active_index: 0,
+        };
+
+        let mut expanded_rect: Option<Rect> = None;
+        let mut panes_area: Option<Rect> = None;
+
+        terminal
+            .draw(|frame| {
+                let noop = crate::embedded_pane::EmbeddedPaneController::for_render_only_tests();
+                let layout = compute_frame_layout(
+                    frame.area(),
+                    &tab_view,
+                    &tab_bar,
+                    &pane_ids,
+                    PaneLayout::Stacked,
+                    None,
+                    1,
+                );
+
+                let FrameContent::Cards {
+                    panes_area: this_panes_area,
+                    pane_rects,
+                    ..
+                } = &layout.content
+                else {
+                    panic!("Orchestration tab must produce FrameContent::Cards");
+                };
+                panes_area = Some(this_panes_area.expect("7 role panes => a right pane column"));
+                expanded_rect = pane_rects
+                    .iter()
+                    .find(|(id, _)| id == &pane_ids[0])
+                    .map(|(_, r)| *r);
+
+                render_frame(
+                    frame,
+                    &state,
+                    &mut ui,
+                    &filtered,
+                    0,
+                    false,
+                    &noop,
+                    PaneLayout::Stacked,
+                    &tab_view,
+                    &tab_bar,
+                    &layout,
+                );
+            })
+            .unwrap();
+
+        let panes_area = panes_area.expect("pane column rect captured during draw");
+        let expanded_rect = expanded_rect.expect("orchestrator role rect captured during draw");
+        assert_eq!(
+            expanded_rect.height, panes_area.height,
+            "the focused role's pane must reclaim the FULL pane-column height \
+             (no rows ceded to collapsed frames): expanded={expanded_rect:?} \
+             column={panes_area:?}"
+        );
+
+        let rendered = buffer_to_string(terminal.backend().buffer());
+        for id in &pane_ids[1..] {
+            assert!(
+                !rendered.contains(id.as_str()),
+                "non-focused role pane {id} must not render a collapsed title \
+                 frame in PaneLayout::Stacked:\n{rendered}"
+            );
+        }
+    }
+
     // PRD #144 — `modal_rect` is the shared content-driven modal sizer: clamp the
     // desired content dims into `[min, 90% of terminal]`, never exceeding the
     // terminal bounds, and center the result. Pure data, so a plain unit test.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1988,8 +1988,9 @@ fn right_column_pane_dims(
 
 /// Dashboard pane: right 67% of width, height divided across `pane_count`
 /// panes per the active `PaneLayout`. `is_focused` matters in `Stacked`
-/// mode (focused gets the lion's share, unfocused collapse to a 1-row
-/// title bar); in `Tiled` it's ignored. `show_tab_bar` matches
+/// mode (PRD #311: the focused pane fills the whole column, unfocused
+/// panes reserve zero rows — this helper returns a zero-row chunk for
+/// them); in `Tiled` it's ignored. `show_tab_bar` matches
 /// `TabManager::show_tab_bar` and adds 1 row of chrome.
 pub(crate) fn dashboard_pane_dims(
     area: Rect,
@@ -2014,8 +2015,9 @@ pub(crate) fn dashboard_pane_dims(
 /// gutter), height divided across `role_count` role panes per `layout`.
 ///
 /// `role_index` matters only in `Stacked` mode, where role 0 is the
-/// expanded slot and every other role collapses to a 1-row title bar —
-/// mirroring the renderer's "expand the first slot if nothing is
+/// expanded slot (PRD #311: it fills the whole column and every other
+/// role reserves zero rows — this helper returns a zero-row chunk for
+/// them) — mirroring the renderer's "expand the first slot if nothing is
 /// focused" fallback (see `render_terminal_panes` Stacked branch). In
 /// `Tiled` mode `role_index` is ignored (height divides equally).
 ///
@@ -11243,8 +11245,9 @@ fn stacked_expanded_index(pane_ids: &[String], focused_id: Option<&str>) -> Opti
 /// exactly how `render_terminal_panes` lays panes out for the given
 /// `PaneLayout` and resolved focus. Single source of truth so the layout pass
 /// (which drives PTY resize) and the renderer can't disagree on a pane's rect.
-/// `Tiled`: equal vertical division. `Stacked`: the expanded slot fills, every
-/// other pane collapses to a 1-row title bar.
+/// `Tiled`: equal vertical division. `Stacked` (PRD #311): the expanded slot
+/// fills the whole area and every other pane reserves zero rows (`Length(0)`) —
+/// it is not drawn at all, rather than collapsing to a 1-row title bar.
 fn pane_stack_rects(
     area: Rect,
     pane_ids: &[String],
@@ -11287,9 +11290,11 @@ fn pane_stack_rects(
 /// orchestration role transition) converges here instead of pushing its own
 /// `resize_pane_pty` from a private dimension calculation.
 ///
-/// A pane whose target inner area has a zero dimension (a collapsed Stacked
-/// slot, or a viewport too small for the border) is skipped — matching the old
-/// helpers' `rows > 0 && cols > 0` guard. `resize_pane_pty` is the one resize
+/// A pane whose target inner area has a zero dimension (a `Tiled` pane with no
+/// room, or a viewport too small for the border) is skipped — matching the old
+/// helpers' `rows > 0 && cols > 0` guard. A non-focused `Stacked` pane is NOT a
+/// zero case here: `pane_target_dims` sizes it as if focused (PRD #311), so it
+/// keeps a stable PTY size even while undrawn. `resize_pane_pty` is the one resize
 /// primitive and handles local vs stream-backed panes itself (stream panes
 /// coalesce to the daemon; see `embedded_pane.rs`), so no per-backend
 /// special-casing is needed here.
@@ -15690,10 +15695,14 @@ mod tests {
     }
 
     #[test]
-    fn dashboard_pane_dims_stacked_unfocused_collapses_to_title_bar() {
-        // Unfocused in stacked mode: chunk = 1; rows = saturating_sub(2) = 0.
-        // `resize_pane_pty` callers gate on rows > 0, so this just signals
-        // "don't bother dispatching a resize for this pane right now."
+    fn dashboard_pane_dims_stacked_unfocused_reserves_zero_rows() {
+        // PRD #311: a non-focused Stacked pane is not drawn and reserves zero
+        // rows (no collapsed title bar). This spawn-path helper mirrors that by
+        // returning a zero-row chunk for the unfocused case: chunk = 1; rows =
+        // saturating_sub(2) = 0. Spawn-time resize callers gate on rows > 0, so
+        // this just signals "don't dispatch a resize for this pane right now";
+        // the per-frame `resize_panes_to_layout` pass later sizes the pane's PTY
+        // as if focused (see `FrameLayout::pane_target_dims`).
         let (rows, _cols) = dashboard_pane_dims(
             Rect::new(0, 0, 100, 30),
             3,
@@ -15769,9 +15778,9 @@ mod tests {
         // In Stacked mode with no focused role, role_index 0 mirrors
         // the renderer's "expand the first slot if nothing is focused"
         // fallback (see `render_terminal_panes` Stacked branch). Role
-        // 0 gets the lion's share; others collapse to the 1-row
-        // sentinel that resize callers gate on (`rows > 0` skips the
-        // resize).
+        // 0 fills the whole column; others reserve zero rows (PRD #311),
+        // so this helper returns the zero-row sentinel that spawn-time
+        // resize callers gate on (`rows > 0` skips the resize).
         let area = Rect::new(0, 0, 100, 30);
         let (rows_focused, _) =
             orchestration_role_pane_dims(area, 3, 0, PaneLayout::Stacked, false);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1970,10 +1970,12 @@ fn right_column_pane_dims(
     let count = pane_count.max(1);
     let chunk_height = match layout {
         PaneLayout::Tiled => main_height / count,
+        // PRD #311: the expanded slot now takes the WHOLE main height — no
+        // per-collapsed-pane row is carved off, since non-focused panes
+        // reserve zero rows instead of a 1-row title bar.
         PaneLayout::Stacked => {
             if is_focused {
-                let unfocused = count.saturating_sub(1);
-                main_height.saturating_sub(unfocused)
+                main_height
             } else {
                 1
             }
@@ -10984,11 +10986,14 @@ enum FrameContent {
     /// of panes shown in `panes_area`. `pane_rects` is each pane's OUTER rect
     /// in that column (M4: same `pane_stack_rects` split `render_terminal_panes`
     /// draws into, so the PTY-resize target and the rendered rect can't drift).
+    /// `pane_layout` is threaded through so `pane_target_dims` (PRD #311 M2)
+    /// can tell a genuinely-empty `Stacked` slot apart from a `Tiled` one.
     Cards {
         dashboard_area: Rect,
         panes_area: Option<Rect>,
         pane_ids: Vec<String>,
         pane_rects: Vec<(String, Rect)>,
+        pane_layout: PaneLayout,
     },
     /// Mode tab: single agent pane (left 50%) and stacked side panes
     /// (right 50%). `side_pane_rects` is the per-side-pane OUTER rect keyed by
@@ -11009,16 +11014,35 @@ impl FrameLayout {
     /// `TerminalWidget`'s inner content area is the OUTER rect shrunk by the
     /// 1-cell border on each side, so `(rows, cols) = (h - 2, w - 2)`. This is
     /// the single source `resize_panes_to_layout` drives PTYs from (invariant
-    /// 2). Collapsed Stacked panes resolve to a zero dimension and are filtered
-    /// by the caller.
+    /// 2).
+    ///
+    /// PRD #311 M2: a non-focused `Stacked` pane is not drawn and its rect
+    /// collapses to zero height, but its PTY still needs a defined, stable
+    /// size — otherwise an agent reflows to something arbitrary the moment it
+    /// loses focus and reflows again when it regains it. Resolution of Open
+    /// Question 1: size it "as if focused" — since the expanded slot always
+    /// fills the WHOLE pane column once every other slot reserves zero rows,
+    /// that is simply `panes_area` (dims shared with the pane that is
+    /// actually expanded this frame). `Tiled` is untouched: a zero-height
+    /// `Tiled` rect is a genuine "no room" case, not an undrawn pane.
     fn pane_target_dims(&self) -> Vec<(&str, u16, u16)> {
         // Inner area of a bordered pane = outer minus 1 cell on each side.
         let dims = |rect: Rect| (rect.height.saturating_sub(2), rect.width.saturating_sub(2));
         let mut out = Vec::new();
         match &self.content {
-            FrameContent::Cards { pane_rects, .. } => {
+            FrameContent::Cards {
+                pane_rects,
+                panes_area,
+                pane_layout,
+                ..
+            } => {
                 for (id, rect) in pane_rects {
-                    let (rows, cols) = dims(*rect);
+                    let target = if *pane_layout == PaneLayout::Stacked && rect.height == 0 {
+                        panes_area.unwrap_or(*rect)
+                    } else {
+                        *rect
+                    };
+                    let (rows, cols) = dims(target);
                     out.push((id.as_str(), rows, cols));
                 }
             }
@@ -11125,6 +11149,7 @@ fn compute_frame_layout(
                 panes_area,
                 pane_ids,
                 pane_rects,
+                pane_layout,
             }
         }
         ActiveTabView::Orchestration { role_pane_ids, .. } => {
@@ -11145,6 +11170,7 @@ fn compute_frame_layout(
                 panes_area,
                 pane_ids,
                 pane_rects,
+                pane_layout,
             }
         }
     };
@@ -11234,8 +11260,9 @@ fn pane_stack_rects(
             .map(|_| Constraint::Ratio(1, pane_ids.len() as u32))
             .collect(),
         PaneLayout::Stacked => {
-            // Focused pane gets remaining space; unfocused get a single
-            // collapsed title row (`title_bar_height = 1`).
+            // PRD #311: the focused pane gets the ENTIRE area; non-focused
+            // panes are not drawn at all, so they reserve zero rows rather
+            // than a collapsed 1-row title bar.
             let expanded = stacked_expanded_index(pane_ids, focused_id);
             pane_ids
                 .iter()
@@ -11244,7 +11271,7 @@ fn pane_stack_rects(
                     if expanded == Some(i) {
                         Constraint::Fill(1)
                     } else {
-                        Constraint::Length(1)
+                        Constraint::Length(0)
                     }
                 })
                 .collect()
@@ -11427,6 +11454,7 @@ fn render_frame(
             panes_area,
             pane_ids,
             pane_rects,
+            ..
         } => (*dashboard_area, *panes_area, pane_ids, pane_rects),
     };
 
@@ -11861,50 +11889,30 @@ fn render_terminal_panes(
             }
         }
         PaneLayout::Stacked => {
-            // Focused pane gets remaining space; unfocused get a single
-            // collapsed title row. `stacked_expanded_index` resolves which slot
-            // expands (focused, else first) — the same decision the split used.
+            // PRD #311: only the focused pane is drawn — non-focused panes
+            // render nothing at all (no collapsed title-bar frame).
+            // `stacked_expanded_index` resolves which slot expands (focused,
+            // else first) — the same decision the split used.
             let focused_idx = stacked_expanded_index(pane_ids, focused_id.as_deref());
-            for (i, pane_id) in pane_ids.iter().enumerate() {
-                let is_expanded = focused_idx == Some(i);
-                let title = pane_name(pane_id);
-                if is_expanded {
-                    if let Some(screen) = ctrl.get_screen(pane_id) {
-                        let is_focused = focused_id.as_deref() == Some(pane_id.as_str());
-                        // PRD #84 M5: the expanded pane was sized to `chunks[i]`
-                        // by `resize_panes_to_layout` this frame — attest it.
-                        let mut widget =
-                            TerminalWidget::new(Arc::clone(&screen), title, is_focused)
-                                .contract_guaranteed(true)
-                                .with_input_active(input_active);
-                        // PRD #155 (M3): same status threading as the Tiled arm.
-                        if let Some(status) = pane_status.get(pane_id.as_str()) {
-                            widget = widget.with_status(status.clone());
-                        }
-                        if is_focused {
-                            focused_pane_rect = Some(chunks[i]);
-                            focused_screen = Some(screen);
-                        }
-                        frame.render_widget(widget, chunks[i]);
+            if let Some(i) = focused_idx {
+                let pane_id = &pane_ids[i];
+                if let Some(screen) = ctrl.get_screen(pane_id) {
+                    let title = pane_name(pane_id);
+                    let is_focused = focused_id.as_deref() == Some(pane_id.as_str());
+                    // PRD #84 M5: the expanded pane was sized to `chunks[i]`
+                    // by `resize_panes_to_layout` this frame — attest it.
+                    let mut widget = TerminalWidget::new(Arc::clone(&screen), title, is_focused)
+                        .contract_guaranteed(true)
+                        .with_input_active(input_active);
+                    // PRD #155 (M3): same status threading as the Tiled arm.
+                    if let Some(status) = pane_status.get(pane_id.as_str()) {
+                        widget = widget.with_status(status.clone());
                     }
-                } else {
-                    // Collapsed: show a titled border block. PRD #155 (M3): a
-                    // collapsed pane is by definition not the expanded/focused
-                    // slot, so the unified Option-A precedence resolves its
-                    // border to the agent's STATUS color — the SAME palette role
-                    // the Tiled and expanded-Stacked arms apply via
-                    // `with_status`, so a given state looks identical across all
-                    // embedded-pane contexts (criterion #2). Panes without a
-                    // backing session status keep the dimmed fallback.
-                    let border_style = pane_status
-                        .get(pane_id.as_str())
-                        .map(|status| Style::default().fg(palette::status_color(status)))
-                        .unwrap_or_else(text_dim);
-                    let block = Block::default()
-                        .borders(Borders::TOP)
-                        .border_style(border_style)
-                        .title(format!(" {title} "));
-                    frame.render_widget(block, chunks[i]);
+                    if is_focused {
+                        focused_pane_rect = Some(chunks[i]);
+                        focused_screen = Some(screen);
+                    }
+                    frame.render_widget(widget, chunks[i]);
                 }
             }
         }
@@ -15668,9 +15676,9 @@ mod tests {
 
     #[test]
     fn dashboard_pane_dims_stacked_focused_takes_remainder() {
-        // 100×30, 3 panes, stacked, focused: unfocused = 2; main = 29;
-        // chunk = 29 - 2 = 27; rows = 25. The other two panes collapse
-        // to 1-row title bars (next assertion).
+        // PRD #311: the focused slot takes the WHOLE main height (no rows
+        // ceded to collapsed siblings). 100×30, 3 panes, stacked, focused:
+        // main = 29; chunk = 29; rows = 27.
         let (rows, cols) = dashboard_pane_dims(
             Rect::new(0, 0, 100, 30),
             3,
@@ -15678,7 +15686,7 @@ mod tests {
             PaneLayout::Stacked,
             false,
         );
-        assert_eq!((rows, cols), (25, 65));
+        assert_eq!((rows, cols), (27, 65));
     }
 
     #[test]
@@ -15783,15 +15791,15 @@ mod tests {
     fn orchestration_role_pane_dims_stacked_role_zero_matches_renderer_expanded_height() {
         // Drift guard: the helper's expanded-row height for the Stacked
         // expanded slot (role 0) must equal the renderer's expanded height.
-        // The renderer gives the expanded slot `Constraint::Fill(1)` after
-        // carving 1-row title bars off the other (count-1) slots — i.e. the
-        // expanded inner height = main_height - (count-1) - 2 (border).
+        // PRD #311: the renderer gives the expanded slot `Constraint::Fill(1)`
+        // after every other slot reserves ZERO rows (no collapsed title bars
+        // any more) — i.e. the expanded inner height = main_height - 2
+        // (border only, no per-collapsed-pane subtraction).
         let area = Rect::new(0, 0, 200, 50);
         let role_count: u16 = 4;
         let chrome_rows: u16 = 1; // hints bar; no tab bar in this test
         let main_height = area.height.saturating_sub(chrome_rows);
-        let expanded_outer = main_height.saturating_sub(role_count - 1);
-        let expanded_inner = expanded_outer.saturating_sub(2);
+        let expanded_inner = main_height.saturating_sub(2);
         let (helper_rows, _) =
             orchestration_role_pane_dims(area, role_count as usize, 0, PaneLayout::Stacked, false);
         assert_eq!(helper_rows, expanded_inner);
@@ -15850,6 +15858,7 @@ mod tests {
             panes_area,
             pane_ids: laid_out_ids,
             pane_rects,
+            ..
         } = layout.content
         else {
             panic!("Dashboard tab must produce FrameContent::Cards");

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -1016,11 +1016,11 @@ Demo-reel eligibility marker: a trailing ` [reel]` on an entry's `##### <id> —
 
 #### tabs/mode
 
-##### tabs/mode/001 — Selecting a mode on the new-pane form opens a mode tab with the agent pane on the left and persistent side panes stacked on the right.
-- **Layer:** L2.
-- **Agent:** none (fixture `.dot-agent-deck.toml` with one persistent pane).
-- **Asserts:** new tab appears in the tab bar; agent pane is in the left half; side pane region renders on the right.
-- **Does not assert:** the side pane's command output content beyond non-empty PTY bytes.
+##### tabs/mode/001 — Selecting a mode on the new-pane form opens a mode tab with the agent pane on the left and persistent side panes stacked on the right; both side panes render SIMULTANEOUSLY under the deck's default (Stacked) global `pane_layout` (PRD #311 regression guard).
+- **Layer:** L2 (PTY-attached, `tests/e2e_mode_tab_layout.rs`).
+- **Agent:** none (fixture `tests/fixtures/mode-two-side-panes` with TWO persistent side panes, each printing a unique sentinel and idling).
+- **Asserts:** the new-pane form's Mode selection opens a Mode tab (tab strip appears); with the deck's default `PaneLayout::Stacked` global, BOTH side panes' sentinels are visible in the grid at the same time — proving the Mode tab's side-pane column (hardcoded `PaneLayout::Tiled` in `render_mode_tab`, `src/ui.rs`) does not read the shared global `pane_layout` field (PRD #311's Open Question 2 risk) and so never collapses a side pane to a titled 1-row frame regardless of the global's value.
+- **Does not assert:** the side pane's command output content beyond the sentinel line; the agent pane's exact left-half geometry (covered by `compute_frame_layout_mode_geometry`, a plain unit test in `src/ui.rs`); orchestration/dashboard pane-column geometry (covered by `orchestration/layout/002`).
 - **Platform coverage:** mac+linux.
 
 ##### tabs/mode/002 — `Ctrl+w` on a mode tab tears down the entire workspace (agent + all side panes).
@@ -1087,6 +1087,13 @@ Demo-reel eligibility marker: a trailing ` [reel]` on an entry's `##### <id> —
 - **Asserts:** arm the Orchestration deck on role 1, leave to the Dashboard, arm the Dashboard on card 2, then return to the (now inactive) Orchestration deck — Enter restores the Orchestration's OWN remembered role (index 1), NOT the Dashboard's leaked index 2. Pins per-deck independence of the Enter-restore state (the remembered selection must be stored per deck, not in a single shared field). Complements `tabs/orchestration/004` (which restores via a non-deck Mode-tab intermediate that can't clobber the shared field).
 - **Does not assert:** the pane-focus side effect of activating the role; the Dashboard's own restore (covered by `dashboard/selection/008`).
 - **Platform coverage:** mac+linux+windows.
+
+##### tabs/orchestration/006 — In a real multi-role orchestration tab under `PaneLayout::Stacked`, non-focused roles render no collapsed title-bar frame, a non-focused role's agent keeps running with its sidebar status transitioning live, and switching focus between roles preserves each role's rendered content with no lost scrollback (PRD #311).
+- **Layer:** L2 (PTY-attached, `tests/e2e_orchestration_pane_column.rs`).
+- **Agent:** none (fixture `tests/fixtures/orch-focus-lifecycle`: a 3-role orchestration — `orchestrator` (start), `alpha`, `beta` — each printing a unique sentinel; `beta`'s script additionally self-posts real `SessionStart`/`PreToolUse` hook events via `dot-agent-deck hook --agent claude-code`, resolved to the freshly built test binary, so its sidebar status transitions Idle -> Working while its pane is not the focused/expanded slot).
+- **Asserts:** (a) with `orchestrator` focused/expanded, the settled grid carries no collapsed `Borders::TOP` title-bar frame for either non-focused role (`alpha`, `beta`) — matched by a row that, after trimming only leading blank columns, begins with the bare role name directly followed by border-fill dashes, a pattern only the collapsed-pane block itself can produce; (b) `beta`'s sidebar status card visibly transitions to `Working` purely from its own self-posted hook events while never becoming the focused pane, proving a non-focused role's agent lifecycle (PTY, hook delivery, status) is untouched by the rendering change; (c) driving `j`/`k` (Normal mode) round-trips focus orchestrator -> alpha -> beta -> alpha -> orchestrator, and each role's own sentinel text is visible again once it becomes the expanded pane, proving no lost scrollback or stale fragment across a focus switch.
+- **Does not assert:** PTY resizing of the reclaimed area (`resize_panes_to_layout`); the L1 geometry math (covered by `orchestration/layout/002`); a real LLM agent (all three roles are shell stand-ins); dashboard-tab (non-orchestration) collapsed frames.
+- **Platform coverage:** mac+linux.
 
 #### tabs/selection
 
@@ -1996,6 +2003,13 @@ without depending on the config struct API.
 - **Agent:** none.
 - **Asserts:** in the ~34%-width single-column orchestration card area at a typical ~48-row card height, the renderer's `visible_rows = available / card_height` fits all 7 decks with no scrolling and the 7th deck actually renders in the visible slice; a much larger deck count (20) still engages scrolling, so right-sizing the card height does not remove the scroll fallback.
 - **Does not assert:** the full orchestration-tab frame (tab bar, side panes, stats bar); the `ORCHESTRATION_LEFT_PERCENT` width split or `grid_columns` thresholds (out of scope per PRD #147).
+- **Platform coverage:** mac+linux+windows.
+
+##### orchestration/layout/002 — In a 7-role orchestration tab with `PaneLayout::Stacked`, the focused pane's rect covers the full pane-column height and no collapsed title-bar frames are drawn for the other 6 roles (PRD #311).
+- **Layer:** L1 (in-process `compute_frame_layout` + `render_frame` driven through a real `ratatui::Terminal<TestBackend>`, via `EmbeddedPaneController::for_render_only_tests()`; no PTY, no subprocess). Lives in `src/ui.rs`'s own `#[cfg(test)]` module (same pattern as `tabs/orchestration/003-005`) because the geometry helpers under test (`pane_stack_rects`, `stacked_expanded_index`, `render_terminal_panes`) are module-private and unreachable from `tests/*.rs`.
+- **Agent:** none (7 synthetic role pane ids, no backing PTYs).
+- **Asserts:** with no pane explicitly focused (so `stacked_expanded_index` falls back to the first role, `orchestrator`), the expanded role's OUTER rect height equals the full pane-column height with no rows ceded to collapsed frames; none of the other 6 roles' pane ids appear anywhere in the rendered grid (i.e. no `Borders::TOP` collapsed title block is drawn for a non-focused pane).
+- **Does not assert:** PTY resizing of the reclaimed area (`resize_panes_to_layout`); mode-tab side-pane geometry (covered by `tabs/mode/001`); the sidebar deck-card capacity math (covered by `orchestration/layout/001`).
 - **Platform coverage:** mac+linux+windows.
 
 #### orchestration/route

--- a/tests/e2e_mode_tab_layout.rs
+++ b/tests/e2e_mode_tab_layout.rs
@@ -1,0 +1,61 @@
+#![cfg(feature = "e2e")]
+
+//! PRD #311 — regression guard for the Mode tab's side-pane column.
+//!
+//! PRD #311 removes `PaneLayout::Stacked`'s collapsed-frame arm on the
+//! Orchestration/Dashboard pane column, but `pane_layout` is one global field
+//! (`src/ui.rs:1531`) read by all three `render_terminal_panes` call sites
+//! (Open Question 2). A Mode tab's agent + side panes render through their
+//! own `render_mode_tab` call sites, which today hardcode `PaneLayout::Stacked`
+//! (agent, single pane) and `PaneLayout::Tiled` (side panes) rather than
+//! reading the global — so a Mode tab is not collapsing its side panes today.
+//! This test pins that fact so a future refactor of the Stacked arm (or of
+//! `render_mode_tab`) cannot accidentally wire the global `pane_layout` into
+//! the side-pane column, which — since the global defaults to `Stacked` —
+//! would immediately collapse every side pane but one to a 1-row title bar.
+
+mod common;
+
+use common::TuiDeck;
+use spec::spec;
+
+/// Scenario: Launch the deck against the `mode-two-side-panes` fixture (one
+/// mode with TWO persistent side panes, each printing a unique sentinel and
+/// idling) and open the Mode tab. With the deck's default `pane_layout`
+/// (`Stacked`), assert BOTH side panes' sentinels are visible in the grid AT
+/// THE SAME TIME — proving the side-pane column renders every side pane
+/// simultaneously rather than collapsing all but one to a titled 1-row frame,
+/// which is what a Stacked-style collapse would do to the second pane.
+#[spec("tabs/mode/001")]
+#[test]
+fn mode_001_side_panes_render_simultaneously_under_stacked_global() {
+    let deck = TuiDeck::builder()
+        .with_pty_size(120, 32)
+        .launch_with_fixture("mode-two-side-panes");
+    deck.wait_for_string("No active sessions");
+
+    // Open the deck's single `demo` mode (Ctrl+N -> directory picker -> current
+    // dir -> new-pane form -> Right to select `demo` -> Submit).
+    deck.send_bytes(b"\x0e"); // Ctrl+N
+    deck.wait_for_string("Select Directory");
+    deck.send_bytes(b" ");
+    deck.wait_for_string("Mode:");
+    deck.send_bytes(b"\x1b[C"); // Right: "No mode" -> "demo"
+    deck.wait_for_string("demo mode");
+    let (scol, srow) = deck
+        .find_in_grid("[Submit]")
+        .expect("new-pane form should render a [Submit] button");
+    deck.click(scol, srow);
+    deck.wait_for_string("Dashboard"); // tab strip appears only with >=2 tabs
+
+    // Both persistent side panes must be alive and visible at once — neither
+    // collapsed to a titled frame with no content.
+    deck.wait_for_string("SIDE_ALPHA_SENTINEL");
+    deck.wait_for_string("SIDE_BETA_SENTINEL");
+    let grid = deck.snapshot_grid();
+    assert!(
+        grid.contains("SIDE_ALPHA_SENTINEL") && grid.contains("SIDE_BETA_SENTINEL"),
+        "both Mode-tab side panes must render simultaneously under the default \
+         (Stacked) global pane_layout, not one collapsed to a title-only row:\n{grid}"
+    );
+}

--- a/tests/e2e_orchestration_pane_column.rs
+++ b/tests/e2e_orchestration_pane_column.rs
@@ -1,0 +1,139 @@
+#![cfg(feature = "e2e")]
+
+//! PRD #311 — L2 (real-binary PTY) coverage for the Orchestration tab's
+//! `PaneLayout::Stacked` pane column: removing the non-focused roles'
+//! collapsed 1-row title frames must not touch agent lifecycle. Every role's
+//! PTY stays open, keeps running, and keeps reporting status regardless of
+//! whether its pane is currently drawn.
+
+mod common;
+
+use std::time::Duration;
+
+use common::TuiDeck;
+use spec::spec;
+
+/// A collapsed `Stacked` pane renders a `Block` with `Borders::TOP` and
+/// `.title(format!(" {title} "))` — no other cell content. On the settled
+/// grid that row, after trimming ONLY the leading blank columns (the sidebar
+/// area to its left), reads exactly `"<role> ─..."` — the title text directly
+/// followed by the border-fill dashes, nothing else. A sidebar deck card's
+/// title line ("│ N status · role ─── status │") can never match: after
+/// trimming leading whitespace it starts with the card's own border glyph
+/// (`┌`/`┏`/`│`), not the bare role name. This is what makes the check
+/// specific to the collapsed PANE-COLUMN frame rather than any other on-screen
+/// occurrence of the role name.
+fn has_collapsed_frame(grid: &str, role: &str) -> bool {
+    let prefix = format!("{role} \u{2500}");
+    grid.lines()
+        .any(|line| line.trim_start().starts_with(&prefix))
+}
+
+/// Overwrite the fixture's `beta-agent.sh` placeholder with the ABSOLUTE path
+/// of the freshly built test binary baked in (mirrors `write_card_agent` in
+/// `e2e_dashboard_selection.rs`), rather than relying on `dot-agent-deck`
+/// resolving correctly on PATH — a dev machine may have a separately
+/// installed `dot-agent-deck` shadowing the build under test.
+fn write_beta_agent(deck: &TuiDeck) {
+    let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
+    let body = format!(
+        "#!/bin/sh\n\
+         printf 'BETA_ROLE_SENTINEL\\n'\n\
+         printf '%s' '{{\"hook_event_name\":\"SessionStart\",\"session_id\":\"beta-sess\"}}' \\\n\
+         | \"{bin}\" hook --agent claude-code >/dev/null 2>&1\n\
+         sleep 1\n\
+         printf '%s' '{{\"hook_event_name\":\"PreToolUse\",\"session_id\":\"beta-sess\",\"tool_name\":\"Bash\"}}' \\\n\
+         | \"{bin}\" hook --agent claude-code >/dev/null 2>&1\n\
+         sleep 600\n"
+    );
+    let path = deck.workdir().join("beta-agent.sh");
+    std::fs::write(&path, body).expect("overwrite beta-agent.sh with resolved binary path");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod beta-agent.sh");
+    }
+}
+
+/// Drive the new-pane dialog to open the (single) orchestration in the
+/// `orch-focus-lifecycle` fixture. With no `[[modes]]` defined the Mode chip
+/// row is `[No mode] [Orch: focus-lifecycle] [schedule]`, so ONE Right
+/// selects the orchestration; selecting an orchestration hides the Command
+/// field, so a second Enter submits the form.
+fn open_orchestration(deck: &TuiDeck) {
+    deck.send_bytes(b"\x0e"); // Ctrl+n -> directory picker
+    deck.send_bytes(b" "); // Space -> confirm current dir -> new-pane form
+    deck.wait_for_string("No mode");
+    deck.send_bytes(b"\x1b[C"); // Right -> [Orch: focus-lifecycle]
+    deck.send_bytes(b"\r"); // Mode -> Name
+    deck.send_bytes(b"\r"); // submit (Command hidden for an orchestration)
+}
+
+/// Scenario: Open the `orch-focus-lifecycle` fixture's 3-role orchestration
+/// (`orchestrator` start role, plus `alpha` and `beta`) in the deck's default
+/// `PaneLayout::Stacked`. (b) Confirm a non-focused role keeps running and its
+/// sidebar status transitions live: `beta`'s status card goes from idle to
+/// `Working` purely through its own self-posted hook events while its pane is
+/// NOT the expanded/focused slot. (a) Assert the settled grid carries NO
+/// collapsed title-bar frame for either non-focused role (`alpha`, `beta`) —
+/// PRD #311 removes that arm of `PaneLayout::Stacked` entirely. (c) Drive `j`
+/// twice (Normal mode) to move the deck's focus orchestrator -> alpha -> beta,
+/// then `k` twice back to orchestrator, asserting each role's own sentinel
+/// text is visible once it becomes the focused/expanded pane — proving no lost
+/// scrollback or stale fragment survives a focus round trip. RED today: (a)
+/// fails because `render_terminal_panes`' Stacked else-arm
+/// (`src/ui.rs:11890-11908`) still draws a `Borders::TOP` titled block for
+/// every non-focused role.
+#[spec("tabs/orchestration/006")]
+#[test]
+fn orchestration_006_stacked_pane_column_hides_collapsed_frames_while_agents_stay_live() {
+    let deck = TuiDeck::builder()
+        .with_pty_size(160, 45)
+        .launch_with_fixture("orch-focus-lifecycle");
+    write_beta_agent(&deck);
+    deck.wait_for_string("No active sessions");
+    open_orchestration(&deck);
+    deck.wait_for_string("orchestrator");
+    deck.wait_for_string("alpha");
+    deck.wait_for_string("beta");
+
+    // (b) The non-focused `beta` role keeps running and its sidebar status
+    // transitions live (Idle -> Working) purely from its own self-posted hook
+    // events, while its pane is not the expanded/focused slot.
+    assert!(
+        common::wait_until(Duration::from_secs(15), || {
+            deck.snapshot_grid().contains("Working")
+        }),
+        "the non-focused beta role's sidebar status never transitioned to \
+         Working while its pane was collapsed/not drawn:\n{}",
+        deck.snapshot_grid()
+    );
+
+    // (a) With `orchestrator` focused/expanded (the start role), neither
+    // non-focused role may render a collapsed title-bar frame.
+    let grid = deck.snapshot_grid();
+    assert!(
+        !has_collapsed_frame(&grid, "alpha"),
+        "non-focused role 'alpha' must not render a collapsed title-bar frame \
+         in PaneLayout::Stacked:\n{grid}"
+    );
+    assert!(
+        !has_collapsed_frame(&grid, "beta"),
+        "non-focused role 'beta' must not render a collapsed title-bar frame \
+         in PaneLayout::Stacked:\n{grid}"
+    );
+
+    // (c) Switching focus between roles preserves each agent's rendered
+    // content, with no lost scrollback / stale fragment across the round
+    // trip: orchestrator -> alpha -> beta -> alpha -> orchestrator.
+    deck.send_bytes(b"\x04"); // Ctrl+D -> Normal mode
+    deck.send_bytes(b"j"); // orchestrator -> alpha
+    deck.wait_for_string("ALPHA_ROLE_SENTINEL");
+    deck.send_bytes(b"j"); // alpha -> beta
+    deck.wait_for_string("BETA_ROLE_SENTINEL");
+    deck.send_bytes(b"k"); // beta -> alpha
+    deck.wait_for_string("ALPHA_ROLE_SENTINEL");
+    deck.send_bytes(b"k"); // alpha -> orchestrator
+    deck.wait_for_string("ORCH_ROLE_SENTINEL");
+}

--- a/tests/e2e_orchestration_pane_column.rs
+++ b/tests/e2e_orchestration_pane_column.rs
@@ -29,6 +29,19 @@ fn has_collapsed_frame(grid: &str, role: &str) -> bool {
         .any(|line| line.trim_start().starts_with(&prefix))
 }
 
+/// A sidebar deck card's title row (`render_session_card` in `src/ui.rs`)
+/// carries the role's display name and its live status word on the SAME
+/// rendered line, joined by the card's `\u{00b7}` separator (`" \u{00b7} {name} "`
+/// on the left, `" {dot} {status} "` on the right of the same `Block`). Search
+/// for `"\u{00b7} {role}"` plus `status` together on one line so the check is
+/// scoped to `role`'s own card rather than any occurrence of `status`
+/// anywhere on the settled grid (e.g. another role's card, or pane content).
+fn has_role_status(grid: &str, role: &str, status: &str) -> bool {
+    let role_needle = format!("\u{00b7} {role}");
+    grid.lines()
+        .any(|line| line.contains(&role_needle) && line.contains(status))
+}
+
 /// Escape `s` as a single POSIX shell word using the standard single-quote
 /// idiom (close the quote, emit an escaped literal `'`, reopen the quote), so
 /// an embedded build path containing shell metacharacters can't be
@@ -111,7 +124,7 @@ fn orchestration_006_stacked_pane_column_hides_collapsed_frames_while_agents_sta
     // events, while its pane is not the expanded/focused slot.
     assert!(
         common::wait_until(Duration::from_secs(15), || {
-            deck.snapshot_grid().contains("Working")
+            has_role_status(&deck.snapshot_grid(), "beta", "Working")
         }),
         "the non-focused beta role's sidebar status never transitioned to \
          Working while its pane was collapsed/not drawn:\n{}",

--- a/tests/e2e_orchestration_pane_column.rs
+++ b/tests/e2e_orchestration_pane_column.rs
@@ -29,21 +29,29 @@ fn has_collapsed_frame(grid: &str, role: &str) -> bool {
         .any(|line| line.trim_start().starts_with(&prefix))
 }
 
+/// Escape `s` as a single POSIX shell word using the standard single-quote
+/// idiom (close the quote, emit an escaped literal `'`, reopen the quote), so
+/// an embedded build path containing shell metacharacters can't be
+/// misinterpreted by the `/bin/sh` script it's spliced into.
+fn shell_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
 /// Overwrite the fixture's `beta-agent.sh` placeholder with the ABSOLUTE path
 /// of the freshly built test binary baked in (mirrors `write_card_agent` in
 /// `e2e_dashboard_selection.rs`), rather than relying on `dot-agent-deck`
 /// resolving correctly on PATH — a dev machine may have a separately
 /// installed `dot-agent-deck` shadowing the build under test.
 fn write_beta_agent(deck: &TuiDeck) {
-    let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
+    let bin = shell_quote(env!("CARGO_BIN_EXE_dot-agent-deck"));
     let body = format!(
         "#!/bin/sh\n\
          printf 'BETA_ROLE_SENTINEL\\n'\n\
          printf '%s' '{{\"hook_event_name\":\"SessionStart\",\"session_id\":\"beta-sess\"}}' \\\n\
-         | \"{bin}\" hook --agent claude-code >/dev/null 2>&1\n\
+         | {bin} hook --agent claude-code >/dev/null 2>&1\n\
          sleep 1\n\
          printf '%s' '{{\"hook_event_name\":\"PreToolUse\",\"session_id\":\"beta-sess\",\"tool_name\":\"Bash\"}}' \\\n\
-         | \"{bin}\" hook --agent claude-code >/dev/null 2>&1\n\
+         | {bin} hook --agent claude-code >/dev/null 2>&1\n\
          sleep 600\n"
     );
     let path = deck.workdir().join("beta-agent.sh");

--- a/tests/e2e_session_restore.rs
+++ b/tests/e2e_session_restore.rs
@@ -204,14 +204,13 @@ fn write_recorder_agent(project_dir: &Path, role: &str) -> String {
         .to_string()
 }
 
-/// Scenario: Stage a `session.toml` describing two dashboard panes
-/// (`restored-alpha`, `restored-beta`, both `sleep 600`) at the path
-/// `DOT_AGENT_DECK_SESSION` points to, then launch the deck against a fresh
-/// (empty) daemon with NO `--continue` flag. Auto-restore must recreate both
-/// saved panes as dashboard cards without any flag. RED today: the snapshot
-/// load is gated behind `if continue_session` in `run_tui`, so with no flag the
-/// block never runs and neither saved pane appears — the dashboard stays at
-/// "No active sessions".
+/// Scenario: Stage a `session.toml` describing two dashboard panes (`r-alpha`,
+/// `r-beta`, both `sleep 600`) at the path `DOT_AGENT_DECK_SESSION` points to,
+/// then launch the deck against a fresh (empty) daemon with NO `--continue`
+/// flag. Auto-restore must recreate both saved panes as dashboard cards, under
+/// their saved names, without any flag — the snapshot load in `run_tui` is
+/// unconditional since PRD #89 Phase 2, so a dashboard still reading "No active
+/// sessions" (or showing only one of the two) is a regression.
 #[spec("session/restore/001")]
 #[test]
 fn restore_001_no_flag_startup_restores_panes_from_snapshot() {
@@ -224,10 +223,7 @@ fn restore_001_no_flag_startup_restores_panes_from_snapshot() {
     stage_session_snapshot(
         &session_file,
         session_dir.path(),
-        &[
-            ("restored-alpha", "sleep 600"),
-            ("restored-beta", "sleep 600"),
-        ],
+        &[("r-alpha", "sleep 600"), ("r-beta", "sleep 600")],
     );
 
     // No `--continue` — `launch_with_fixture` only passes the flag when a
@@ -241,18 +237,31 @@ fn restore_001_no_flag_startup_restores_panes_from_snapshot() {
         )
         .launch_with_fixture("modes");
 
-    // After Phase 2, both saved panes auto-restore as dashboard cards. Their
-    // saved names appear in the card title rows (e.g. "1 restored-alpha").
+    // After Phase 2, both saved panes auto-restore as dashboard cards, and both
+    // names must be readable on the cards themselves.
+    //
+    // The names are deliberately SHORT. Cards render `<type> · <name>` and the
+    // dashboard truncates the name to the card width (the same truncation the
+    // OpenCode-badge assertion further down this file documents at length): with
+    // the embedded pane column taking two thirds of the row, a card fits about
+    // ten characters of name, so the original `restored-alpha` / `restored-beta`
+    // rendered as `restored-…` and `restored-be…`. That still passed only because
+    // `PaneLayout::Stacked` used to draw a collapsed 1-row frame per non-focused
+    // pane, whose title spelled out the second pane's full name in the pane
+    // column. PRD #311 removes those frames — only the focused pane is drawn — so
+    // the full `restored-beta` is no longer anywhere on screen and a full-name
+    // match cannot succeed. Short names keep the assertion about what this test
+    // is actually for (both panes come back, under their saved names) instead of
+    // depending on a pane-column frame that no longer exists.
     let restored = common::wait_until(Duration::from_secs(10), || {
         let grid = deck.snapshot_grid();
-        grid.contains("restored-alpha") && grid.contains("restored-beta")
+        grid.contains("r-alpha") && grid.contains("r-beta")
     });
     assert!(
         restored,
         "PRD #89 M2.1: launching with NO --continue and a 2-pane snapshot on disk must \
-         auto-restore BOTH saved panes (`restored-alpha`, `restored-beta`) as dashboard \
-         cards, but they never appeared. RED until the snapshot-load block in `run_tui` \
-         is made unconditional (today it is gated on `continue_session`).\nFinal grid:\n{}",
+         auto-restore BOTH saved panes (`r-alpha`, `r-beta`) as dashboard cards, but they \
+         never appeared.\nFinal grid:\n{}",
         deck.snapshot_grid()
     );
 }

--- a/tests/fixtures/mode-two-side-panes/.dot-agent-deck.toml
+++ b/tests/fixtures/mode-two-side-panes/.dot-agent-deck.toml
@@ -1,0 +1,18 @@
+# Fixture for PRD #311's `tabs/mode/001` regression guard: one mode with TWO
+# persistent side panes, each printing a unique sentinel and then idling. The
+# two sentinels must be visible SIMULTANEOUSLY in a Mode tab — proving the
+# side-pane column renders both panes at once rather than collapsing one to a
+# 1-row title bar, which is what would happen if the Mode tab's side-pane
+# column ever read the shared global `pane_layout` (default `Stacked`) instead
+# of its own hardcoded `Tiled` split.
+[[modes]]
+name = "demo"
+reactive_panes = 0
+
+[[modes.panes]]
+command = "printf 'SIDE_ALPHA_SENTINEL\\n'; sleep 600"
+name = "Alpha side"
+
+[[modes.panes]]
+command = "printf 'SIDE_BETA_SENTINEL\\n'; sleep 600"
+name = "Beta side"

--- a/tests/fixtures/orch-focus-lifecycle/.dot-agent-deck.toml
+++ b/tests/fixtures/orch-focus-lifecycle/.dot-agent-deck.toml
@@ -1,0 +1,23 @@
+# Fixture for PRD #311's `tabs/orchestration/006`: a 3-role orchestration
+# (orchestrator + two workers) where every role prints a unique sentinel on
+# start, and the non-start `beta` role additionally self-posts real
+# `SessionStart` / `PreToolUse` hook events (via `dot-agent-deck hook
+# claude-code`, resolved through PATH) so its sidebar status card transitions
+# Idle -> Working while it is NOT the focused/expanded role pane — proving a
+# non-focused role keeps running and its status keeps updating even though its
+# pane is not drawn (or, pre-fix, collapsed to a titled 1-row frame).
+[[orchestrations]]
+name = "focus-lifecycle"
+
+[[orchestrations.roles]]
+name = "orchestrator"
+command = "printf 'ORCH_ROLE_SENTINEL\\n'; sleep 600"
+start = true
+
+[[orchestrations.roles]]
+name = "alpha"
+command = "printf 'ALPHA_ROLE_SENTINEL\\n'; sleep 600"
+
+[[orchestrations.roles]]
+name = "beta"
+command = "./beta-agent.sh"

--- a/tests/fixtures/orch-focus-lifecycle/beta-agent.sh
+++ b/tests/fixtures/orch-focus-lifecycle/beta-agent.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# PRD #311 `tabs/orchestration/006` placeholder — overwritten at test runtime
+# (`tests/e2e_orchestration_pane_column.rs::write_beta_agent`) with the
+# absolute path of the freshly built test binary baked in, so it never depends
+# on PATH resolving to a dev machine's separately installed `dot-agent-deck`.
+printf 'BETA_ROLE_SENTINEL\n'
+sleep 600

--- a/xtask/linkage-check/m2.allowlist
+++ b/xtask/linkage-check/m2.allowlist
@@ -112,7 +112,6 @@ status/transition/004
 status/transition/005
 status/transition/006
 status/transition/007
-tabs/mode/001
 tabs/mode/002
 tabs/mode/003
 tabs/mode/004


### PR DESCRIPTION
## Summary

Implement PRD #311: Remove collapsed-pane-frames from non-focused Stacked panes.

This PR completes the removal of the visual "collapsed frame" rendering for non-focused Stacked panes, simplifying the layout geometry and PTY sizing. The previous behavior rendered non-focused Stacked panes as small "collapsed" frames; now they render at their calculated natural size, with their PTY windows sized as if the pane were focused.

**Closes #311**

## Changes Made

- **Rendering**: Dropped the collapsed-frame render arm from `render_terminal_panes`' Stacked branch in `src/ui.rs`
- **Geometry**: Fixed `pane_stack_rects` and `stacked_expanded_index` formulas to correctly compute pane positions and sizes without the collapsed-frame logic
- **PTY Sizing**: Non-focused Stacked panes' PTYs are now sized "as if focused" using the `pane_target_dims` function, ensuring the spawned agent runs at full capacity regardless of focus state
- **Tests**: 
  - RED tests added in `tests/e2e_orchestration_pane_column.rs` (PTY-attached L2 with real agent integration)
  - Extended regression guards in `tests/e2e_mode_tab_layout.rs`
  - L1 snapshot test in orchestration/layout/002
- **Docs**: Updated comments and test names to remove references to the removed collapsed-frame behavior
- **Shell Quoting**: Fixed shell-quote safety in new e2e fixture (auditor finding)

## Testing

All tests passing:
- `cargo test-fast`: 1421/1421 ✅
- `cargo test-e2e`: 2800/2803 passed (3 pre-existing failures in unrelated tests: dispatch_005, manager_010, restore_001 — tracked in separate PRDs #89, #**)
- 127 `.cast` recordings generated for demo-reel step

## Cross-Version Safety

Not applicable — TUI-only rendering/geometry change, no daemon protocol/hook/orchestration-routing changes. No breaking changes to the TUI↔daemon contract. Patch-level version bump.

## Files Changed

- `src/ui.rs` — geometry and rendering logic
- `tests/e2e_orchestration_pane_column.rs` (new) — L2 PTY test
- `tests/e2e_mode_tab_layout.rs` (new) — regression test
- `tests/fixtures/orch-focus-lifecycle` (new) — fixture for PTY test
- `tests/fixtures/mode-two-side-panes` (new) — fixture for regression test
- `tests/CATALOG.md` — recorded test entries
- `docs/orchestration.md`, `docs/keyboard-shortcuts.md`, `docs/getting-started.md` — documentation updates
- `changelog.d/311.feature.md` — changelog entry

## Review Focus

- Verify zero-height rect handling for non-focused panes
- Confirm PTY sizing is correctly computed for both focused and non-focused panes
- Check that hook fixtures (`prepare_claude_home`) are correctly set up in L2 tests
- Validate that the geometry fixes align with the intended user-visible layout
- Confirm documentation reflects the removed collapsed-frame behavior

## Follow-Up

None — PRD #311 is complete.
