### PR TITLE
test(e2e): restore the agent-ready gate the fixture shims stopped exercising (#343)

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4422,6 +4422,48 @@ pub fn wait_for_file_substr_count(
     }
 }
 
+/// A `/bin/sh` line that posts one synthetic Claude-Code hook event from inside
+/// a fixture agent script, through the REAL `dot-agent-deck hook` CLI.
+///
+/// Centralised because six fixture shims across five e2e files hand-rolled this
+/// line, and when the CLI moved the agent from a positional argument to
+/// `--agent` (PRD #30), five of them kept emitting the stale `hook claude-code`
+/// form. `clap` rejected it (exit 2), the `>/dev/null 2>&1` swallowed the error,
+/// and no readiness signal was ever emitted — so the agent-ready gate those
+/// tests exist to exercise silently fell through to the 10-second
+/// `process_pending_seed_prompts` timeout fallback instead (issue #343). They
+/// still passed, just ~10s slower and proving nothing about readiness.
+///
+/// The `|| exit` is what stops that recurring: `handle_hook` returns
+/// `ExitCode::SUCCESS` on EVERY path it reaches — bad JSON, unmapped event, even
+/// a failed socket send — so a nonzero exit can only mean `clap` refused the
+/// argument shape. That makes failing hard here deterministic rather than
+/// load-sensitive: a future CLI change kills the fixture agent loudly instead of
+/// quietly degrading its test into a passing-but-vacuous one.
+///
+/// `bin` is the ABSOLUTE path of the binary under test (`CARGO_BIN_EXE_…`),
+/// single-quoted here so a checkout under a path containing spaces — or a quote
+/// — still resolves the build under test rather than whatever `dot-agent-deck`
+/// a dev machine happens to have on `$PATH`.
+#[allow(dead_code)]
+pub fn claude_hook_line(bin: &str, payload_json: &str) -> String {
+    let quoted_bin = format!("'{}'", bin.replace('\'', r"'\''"));
+    format!(
+        "printf '%s' '{payload_json}' | {quoted_bin} hook --agent claude-code >/dev/null 2>&1 \
+         || {{ echo 'dot-agent-deck hook rejected the fixture payload' >&2; exit 97; }}\n"
+    )
+}
+
+/// [`claude_hook_line`] for the common case: the `SessionStart` event that acts
+/// as the agent-ready signal the spawn-time prompt gate waits on.
+#[allow(dead_code)]
+pub fn claude_session_start_line(bin: &str, session_id: &str) -> String {
+    claude_hook_line(
+        bin,
+        &format!(r#"{{"hook_event_name":"SessionStart","session_id":"{session_id}"}}"#),
+    )
+}
+
 /// The recorder line the deck's own Codex metadata probe produces.
 ///
 /// PRD #20 §4.2.1: the deck records SCOPED, hash-pinned trust for its own Codex

--- a/tests/e2e_dashboard_selection.rs
+++ b/tests/e2e_dashboard_selection.rs
@@ -39,10 +39,10 @@ fn write_card_agent(work: &std::path::Path) -> String {
     let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
     let body = format!(
         "#!/bin/sh\n\
-         printf '%s' '{{\"hook_event_name\":\"SessionStart\",\"session_id\":\"modecard\"}}' \
-         | \"{bin}\" hook claude-code >/dev/null 2>&1\n\
+         {hook}\
          echo ready > started-card.log\n\
-         sleep 600\n"
+         sleep 600\n",
+        hook = common::claude_session_start_line(bin, "modecard"),
     );
     let path = work.join("card-agent.sh");
     std::fs::write(&path, body).expect("write mode agent script");

--- a/tests/e2e_mode_seed_prompt.rs
+++ b/tests/e2e_mode_seed_prompt.rs
@@ -12,7 +12,7 @@
 //! ## Exercising the agent-ready gate
 //! Delivery is gated on the agent's readiness signal (the `SessionStart` hook
 //! event, as orchestrations use). The test's agent is a fixture script that
-//! self-posts `SessionStart` via `dot-agent-deck hook claude-code` — the real
+//! self-posts `SessionStart` via `dot-agent-deck hook --agent claude-code` — the real
 //! hook path — using the `DOT_AGENT_DECK_PANE_ID` injected per-pane and the
 //! `DOT_AGENT_DECK_SOCKET` inherited from the daemon. After posting readiness
 //! it records every line written into its PTY stdin to a cwd-relative file, so
@@ -41,9 +41,9 @@ fn write_agent_script(work: &std::path::Path, tag: &str) -> String {
     let body = format!(
         "#!/bin/sh\n\
          echo started >> started-{tag}.log\n\
-         printf '%s' '{{\"hook_event_name\":\"SessionStart\",\"session_id\":\"seedtest-{tag}\"}}' \
-         | \"{bin}\" hook claude-code >/dev/null 2>&1\n\
-         while IFS= read -r l; do printf '%s\\n' \"$l\" >> record-{tag}.log; done\n"
+         {hook}\
+         while IFS= read -r l; do printf '%s\\n' \"$l\" >> record-{tag}.log; done\n",
+        hook = common::claude_session_start_line(bin, &format!("seedtest-{tag}")),
     );
     let path = work.join(&script_name);
     std::fs::write(&path, body).expect("write agent script");

--- a/tests/e2e_orchestration_pane_column.rs
+++ b/tests/e2e_orchestration_pane_column.rs
@@ -42,30 +42,25 @@ fn has_role_status(grid: &str, role: &str, status: &str) -> bool {
         .any(|line| line.contains(&role_needle) && line.contains(status))
 }
 
-/// Escape `s` as a single POSIX shell word using the standard single-quote
-/// idiom (close the quote, emit an escaped literal `'`, reopen the quote), so
-/// an embedded build path containing shell metacharacters can't be
-/// misinterpreted by the `/bin/sh` script it's spliced into.
-fn shell_quote(s: &str) -> String {
-    format!("'{}'", s.replace('\'', r"'\''"))
-}
-
 /// Overwrite the fixture's `beta-agent.sh` placeholder with the ABSOLUTE path
 /// of the freshly built test binary baked in (mirrors `write_card_agent` in
 /// `e2e_dashboard_selection.rs`), rather than relying on `dot-agent-deck`
 /// resolving correctly on PATH — a dev machine may have a separately
 /// installed `dot-agent-deck` shadowing the build under test.
 fn write_beta_agent(deck: &TuiDeck) {
-    let bin = shell_quote(env!("CARGO_BIN_EXE_dot-agent-deck"));
+    let bin = env!("CARGO_BIN_EXE_dot-agent-deck");
     let body = format!(
         "#!/bin/sh\n\
          printf 'BETA_ROLE_SENTINEL\\n'\n\
-         printf '%s' '{{\"hook_event_name\":\"SessionStart\",\"session_id\":\"beta-sess\"}}' \\\n\
-         | {bin} hook --agent claude-code >/dev/null 2>&1\n\
+         {session_start}\
          sleep 1\n\
-         printf '%s' '{{\"hook_event_name\":\"PreToolUse\",\"session_id\":\"beta-sess\",\"tool_name\":\"Bash\"}}' \\\n\
-         | {bin} hook --agent claude-code >/dev/null 2>&1\n\
-         sleep 600\n"
+         {pre_tool_use}\
+         sleep 600\n",
+        session_start = common::claude_session_start_line(bin, "beta-sess"),
+        pre_tool_use = common::claude_hook_line(
+            bin,
+            r#"{"hook_event_name":"PreToolUse","session_id":"beta-sess","tool_name":"Bash"}"#,
+        ),
     );
     let path = deck.workdir().join("beta-agent.sh");
     std::fs::write(&path, body).expect("overwrite beta-agent.sh with resolved binary path");

--- a/tests/e2e_scheduler_manager.rs
+++ b/tests/e2e_scheduler_manager.rs
@@ -171,10 +171,10 @@ fn manager_002_edit_spawns_seeded_authoring_agent_prefilled() {
             &path,
             format!(
                 "#!/bin/sh\n\
-                 printf '%s' '{{\"hook_event_name\":\"SessionStart\",\"session_id\":\"authoring\"}}' \
-                 | \"{bin}\" hook claude-code >/dev/null 2>&1\n\
+                 {hook}\
                  while IFS= read -r l; do printf '%s\\n' \"$l\" >> \"{rec}\"; done\n",
-                rec = record.to_string_lossy()
+                rec = record.to_string_lossy(),
+                hook = common::claude_session_start_line(bin, "authoring"),
             ),
         )
         .unwrap_or_else(|e| panic!("write {name} shim: {e}"));
@@ -575,10 +575,10 @@ fn write_recorder_shim(shim_dir: &std::path::Path, name: &str, record: &std::pat
         format!(
             "#!/bin/sh\n\
              pwd >> \"{rec}\"\n\
-             printf '%s' '{{\"hook_event_name\":\"SessionStart\",\"session_id\":\"authoring\"}}' \
-             | \"{bin}\" hook claude-code >/dev/null 2>&1\n\
+             {hook}\
              while IFS= read -r l; do printf '%s\\n' \"$l\" >> \"{rec}\"; done\n",
-            rec = record.to_string_lossy()
+            rec = record.to_string_lossy(),
+            hook = common::claude_session_start_line(bin, "authoring"),
         ),
     )
     .unwrap_or_else(|e| panic!("write {name} shim: {e}"));

--- a/tests/e2e_session_restore.rs
+++ b/tests/e2e_session_restore.rs
@@ -185,11 +185,11 @@ fn write_recorder_agent(project_dir: &Path, role: &str) -> String {
     let body = format!(
         "#!/bin/sh\n\
          echo started >> \"{started}\"\n\
-         printf '%s' '{{\"hook_event_name\":\"SessionStart\",\"session_id\":\"restore-{role}\"}}' \
-         | \"{bin}\" hook claude-code >/dev/null 2>&1\n\
+         {hook}\
          while IFS= read -r l; do printf '%s\\n' \"$l\" >> \"{record}\"; done\n",
         started = started.display(),
         record = record.display(),
+        hook = common::claude_session_start_line(bin, &format!("restore-{role}")),
     );
     std::fs::write(&script_path, body).expect("write recorder agent script");
     #[cfg(unix)]


### PR DESCRIPTION
Fixes #343
Fixes #349

#343 and #349 are the same bug, filed hours apart. Both frame it as a functional regression in the blank-`default_command` → `claude` fallback. **That framing is wrong** — the fallback works. `resolve_authoring_command` (`src/ui.rs:432`) trims and falls back to `agent_registry::CLAUDE_CODE.default_command`, applied at the form pre-fill and at both submit doors. The real defect is in the test harness.

## Root cause

Five fixture agent shims across four e2e files posted their `SessionStart` readiness signal as:

```sh
dot-agent-deck hook claude-code    # positional — dropped in PRD #30 (#31)
```

The CLI takes `--agent` (defaulting to claude-code). clap rejected the positional with **exit 2**, the `>/dev/null 2>&1` swallowed the error, and no event was ever emitted.

Nothing failed, because `process_pending_seed_prompts` delivers the seed anyway 10s after spawn when no `SessionStart` arrives (`src/ui.rs:2943`). So every affected test passed while proving nothing about the readiness path it exists to cover — and sat ~10s deep in a 15s assertion budget, leaving ~5s of headroom that the full-parallel gate exhausted. That is what #343/#349 actually observed: their 18.96s/19.35s failures are the 15s assertion expiring after inflated setup, the same load profile as #351.

Production was never affected: `hooks_manage.rs` installs `{binary_path} hook` (bare, correct default).

### How it was found

Probed the dashboard card 3s after spawn — it read `No agent`, i.e. `AgentType::None`, so the hook had never upgraded it. Capturing the shim's hook stderr and exit code gave the answer directly:

```
PROBE pane=[1] agent=[1] sock=[…/hook.sock]
error: unexpected argument 'claude-code' found
PROBE hook_exit=2
```

## Fix

Test-only; `src/` untouched, so no TUI↔daemon contract question arises (rule 12).

- Corrected the invocation at all five stale sites.
- Routed all six sites (including the one already correct) through shared `common::claude_hook_line` / `claude_session_start_line` — one place to keep right instead of six hand-rolled copies. Absorbed `e2e_orchestration_pane_column`'s local `shell_quote` into the helper so every site gets the stronger single-quote form.
- **The helper fails hard on a nonzero exit** instead of swallowing it. Safe to do deterministically: `handle_hook` returns `ExitCode::SUCCESS` on every path it reaches — bad JSON, unmapped event, even a failed socket send — so a nonzero exit can only mean clap refused the argument shape, never load or timing.

Assertion budgets deliberately **not** raised: fixing the gate removed the reason they were tight, and raising them too would re-hide the next regression.

## Verification

Delivery now rides the real signal, and the tests collapse accordingly — this is the acceptance criterion:

| test | before | after |
|---|---|---|
| `manager_010` | 10.637s | **1.330s** |
| `form_002` | 10.953s | 1.472s |
| `form_003` | 10.938s | 1.503s |
| `form_006` | 10.949s | 1.506s |
| `manager_002` | 10.907s | 1.475s |
| `form_007` | 10.906s | 1.465s |
| `mode_005` | 14.339s | 5.517s |

Guard proven by reintroducing the stale form: `manager_010` then **FAILS** rather than passing 10s slower.

- `cargo fmt --check` ✅
- `cargo clippy --all-targets --features e2e -- -D warnings` ✅
- `cargo test-fast` — 1521/1521 ✅
- `cargo test-e2e` — 3452/3455 ✅

The 3 full-gate failures are unrelated, each re-verified passing in isolation:

- `opencode_import_rejects_a_symlinked_source_root` — 73/73 pass in isolation, including in the binary that failed under load; tempdir race (#322 territory).
- `card_stats_005_real_agent_card_narrows_without_restructuring` — real-agent tier, passes in isolation (24.1s).
- `route_001_two_tabs_same_cwd_do_not_cross_deliver` — real-agent tier; the agent asked "What would you like me to do?" instead of executing, the failure mode bf517c4 fixed for the pi worker. Passes in isolation (29.1s vs 174s under load).

The `tests/common/mod.rs` change is purely additive (no existing line removed or modified), and neither failing file references the new helpers.

No changelog fragment — a test-harness fix isn't release-note material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)