### PR TITLE
ci(ruleset): let Renovate bypass the review requirement before it silently stalls

### DIFF
--- a/docs/develop/governance.md
+++ b/docs/develop/governance.md
@@ -47,7 +47,7 @@ The order matters. Each step is safe to stop at.
 
 **2. Create the PAT and set the secret.** A fine-grained PAT scoped to this repository with Contents: read and write, stored as `RELEASE_TOKEN`. Verify with `scripts/apply-branch-protection.sh status`, which reports whether the secret is visible.
 
-**3. Onboard the second maintainer.** Grant `write` (or `maintain`) access and add them to `MAINTAINERS.md` in the same change. Do not skip ahead while there is only one collaborator, or apply step 4 with `REQUIRED_APPROVALS=0`.
+**3. Onboard the second maintainer.** Grant `write` (or `maintain`) access and add them to `MAINTAINERS.md` in the same change. Do not skip ahead while there is only one collaborator, or apply step 4 with `REQUIRED_APPROVALS=0`. Raising approvals to 1 is also the moment the Renovate bypass starts mattering — see [Renovate and automerge](#renovate-and-automerge).
 
 **4. Apply the ruleset.**
 
@@ -70,6 +70,23 @@ This is the step that actually validates the token, and it has to come *after* s
 If the canary comes back `GH006`, the token cannot bypass. Fall back to a classic PAT (unambiguous, but `repo` scope reaches every repository the account can see) or move to the GitHub App variant below, which is both narrowly scoped and unambiguously a bypass actor.
 
 **6. Reconsider required status checks.** They were removed for the same `GH006` reason and can come back once the canary has proven the token bypasses. Add them to the ruleset's `rules` array as a `required_status_checks` entry.
+
+## Renovate and automerge
+
+`renovate.json` automerges five groups on green CI: Rust patch crates, Rust minors on crates already at 1.0, devbox packages, GitHub Actions, and the docs-site npm dependencies. Renovate merges these itself — PR #426 was merged by `renovate[bot]`, not by a human — so the ruleset applies to it like any other actor.
+
+**Renovate is a GitHub App, not a collaborator.** The `RepositoryRole: admin` bypass does not cover it; apps are a separate `actor_type` (`Integration`). That distinction is the whole hazard:
+
+- At `REQUIRED_APPROVALS=0` nothing breaks. A pull request is required, Renovate opens one anyway, and no approval is needed.
+- At `REQUIRED_APPROVALS=1` every automerge group **stalls silently**. A bot cannot approve its own pull request, and GitHub counts approvals only from write/admin accounts. Nothing errors and nothing is logged — the pull requests simply accumulate, which is a slow and confusing way to discover the cause.
+
+The script therefore adds Renovate (app id 2740, from `gh api /apps/renovate --jq .id`) as a bypass actor by default, in `pull_request` mode rather than `always`: it may merge a pull request that lacks the required approvals, but still cannot push directly to `main`. That is strictly narrower than the admin bypass.
+
+It is enabled by default deliberately. While approvals are 0 the entry is inert, so turning it on early costs nothing — and the alternative is remembering this at the exact moment a second maintainer is onboarded, which is when attention is elsewhere. Set `RENOVATE_BYPASS=false` to leave it out and review every dependency bump by hand.
+
+One consequence to accept: with the bypass in place, CI gating on dependency pull requests rests on Renovate's own configuration (it waits for branch status before merging), not on the ruleset. Adding `required_status_checks` in step 6 does not change that, because a bypass actor bypasses those too.
+
+The `required_review_thread_resolution` rule is not a problem here in practice — Greptile posts no review and no inline comments on Renovate pull requests (verified on #426, #389 and #384). It would become one if that ever changed.
 
 ## What is gated
 

--- a/scripts/apply-branch-protection.sh
+++ b/scripts/apply-branch-protection.sh
@@ -49,7 +49,48 @@ REQUIRED_APPROVALS="${REQUIRED_APPROVALS:-1}"
 # part of the ruleset source or owner organization`).
 ADMIN_BYPASS_MODE="${ADMIN_BYPASS_MODE:-always}"
 
+# Let the Renovate GitHub App bypass the pull_request rule.
+#
+# Renovate is an App, not a collaborator, so the RepositoryRole bypass above does
+# not cover it — apps are a separate actor_type. Without this entry, raising
+# REQUIRED_APPROVALS to 1 silently stalls every automerge group in renovate.json
+# (Rust patch crates, Rust minors at >=1.0, devbox packages, GitHub Actions, and
+# the docs-site npm deps), because a bot cannot approve its own pull request and
+# GitHub counts approvals only from write/admin accounts. Nothing errors; the
+# pull requests simply sit there, which is a slow and confusing way to find out.
+#
+# `pull_request` mode rather than `always`: Renovate may merge a pull request
+# that lacks the required approvals, but still cannot push directly to main. That
+# is strictly narrower than the admin bypass above.
+#
+# Defaults on. While REQUIRED_APPROVALS=0 there is nothing to bypass, so enabling
+# it early is inert — and the alternative is remembering this at the exact moment
+# a second maintainer is onboarded, which is precisely when attention is
+# elsewhere. Set RENOVATE_BYPASS=false to leave it out and review every
+# dependency bump by hand instead.
+RENOVATE_BYPASS="${RENOVATE_BYPASS:-true}"
+# `gh api /apps/renovate --jq .id` -> 2740 (the public Renovate app).
+RENOVATE_APP_ID="${RENOVATE_APP_ID:-2740}"
+
 usage() { sed -n '4,22p' "$0" >&2; exit 64; }
+
+# Render the ruleset's bypass_actors array. Kept out of the payload heredoc
+# because the Renovate entry is conditional.
+bypass_actors_json() {
+  printf '{ "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "%s" }' \
+    "$ADMIN_BYPASS_MODE"
+  if [ "$RENOVATE_BYPASS" = "true" ]; then
+    case "$RENOVATE_APP_ID" in
+      ''|*[!0-9]*)
+        echo >&2
+        echo "error: RENOVATE_APP_ID must be numeric, got '$RENOVATE_APP_ID'." >&2
+        return 1
+        ;;
+    esac
+    printf ',\n    { "actor_id": %s, "actor_type": "Integration", "bypass_mode": "pull_request" }' \
+      "$RENOVATE_APP_ID"
+  fi
+}
 
 # Echo the id of the `$RULESET_NAME` ruleset, or nothing if it does not exist.
 #
@@ -89,13 +130,18 @@ existing_ruleset_id() {
 }
 
 payload() {
+  local actors
+  # Assign on its own line so a non-zero return (bad RENOVATE_APP_ID) propagates
+  # under `set -e` instead of being masked, and so a malformed value can never
+  # reach the API as part of an otherwise valid-looking ruleset.
+  actors="$(bypass_actors_json)"
   cat <<JSON
 {
   "name": "$RULESET_NAME",
   "target": "branch",
   "enforcement": "active",
   "bypass_actors": [
-    { "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "$ADMIN_BYPASS_MODE" }
+    $actors
   ],
   "conditions": {
     "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] }


### PR DESCRIPTION
## Why

`renovate.json` automerges five groups on green CI — Rust patch crates, Rust minors on crates already at 1.0, devbox packages, GitHub Actions, and the docs-site npm deps. Renovate merges them itself; #426 was merged by `renovate[bot]`, not a human.

**Renovate is a GitHub App, not a collaborator.** The `RepositoryRole: admin` bypass in `main-protected` does not cover it — apps are a separate `actor_type`.

At today's `REQUIRED_APPROVALS=0` that's harmless. The moment a second maintainer is onboarded and approvals goes to 1, **every automerge group stalls silently**: a bot cannot approve its own PR, and GitHub counts approvals only from write/admin accounts. Nothing errors, nothing is logged — the PRs just accumulate.

## What this does

Adds Renovate (app id 2740, from `gh api /apps/renovate --jq .id`) as an `Integration` bypass actor in **`pull_request` mode, not `always`** — it may merge a PR lacking the required approvals, but still cannot push directly to `main`. Strictly narrower than the admin bypass.

On by default: while approvals are 0 the entry is inert, so enabling it early costs nothing, and the alternative is remembering this at onboarding time, which is exactly when attention is elsewhere. `RENOVATE_BYPASS=false` opts out and reviews every bump by hand.

## Consequence, stated rather than glossed

With the bypass in place, CI gating on dependency PRs rests on **Renovate's own config** (it waits for branch status before merging), not on the ruleset. Step 6's `required_status_checks` will not change that, because a bypass actor bypasses those too. If that trade isn't wanted, `RENOVATE_BYPASS=false` is the lever.

`required_review_thread_resolution` is not a problem here in practice — Greptile posts no review and no inline comments on Renovate PRs (verified on #426, #389, #384). It would become one if that changed.

## Verification

| Case | Result |
|---|---|
| default (unset) | both actors: `RepositoryRole/5/always` + `Integration/2740/pull_request` |
| `RENOVATE_BYPASS=false` | admin actor only |
| `RENOVATE_APP_ID='2740; DROP'` | rejected — exit 1, **0 bytes** on stdout, nothing reaches the API |

Plus `bash -n` clean, `cargo fmt --check` clean (no Rust changed), payload parses as JSON in every branch.

Not applied to the live ruleset yet — that happens after merge, so the running config matches what's committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)