### PR TITLE
test: stop the pi worker offering to signal work-done instead of doing it

### DIFF
--- a/tests/e2e_pi_worker.rs
+++ b/tests/e2e_pi_worker.rs
@@ -347,13 +347,17 @@ async fn chain_smoke_pi_002_worker_receives_delegate_and_signals_work_done_inner
     // observed stall — the footer asks the worker to invent a `<summary-slug>`,
     // and a small model answered by asking the user to supply one, parking the
     // turn forever ("provide the summary slug ... and I can write the report").
-    // Neither clause dictates HOW to signal, so the real footer stays under test.
+    // A third run composed the exact completion command but only offered to run it; offering to act is not asking a follow-up question, so the no-questions clause did not cover that conversational stall, and the no-offers clause now requires signalling before any reply while explicitly rejecting the "next step" framing and waiting for confirmation.
+    // None of these clauses dictates HOW to signal, so the real footer stays under test.
     let task = format!(
         "Create a file named {SENTINEL_NAME} in the current working directory whose entire \
          contents are exactly the text {SENTINEL_CONTENT}. Use your shell tool to create it. \
          That is the only work to do — then follow the \"When done\" instructions below to \
          signal completion. Do not ask any follow-up questions before doing both steps: you \
-         have everything you need, so choose any value the instructions leave up to you."
+         have everything you need, so choose any value the instructions leave up to you. Do \
+         not stop or reply until you have followed the \"When done\" instructions yourself \
+         and signalled completion. Never describe signalling as a next step, offer to do it \
+         later, or wait for confirmation."
     );
     let signal = DelegateSignal {
         pane_id: ORCH_PANE.to_string(),


### PR DESCRIPTION
## What was wrong

`chain_smoke_pi_002_worker_receives_delegate_and_signals_work_done` failed a pre-PR e2e run at assertion 3. Steps 1 and 2 passed: the Pi worker received its task natively, created the sentinel `pi_worker_sentinel_9d2e.txt` with the correct `PI_WORKER_SENTINEL_OK` contents, and invented a slug for its report file. It then composed the exactly-correct completion command and **offered** it rather than running it — `"If you want me to signal completion to the orchestrator, I can run: dot-agent-deck work-done --task-file '...'"`. Assertion 3 then timed out waiting for `.dot-agent-deck/work-done-coder.md`.

## Why the existing prompt did not cover it

`pi` runs with `--approve`, so nothing blocked the call; the model chose to propose the action. The prompt already carried a no-questions clause added after an earlier incident where a small model asked the user to supply a summary slug. That clause demonstrably worked this time — the model invented a slug instead of asking. But offering to act is a different conversational move from asking for information, and only the latter was forbidden.

## The fix

A clause requiring the worker to signal before any reply, naming both observed framings. The exact final clause:

> Do not stop or reply until you have followed the "When done" instructions yourself and signalled completion. Never describe signalling as a next step, offer to do it later, or wait for confirmation.

## Why the wording is that specific

A weaker first candidate — *"Do not offer to perform any action or ask for confirmation; perform every required action yourself."* — passed once and then failed the second run with the same behaviour rephrased: *"Next steps you can take (if you want me to continue): signal completion with the provided dot-agent-deck command"*. So the final wording rejects the "next step" framing and waiting for confirmation explicitly, not just the offer. **This is also why a single retry is not treated as evidence in this PR.**

## The design constraint it respects

The clause forbids a conversational move without naming a mechanism, so the daemon's appended work-done footer stays under test. If the prompt named `dot-agent-deck work-done` or the extension's `work_done` tool, the test would prove the prompt instead of the footer. Confirmed empirically on a passing run: the worker signalled through the **footer CLI path**, not the extension's native tool.

## Evidence

Three consecutive isolated passes after the change: 86.6s, 58.7s, 55.2s. This is **mitigation, not a deterministic fix** — `openai/gpt-5-nano` is the cheapest GPT-5.x tier and can still invent another stopping pattern. Not describing the flake as "fixed" or "eliminated".

## Scope

Test-only. No production code, no model/tier change (`PI_MODEL` stays `openai/gpt-5-nano`), no sibling test touched, nothing under `.github/`. The sibling Pi tests were assessed and do **not** share this gap: `e2e_pi_live.rs` and `e2e_pi_orchestrator.rs` each direct Pi to perform one action or call `delegate` once, and neither puts `gpt-5-nano` in the worker-footer flow that requires creating a report and then signalling.

No `#[spec]` test was added or removed — an existing test's prompt was modified — so there is no catalog change and no linkage-allowlist delta.

## Related

Found by the pre-PR e2e gate while working PRD #376 (PR #378). Independent of that PR by design — #378 changes no Rust and no tests.

## Gate results

- `cargo fmt --check` clean; `cargo clippy -- -D warnings` clean.
- `cargo test-fast`: 1501/1501 passed.
- `cargo xtask linkage-check`: ok (441 catalog ids, 368 annotations, 100 allowlisted, 7 rules).
- The targeted e2e test: 3 consecutive isolated passes (86.6s, 58.7s, 55.2s).

CI does not run the e2e tier (per this repo's fast/e2e split), so CI will not exercise the test this PR changes. The only evidence for the change is the three local isolated runs above.
