### PR TITLE
fix(tests): make card snapshots independent of the wall clock (#350)

### DIFF
--- a/tests/mode_indication.rs
+++ b/tests/mode_indication.rs
@@ -88,6 +88,15 @@ fn nonblank_rows(buffer: &Buffer) -> usize {
 }
 
 fn selected_card_fixture() -> SessionState {
+    // `last_activity` is nudged 30s into the future of `now` (issue #350):
+    // `mode_deck_001_selected_card_styles` pins this fixture's rendered card
+    // into a color/style-aware snapshot, and the bottom border's `Last:` field
+    // is computed by `format_elapsed` (src/ui.rs) from `Utc::now()` at render
+    // time, not at fixture-build time. Seeding it to exactly `now` raced that
+    // computation across a whole second boundary under any scheduling delay.
+    // The forward nudge relies on `format_elapsed`'s existing clamp of a
+    // negative delta to zero (`delta.num_seconds().max(0)`), so the rendered
+    // value holds at `0s` for 30s. Committed snapshot is unchanged.
     let now = chrono::Utc::now();
     SessionState {
         session_id: "mode-card".to_string(),
@@ -96,7 +105,7 @@ fn selected_card_fixture() -> SessionState {
         status: SessionStatus::Working,
         active_tool: None,
         started_at: now,
-        last_activity: now,
+        last_activity: now + chrono::Duration::seconds(30),
         recent_events: VecDeque::new(),
         tool_count: 0,
         last_user_prompt: None,

--- a/tests/render_dashboard.rs
+++ b/tests/render_dashboard.rs
@@ -57,9 +57,22 @@ fn pane_004_card_title_row() {
     // doesn't need its own fn — keeping the test body
     // self-contained also reads as cleaner generated `.md` Steps).
     //
-    // Both timestamps use one current instant so the fixture starts with a
+    // Both timestamps derive from one current instant so the fixture keeps a
     // compact `0s` elapsed value; a fixed calendar instant previously drifted
     // into a large hour count as the test aged (M3 fix).
+    //
+    // `last_activity` is nudged 30s into the *future* of that instant rather
+    // than left equal to it (issue #350). The bottom border's `Last:` field is
+    // computed by `format_elapsed` (src/ui.rs) from `Utc::now()` at *render*
+    // time, not at fixture-build time, so `last_activity == now` put the
+    // rendered value exactly on the `0s`/`1s` boundary — any scheduling delay
+    // between building the fixture and rendering (routine under parallel test
+    // load) tipped this snapshot to `Last: 1s`. A *past* offset would only
+    // shrink the margin further; nudging forward instead relies on
+    // `format_elapsed`'s existing clamp of a negative delta to zero
+    // (`delta.num_seconds().max(0)`), so the value holds at `0s` for any
+    // render within 30s. No production change is needed — the clamp already
+    // handles this shape of input, and the committed snapshot is unchanged.
     let now = chrono::Utc::now();
     let session = SessionState {
         session_id: "sess-abc123".to_string(),
@@ -71,7 +84,7 @@ fn pane_004_card_title_row() {
             detail: Some("src/main.rs".to_string()),
         }),
         started_at: now,
-        last_activity: now,
+        last_activity: now + chrono::Duration::seconds(30),
         recent_events: VecDeque::new(),
         tool_count: 7,
         last_user_prompt: Some("fix the login bug".to_string()),
@@ -724,6 +737,17 @@ fn pane_007_pi_card_shows_pi_identity() {
 #[spec("dashboard/pane/008")]
 #[test]
 fn pane_008_codex_card_shows_colored_identity_badge() {
+    // `last_activity` is nudged 30s into the future of `now` (issue #350). This
+    // fixture feeds *both* snapshots below — the immediate one, and
+    // `pane_008_named_agent_badges` via `session.clone()` in the loop further
+    // down — so by the time the second one renders, real wall-clock time has
+    // already been spent on the first snapshot's assertions and comparisons.
+    // `format_elapsed` (src/ui.rs) reads `Utc::now()` at render time, so
+    // `last_activity == now` raced the `0s`/`1s` boundary, and the widened
+    // window is why the *second* snapshot is the one that flaked first. The
+    // forward nudge relies on `format_elapsed`'s existing clamp of a negative
+    // delta to zero (`delta.num_seconds().max(0)`): both renders stay at `0s`
+    // for 30s. Committed snapshots are unchanged.
     let now = chrono::Utc::now();
     let session = SessionState {
         session_id: "wrapped-01".to_string(),
@@ -732,7 +756,7 @@ fn pane_008_codex_card_shows_colored_identity_badge() {
         status: SessionStatus::Thinking,
         active_tool: None,
         started_at: now,
-        last_activity: now,
+        last_activity: now + chrono::Duration::seconds(30),
         recent_events: VecDeque::new(),
         tool_count: 0,
         last_user_prompt: Some("inspect the repository".to_string()),
@@ -1515,6 +1539,15 @@ fn pane_005_highlight_follows_selected_session_id() {
     //
     // All sessions share one current activity time, keeping their compact
     // bottom-border elapsed values identical in the snapshot.
+    //
+    // That time is nudged 30s into the future (issue #350): `format_elapsed`
+    // (src/ui.rs) reads `Utc::now()` at render time, so seeding it to exactly
+    // `now` left every card on the `0s`/`1s` boundary — and this test renders
+    // several cards in sequence, so the later ones sat furthest from the
+    // instant the fixture was built. The forward nudge relies on
+    // `format_elapsed`'s existing clamp of a negative delta to zero
+    // (`delta.num_seconds().max(0)`), holding every card at `0s` for 30s.
+    // Committed snapshot is unchanged.
     let now = chrono::Utc::now();
     let make = |sid: &str, pane: &str, name: &str, cwd: &str| SessionState {
         session_id: sid.to_string(),
@@ -1526,7 +1559,7 @@ fn pane_005_highlight_follows_selected_session_id() {
             detail: Some("src/main.rs".to_string()),
         }),
         started_at: now,
-        last_activity: now,
+        last_activity: now + chrono::Duration::seconds(30),
         recent_events: VecDeque::new(),
         tool_count: 3,
         last_user_prompt: Some("do the thing".to_string()),


### PR DESCRIPTION
Fixes #350.

## What was actually wrong

Issue #350 offered two possibilities — a rendering regression, or legitimate output drift needing `cargo insta accept`. It is **neither**: the snapshot is **non-deterministic**.

Four card-render fixtures seed `last_activity` with the same `Utc::now()` instant used to build them, but `format_elapsed` (`src/ui.rs:16006`) re-reads `Utc::now()` at **render** time. That puts the bottom border's `Last:` field exactly on the `0s`/`1s` boundary, so any scheduling delay between building a fixture and rendering it — routine under parallel test load — flips the pinned snapshot to `Last: 1s`.

This is why it surfaced during #346's pre-PR e2e gate against a change that touched only `tests/delegate_prompt_injection.rs`, with no relation to card rendering.

The timing corroborates it: `49df543` ("move card Last/Tools stats to the bottom border") put the elapsed value into the card border on 2026-08-02 21:16 UTC; #350 was filed five hours later.

## The fix

Seed `last_activity` **30s into the future** instead, relying on `format_elapsed`'s existing clamp of a negative delta to zero (`delta.num_seconds().max(0)`), so the value holds at `0s` for any render within 30s.

- A **past** offset would only shrink the margin, not widen it.
- **No production change** — the clamp already handles this shape of input.
- **Every committed `.snap` is byte-identical.** That is itself the check that the fix is behaviour-preserving: if a snapshot moved, the fix would be wrong.

## Scope: four fixtures, five snapshots

Broader than the single test in the issue title:

| Test | File |
|---|---|
| `pane_004_card_title_row` | `tests/render_dashboard.rs` |
| `pane_005_highlight_follows_selected_session_id` | `tests/render_dashboard.rs` |
| `pane_008_codex_card_shows_colored_identity_badge` (2 snapshots) | `tests/render_dashboard.rs` |
| `mode_deck_001_selected_card_styles` | `tests/mode_indication.rs` |

The `pane_008` fixture feeds **both** its snapshots via `session.clone()`, so the second renders only after the first's assertions and comparisons have run. That widened window is why `pane_008_named_agent_badges` is the one that flaked first.

The other four `last_activity: now` fixtures are untouched — they don't feed a snapshot. No test asserts on the `Last:` string outside the snapshots (the only exact matches are `Last: 1h`, on the already-backdated `card_stats_session`).

## Verification

- **Boundary demonstration with a control** (temporary, not committed): the old seeding reproducibly rendered `└─… Last: 1s  Tools: 7 ┘` after a 1.5s delay, while the nudged seeding held `Last: 0s` at 0 / 1.5 / 2.5s. A determinism fix proved only by green runs proves nothing, so the bug is reproduced on demand here.
- **20 consecutive runs** of the four tests, all green, with no `.snap` diff and no `.snap.new`.
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` both clean.

No changelog fragment, matching #352 — the directly analogous test-only flakiness fix.

## Pre-existing failures, not from this change

The full fast tier is not green on `main` either. Measured back to back on the same machine:

| | `delegate_prompt_injection` binary |
|---|---|
| `main` | 7 of 40 fail |
| this branch | 6 of 40 fail |

`main` fails *more*. `codex_trust_002` and `spawn_time_role_prompt_…` pass in isolation on both. This is the known load-flake family (#346 / #364 / #402), untouched by this PR.

## Attribution

Ports the analysis and fix from [prageethw/dot-agent-deck#37](https://github.com/prageethw/dot-agent-deck/pull/37) ("test: make card snapshots independent of the wall clock"), adapted to upstream's test names — the fork renamed `pane_008` in a fork-only change, so this is not a clean cherry-pick. Credit to @prageethw, including the observation that the cloned fixture widens the window for the second snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
