### PR TITLE
feat(orchestration): gate the command-entry lock behind the experimental flag (#393)

### DIFF
--- a/changelog.d/orchestration-command-entry-lock.feature.md
+++ b/changelog.d/orchestration-command-entry-lock.feature.md
@@ -1,4 +1,6 @@
-## Typing Into a Worker Pane Is Now a Decision, Not a Reflex
+## Typing Into a Worker Pane Can Now Be a Decision Rather Than a Reflex (Experimental)
+
+**This ships behind the `experimental` feature flag and is off by default.** Nothing about how you work today changes unless you turn it on: set `experimental = true` under a `[features]` table in your `.dot-agent-deck.toml`, or launch with `DOT_AGENT_DECK_EXPERIMENTAL=1`. It is gated precisely because it changes a reflex you already have — the default is deliberately restrictive, and that deserves real use before it reaches everyone. Everything below describes what you get once it is on.
 
 An orchestration is one workflow with a single coordinator, but every worker pane sits there with a cursor in it, inviting you to answer its question on the spot. Doing that puts a second, uncoordinated actor inside the workflow: you change state the orchestrator believes it owns, with no path for it to learn that you did. The deck does not look broken afterwards — it looks fine, and the model behind it has quietly diverged. Most often it is not even deliberate: you open a worker pane to check on it, get distracted, and type your next instruction into the pane in front of you instead of the one you meant.
 

--- a/docs/develop/experimental-flag.md
+++ b/docs/develop/experimental-flag.md
@@ -58,6 +58,9 @@ This lets work-in-progress code merge to `main` without exposing unfinished UI d
 |---|---|---|---|
 | `show_experimental_footer()` | The experimental dashboard footer | #139 | — |
 | `show_issue_dispatch_authoring()` | The new-pane `schedule: issues` modal authoring option (PRD #120 creation UX) | #120 | `graduate-issue-dispatch` |
+| `show_command_entry_lock()` | The orchestration command-entry lock: the `Ctrl+E` binding, the keystroke gate on a focused worker pane, and the waiting-pane focus steering | #393 | `graduate-command-entry-lock` |
+
+> **`show_command_entry_lock()` was added AFTER the feature merged (#404), not before it.** PRD #393 shipped un-gated and locked-by-default; the flag was added while it was still unreleased, so no version ever exposed it on. Three seams in `src/ui.rs` read the wrapper — the `Ctrl+E` binding resolution, the `PaneInput` keystroke gate, and the auto-focus chain. Note the third: the focus steering is part of the same surface rather than a separate feature, because it only ever ran while the lock was engaged, so gating it off is what makes flag-off behaviour identical to v0.35.8. The helpers themselves (`scope_command_entry_lock`, `gate_pane_input_key`) stay flag-free so their unit tests exercise the real logic rather than the gate; `UiState::command_entry_locked` also still starts `true`, since the flag decides whether that value is *consulted*, not what it is.
 
 ## Graduated
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -20,7 +20,7 @@ A mode tab's side panes scroll when the pointer is over them; anywhere else the 
 | `Ctrl+T` | Toggle stacked / tiled layout — stacked shows only the focused pane at full height, tiled shows every pane at once | Any mode |
 | `Ctrl+L` | Toggle the orchestration sidebar/pane-column split ratio between 34/66 and 25/75 (applies to every orchestration tab) | **Orchestration tabs, command mode only** |
 | `Ctrl+W` | Close the selected pane on the dashboard, or tear down the entire mode tab (agent + side panes) when used on a mode tab — after a confirmation dialog. The dashboard tab itself cannot be closed. | **Command mode only** |
-| `Ctrl+E` | Toggle the command-entry lock — whether you can type directly into a worker pane on an orchestration tab. See [`Ctrl+E` locks command entry to the orchestrator pane](#ctrle-locks-command-entry-to-the-orchestrator-pane). | **Command mode only, on an orchestration tab** |
+| `Ctrl+E` | **Experimental — off by default.** Toggle the command-entry lock — whether you can type directly into a worker pane on an orchestration tab. See [`Ctrl+E` locks command entry to the orchestrator pane](#ctrle-locks-command-entry-to-the-orchestrator-pane). | **Command mode only, on an orchestration tab**, and only while the `experimental` flag is on |
 
 ### Which mode you're in
 
@@ -40,7 +40,11 @@ The confirmation defaults to **Cancel**, so an accidental `Ctrl+W` followed by a
 
 ### `Ctrl+E` locks command entry to the orchestrator pane
 
-On an **orchestration tab**, typing into a worker pane is locked by default. Your keystrokes reach the orchestrator's pane exactly as before; aim them at a worker role and they are dropped rather than delivered, and the bottom bar says `Pane locked — Ctrl+d then Ctrl+e to unlock`. Press `Ctrl+D` to reach command mode, then `Ctrl+E`, and the deck reports `Pane entry: unlocked`; the same chord locks it again.
+> **Experimental — the whole of this section is off unless you turn it on.**
+>
+> The command-entry lock is gated behind the `experimental` feature flag while it is evaluated in real use. With the flag off — the default — `Ctrl+E` is not claimed anywhere, keystrokes reach a focused worker pane exactly as they always have, and the deck never moves focus on its own. To try it, set `experimental = true` under a `[features]` table in your `.dot-agent-deck.toml`, or launch with `DOT_AGENT_DECK_EXPERIMENTAL=1` (the environment variable wins over the file). Note that the focus steering described at the end of this section is part of the same gated surface — it only ever runs while the lock is engaged.
+
+With the flag on, on an **orchestration tab**, typing into a worker pane is locked by default. Your keystrokes reach the orchestrator's pane exactly as before; aim them at a worker role and they are dropped rather than delivered, and the bottom bar says `Pane locked — Ctrl+d then Ctrl+e to unlock`. Press `Ctrl+D` to reach command mode, then `Ctrl+E`, and the deck reports `Pane entry: unlocked`; the same chord locks it again. `Ctrl+E` leaves you in command mode, so press `Ctrl+D` once more to return to the pane and type.
 
 **This is not a read-only mode, and it does not apply anywhere else.** Dashboard and mode tabs are untouched, nothing is disabled, and every pane still shows live output and scrolls normally. On an orchestration tab the lock costs one deliberate `Ctrl+D`, `Ctrl+E` before you can type at a worker — and that pause is the point. An orchestration is one workflow with a single coordinator, and an open pane invites the reflex of answering a worker's question on the spot. Doing that puts a second, uncoordinated actor inside the workflow: you change state the orchestrator believes it owns, with no way for it to find out. Most often this is not even deliberate — you inspect a worker pane, get distracted, and type your next instruction into the wrong pane. The lock turns that reflex into a decision, and the default has to be locked for it to mean anything.
 
@@ -191,7 +195,7 @@ help = "F1"                      # open help with F1 instead of ?
 | `new_pane` | `Ctrl+n` | New pane (directory picker → name + command) — works from any mode |
 | `close_pane` | `Ctrl+w` | Close selected pane / tear down mode tab, with confirmation — **command mode only**; in a pane the chord is ordinary input for whatever is running there |
 | `toggle_layout` | `Ctrl+t` | Toggle stacked / tiled layout — works from any mode |
-| `toggle_orchestration_lock` | `Ctrl+e` | Toggle the orchestration command-entry lock — **command mode only, on an orchestration tab**; everywhere else the chord is ordinary input for whatever is running in the pane |
+| `toggle_orchestration_lock` | `Ctrl+e` | **Experimental — requires the `experimental` flag; without it the chord is never claimed.** Toggle the orchestration command-entry lock — **command mode only, on an orchestration tab**; everywhere else the chord is ordinary input for whatever is running in the pane |
 | `toggle_orchestration_split` | `Ctrl+l` | Toggle the orchestration sidebar/pane-column split between 34/66 and 25/75 — one press applies to every orchestration tab, including ones you open afterwards. **Orchestration tabs, command mode only**; in a pane, and on every other tab, the chord is ordinary input for whatever is running there |
 | `jump_1` … `jump_9` | `1` … `9` | Jump to card N and focus its pane |
 

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -93,7 +93,7 @@ These require command mode — press `Ctrl+d` first if you are typing in a role 
 | `Left` / `Right` (or `h` / `l`) | Cycle to previous / next tab |
 | `1`–`9` | Jump to role card N and focus its pane |
 | `Ctrl+w` | Close the orchestration tab (stops all role panes), after a confirmation |
-| `Ctrl+e` | Toggle the command-entry lock — whether you can type directly into a worker pane (see below) |
+| `Ctrl+e` | **Experimental, off by default** — toggle the command-entry lock, i.e. whether you can type directly into a worker pane (see below) |
 
 These work from anywhere, including while typing in a role pane:
 
@@ -107,13 +107,17 @@ The tab bar carries the same signal one level up: a **background** orchestration
 
 In the default `Stacked` pane layout, only the focused role's pane is drawn — switching roles swaps which pane is visible, but every other role's agent keeps running underneath, and the sidebar is what tells you it's still busy or idle. Toggle to `Tiled` (`Ctrl+t`) to see every role's pane at once.
 
-### Typing into a worker is locked by default
+### Typing into a worker is locked by default (experimental)
 
-You talk to the orchestrator; the orchestrator talks to the workers. On an orchestration tab the deck makes that the default rather than a convention you have to remember: keystrokes aimed at a worker role are dropped instead of delivered, and the bottom bar says `Pane locked — Ctrl+d then Ctrl+e to unlock`. The orchestrator's own pane is never locked, and Dashboard and mode tabs are not affected at all.
+> **Experimental — this section describes a surface that is off unless you turn it on.**
+>
+> The command-entry lock, and the focus steering that comes with it, are gated behind the `experimental` feature flag while the behaviour is evaluated in real use. With the flag off — the default — typing into a worker pane works exactly as it always has, `Ctrl+e` is not claimed, and the deck never moves focus on its own. To try it, set `experimental = true` under a `[features]` table in your `.dot-agent-deck.toml`, or launch with `DOT_AGENT_DECK_EXPERIMENTAL=1` (the environment variable wins over the file).
+
+You talk to the orchestrator; the orchestrator talks to the workers. With the flag on, an orchestration tab makes that the default rather than a convention you have to remember: keystrokes aimed at a worker role are dropped instead of delivered, and the bottom bar says `Pane locked — Ctrl+d then Ctrl+e to unlock`. The orchestrator's own pane is never locked, and Dashboard and mode tabs are not affected at all.
 
 The reason is that an orchestration is one workflow with a single coordinator. Type into a worker and you become a second, uncoordinated actor inside it: you change state the orchestrator believes it owns, and there is no path for it to learn that you did. What you usually get is not an obviously broken deck but a quietly diverged one — commonly the orchestrator and a worker contradicting each other into a deadlock. And most of the time it is not even deliberate: you open a worker pane to see how it is doing, get distracted, and type your next instruction into the pane that happens to be in front of you rather than the one you meant.
 
-**Nothing is read-only, and nothing is taken away.** When you do want to reach into a worker — a provider hiccup parked an agent, a weaker model never called `work-done`, an agent is waiting somewhere you did not expect — it costs one deliberate `Ctrl+d`, `Ctrl+e`. That pause is the whole feature: it converts a reflex into a decision. Unlocking reports `Pane entry: unlocked`; the same chord locks it again. The setting is one value for the whole deck, so unlocking on one orchestration tab unlocks all of them and a newly opened tab adopts the current value; it is not saved across restarts, so every deck starts locked.
+**Nothing is read-only, and nothing is taken away.** When you do want to reach into a worker — a provider hiccup parked an agent, a weaker model never called `work-done`, an agent is waiting somewhere you did not expect — it costs one deliberate `Ctrl+d`, `Ctrl+e`. That pause is the whole feature: it converts a reflex into a decision. Unlocking reports `Pane entry: unlocked` and leaves you in command mode, so press `Ctrl+d` once more to return to the pane and type; the same chord locks it again. The setting is one value for the whole deck, so unlocking on one orchestration tab unlocks all of them and a newly opened tab adopts the current value; it is not saved across restarts, so every deck starts locked.
 
 **A worker that has stopped and asked you something is never locked.** While a role pane reports `WaitingForInput` — an agent showing a permission prompt, a numbered option list, or a plain "what next?" — every key reaches it with no unlock at all, and the lock re-engages the instant that status clears. Answering a question the agent itself asked is a response to a request, not an intrusion into one. Two limits are worth knowing: an agent that never reports `WaitingForInput` gets no exemption and still needs the deliberate unlock, and a pane that is temporarily typeable for this reason looks no different from a locked one, so a stuck or mis-reported status leaves a pane open with no visual cue.
 

--- a/src/features.rs
+++ b/src/features.rs
@@ -98,6 +98,27 @@ pub fn show_issue_dispatch_authoring() -> bool {
     experimental_enabled()
 }
 
+/// Production wrapper for the orchestration command-entry lock (PRD #393),
+/// gated after it landed so it can be evaluated in real use before it reaches
+/// everyone. One wrapper per feature (CLAUDE.md #9) so
+/// `grep show_command_entry_lock` finds every gate at graduation — see the
+/// `graduate-command-entry-lock` issue.
+///
+/// A *presentation* switch, gated at three live-loop seams in `src/ui.rs`: the
+/// `Ctrl+E` binding resolution, the keystroke gate on a focused worker pane,
+/// and the auto-focus chain that steers toward waiting panes. Nothing else
+/// branches on it — `UiState::command_entry_locked` still starts `true` and the
+/// helpers (`scope_command_entry_lock`, `gate_pane_input_key`) are flag-free,
+/// so their unit tests keep exercising the real logic rather than the gate.
+///
+/// With the flag OFF the deck behaves exactly as v0.35.8 did: `Ctrl+E` is not
+/// claimed anywhere, keystrokes reach a focused worker pane untouched, and no
+/// automatic focus movement happens. Note that the focus steering is part of
+/// the gated surface, not a separate feature — it only ever ran while locked.
+pub fn show_command_entry_lock() -> bool {
+    experimental_enabled()
+}
+
 /// Guards [`init_and_watch`] so the periodic watcher thread is spawned at
 /// most once per process (reviewer #4 / audit INFO-3): a second call is a
 /// no-op rather than leaking a duplicate poll thread.

--- a/src/tab.rs
+++ b/src/tab.rs
@@ -2880,6 +2880,81 @@ mod tests {
         );
     }
 
+    /// Scenario: Turning the `experimental` flag OFF mid-session must clear the
+    /// waiting-episode latch, exactly as the `Ctrl+E` unlock does. The flag is
+    /// live-reloaded from `.dot-agent-deck.toml`, so it is a SECOND way to stop
+    /// observing — and the latch is edge-triggered, so freezing it while a pane
+    /// is waiting would replay a stale all-clear the next time the flag goes
+    /// on. Here a worker latches while the flag is on, the flag goes off, the
+    /// worker resolves unobserved, and the first frame back on must steal no
+    /// focus.
+    #[spec("orchestration/focus/009")]
+    #[test]
+    fn focus_009_flag_off_clears_latch_so_re_enabling_replays_no_stale_edge() {
+        use crate::state::SessionStatus;
+
+        let pc = Arc::new(MockPaneController::new());
+        let mut tm = TabManager::new(pc.clone());
+        let (_idx, roles) = tm
+            .open_orchestration_tab(&orch_config_3("orch"), "/work", None, None, (24, 80))
+            .expect("open orchestration tab");
+        let orchestrator = roles[0].clone();
+        let alpha = roles[1].clone();
+
+        // Mirrors the real per-frame call site AFTER the experimental gate: the
+        // flag's `false` arm CLEARS the latch rather than merely skipping
+        // observation, which is the whole point of this test.
+        fn frame(
+            tm: &mut TabManager,
+            status: &HashMap<&str, SessionStatus>,
+            flag_on: bool,
+            locked: bool,
+        ) -> Option<String> {
+            if !flag_on {
+                tm.clear_waiting_pane_latch();
+                return None;
+            }
+            if !locked {
+                return None;
+            }
+            tm.observe_waiting_panes(status);
+            tm.auto_focus_waiting_pane(status)
+                .or_else(|| tm.auto_focus_all_clear())
+        }
+
+        let mut status: HashMap<&str, SessionStatus> = HashMap::new();
+        status.insert(orchestrator.as_str(), SessionStatus::Idle);
+        status.insert(alpha.as_str(), SessionStatus::Idle);
+
+        // 1. Flag on and locked: `alpha` waits, latching the episode and
+        // stealing focus (`orchestration/focus/001`).
+        status.insert(alpha.as_str(), SessionStatus::WaitingForInput);
+        assert_eq!(
+            frame(&mut tm, &status, true, true).as_deref(),
+            Some(alpha.as_str())
+        );
+
+        // 2. The user edits `.dot-agent-deck.toml`; the watcher picks the flag
+        // up as OFF. One frame passes in that state.
+        assert_eq!(frame(&mut tm, &status, false, true), None);
+
+        // 3. While the surface is off, `alpha` resolves — unobserved.
+        status.insert(alpha.as_str(), SessionStatus::Idle);
+
+        // 4. The flag goes back on. Nothing new has happened from the deck's
+        // perspective, so there is no edge to fire. A latch left standing in
+        // step 2 would read here as a stale `true` -> `false` all-clear and
+        // yank focus to the orchestrator for an episode already dealt with.
+        assert_eq!(
+            frame(&mut tm, &status, true, true),
+            None,
+            "turning the experimental flag off must CLEAR the waiting-episode \
+             latch, not freeze it — otherwise re-enabling the flag replays an \
+             already-resolved episode as a fresh all-clear edge and steals \
+             focus to the orchestrator"
+        );
+    }
+
     /// Scenario: The waiting-focus branch must not steal focus while a
     /// keystroke is still queued for the pane that currently has it. Within a
     /// locked orchestration tab (roles `orchestrator` < `alpha` < `beta`),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10607,7 +10607,22 @@ pub fn run_tui(
         // deck would move focus on its own for a lock the user cannot see or
         // reach. Flag off therefore means no automatic focus movement at all,
         // which is exactly v0.35.8's behaviour.
-        if crate::features::show_command_entry_lock() && ui.command_entry_locked {
+        //
+        // Greptile PR #446: the flag is LIVE-RELOADED (`features::spawn_watcher`
+        // re-reads `.dot-agent-deck.toml` every ~2s), so unlike a compile-time
+        // gate it can flip mid-session — which makes it a second way to stop
+        // observing, alongside the `Ctrl+E` unlock. The latch this chain reads
+        // (`had_waiting_pane` / `all_clear_pending`) is EDGE-triggered, so
+        // stopping observation while it is set freezes it: a pane that resolves
+        // while the flag is off would be re-read on the next enable as a fresh
+        // all-clear edge and yank focus to the orchestrator for an episode the
+        // human already dealt with. The `Ctrl+E` handler compensates for its own
+        // half by calling `clear_waiting_pane_latch`; the flag needs the same
+        // compensation, done here rather than edge-tracked because holding no
+        // latch at all is the honest state while the surface does not exist.
+        if !crate::features::show_command_entry_lock() {
+            tab_manager.clear_waiting_pane_latch();
+        } else if ui.command_entry_locked {
             let pane_status_for_focus: HashMap<&str, SessionStatus> = build_pane_status(&snapshot);
             // The observation runs FIRST and outside the chain, because it must
             // happen on every locked frame no matter which branch below wins.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10620,7 +10620,21 @@ pub fn run_tui(
         // half by calling `clear_waiting_pane_latch`; the flag needs the same
         // compensation, done here rather than edge-tracked because holding no
         // latch at all is the honest state while the surface does not exist.
-        if !crate::features::show_command_entry_lock() {
+        // Read ONCE per frame into a local. The `else if` below tests
+        // `ui.command_entry_locked` — a `UiState` bool, not the flag — so this
+        // is already a single read and the local changes no behaviour; it is
+        // here to keep that property obvious, so a later edit cannot introduce
+        // a second read that disagrees with this one mid-frame.
+        //
+        // Note also why a torn read could not persist even if one occurred: the
+        // clear below is LEVEL-triggered, running on every frame the flag is
+        // off, not edge-triggered on the transition. So a frame that somehow
+        // observed the wrong value self-corrects on the next one (~16ms) —
+        // orders of magnitude faster than a human can resolve a waiting pane.
+        // That is the reason this compensates unconditionally rather than
+        // tracking the on->off edge.
+        let command_entry_lock_enabled = crate::features::show_command_entry_lock();
+        if !command_entry_lock_enabled {
             tab_manager.clear_waiting_pane_latch();
         } else if ui.command_entry_locked {
             let pane_status_for_focus: HashMap<&str, SessionStatus> = build_pane_status(&snapshot);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -9096,7 +9096,18 @@ fn handle_key_event(
         // typing at. Un-resolving it lets the key fall through to the normal
         // `PaneInput` forwarding path (`0x05`) instead.
         let is_orchestration_tab = matches!(tab_manager.active_tab(), Tab::Orchestration { .. });
-        action = scope_command_entry_lock(action, is_orchestration_tab, ui.mode);
+        // PRD #393 experimental gate (CLAUDE.md #9). Passing `false` for the
+        // tab term when the flag is off makes `scope_command_entry_lock`
+        // un-resolve `Ctrl+E` everywhere, exactly as it already does off an
+        // Orchestration tab — so the key falls through to the PTY and the lock
+        // has no binding at all. Expressed through the existing tab term rather
+        // than a second branch so there is only one place that decides whether
+        // the chord is claimed.
+        action = scope_command_entry_lock(
+            action,
+            is_orchestration_tab && crate::features::show_command_entry_lock(),
+            ui.mode,
+        );
         // PRD #336: the split toggle resolves only on an orchestration tab, in
         // command mode. This is the first point in the funnel with tab context,
         // so narrow it here — otherwise `Ctrl+l` is claimed everywhere and
@@ -9185,13 +9196,22 @@ fn handle_key_event(
                 // the plain `build_pane_status` the pane borders read: it omits
                 // any `pane_id` claimed by more than one session, so an
                 // ambiguous pane can never earn the carve-out.
-                let gated = gate_pane_input_key(
-                    candidate.clone(),
-                    ui,
-                    tab_manager,
-                    pane,
-                    &build_pane_status_for_gate(snapshot),
-                );
+                //
+                // PRD #393 experimental gate (CLAUDE.md #9): with the flag off
+                // the keystroke is forwarded untouched, which also skips
+                // building the status join above — the lock is the only reader
+                // of it, so there is nothing to compute when it cannot act.
+                let gated = if crate::features::show_command_entry_lock() {
+                    gate_pane_input_key(
+                        candidate.clone(),
+                        ui,
+                        tab_manager,
+                        pane,
+                        &build_pane_status_for_gate(snapshot),
+                    )
+                } else {
+                    candidate.clone()
+                };
                 if matches!(candidate, Action::ForwardToPane(_))
                     && matches!(gated, Action::Continue)
                 {
@@ -10580,7 +10600,14 @@ pub fn run_tui(
         // handler calls `clear_waiting_pane_latch` on the locked→unlocked half
         // to compensate (see that method's doc comment for the straddling trace
         // this protects).
-        if ui.command_entry_locked {
+        //
+        // PRD #393 experimental gate (CLAUDE.md #9). The steering is part of the
+        // gated surface rather than a separate feature: it only ever ran while
+        // locked, so with the flag off it must not run either — otherwise the
+        // deck would move focus on its own for a lock the user cannot see or
+        // reach. Flag off therefore means no automatic focus movement at all,
+        // which is exactly v0.35.8's behaviour.
+        if crate::features::show_command_entry_lock() && ui.command_entry_locked {
             let pane_status_for_focus: HashMap<&str, SessionStatus> = build_pane_status(&snapshot);
             // The observation runs FIRST and outside the chain, because it must
             // happen on every locked frame no matter which branch below wins.

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -2195,6 +2195,13 @@ without depending on the config struct API.
 - **Does not assert:** anything when skipped — where credentials are absent this test executes nothing, so `orchestration/lock/008`/`011` carry the CI-visible coverage.
 - **Platform coverage:** mac+linux (real-agent tier is local-only).
 
+##### orchestration/lock/014 — With the `experimental` flag OFF (the default), the command-entry lock surface is absent entirely.
+- **Layer:** L2 (PTY end-to-end).
+- **Agent:** none (`orch-deck` fixture, two stub `cat` roles). Deliberately launched WITHOUT `DOT_AGENT_DECK_EXPERIMENTAL`, unlike every other test in the file.
+- **Asserts:** on a real orchestration tab a keystroke typed at the focused non-orchestrator worker reaches its PTY with no unlock chord at all; the `Pane locked` message never appears; and `Ctrl+e` sent in command mode is not claimed, so no `Pane entry:` report is produced. This is the other side of the PRD #393 gate — a regression that shipped the lock unconditionally fails here rather than reaching every user silently.
+- **Does not assert:** the locked behaviour itself (`orchestration/lock/008`); that the focus steering is gated too (no automatic focus movement is asserted here).
+- **Platform coverage:** mac+linux.
+
 #### orchestration/focus
 
 ##### orchestration/focus/001 — Auto-focus follows the lowest-order `WaitingForInput` role pane on the active tab, and never touches another tab.

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -2260,6 +2260,13 @@ without depending on the config struct API.
 - **Does not assert:** the real `src/ui.rs` per-frame call site actually computing `input_pending` from `crossterm::event::poll` or applying the result via `pane.focus_pane` (out of L1 `TabManager` reach — it would need a PTY-attached L2 test, and an L2 test was evaluated and rejected: the underlying terminal race is not economically reproducible there, since it requires a keystroke to be sitting in the terminal's input queue on the exact frame a lower-order pane transitions to `WaitingForInput`); the deck-global lock gate itself (`ui.command_entry_locked`, covered by `orchestration/focus/005`/`006`); the multi-waiter ordering contract, covered exhaustively by `orchestration/focus/001`/`004`.
 - **Platform coverage:** mac+linux+windows.
 
+##### orchestration/focus/009 — Turning the `experimental` flag OFF mid-session clears the waiting-episode latch, so re-enabling it replays no stale all-clear edge.
+- **Layer:** L1 (in-process unit test; `src/tab.rs`, alongside `orchestration/focus/001`-`006`/`008`).
+- **Agent:** none (mock `PaneController`; synthetic `SessionStatus` map, no panes/PTYs).
+- **Asserts:** with the flag on and the deck locked, `alpha` goes `WaitingForInput`, latching the episode and stealing focus; the flag then flips OFF (the watcher re-reads `.dot-agent-deck.toml` roughly every 2s, so this is reachable without a restart) and `alpha` resolves unobserved; on the first frame after the flag returns, no focus move may be produced. A latch left standing while the flag was off would read there as a stale `true` -> `false` all-clear and yank focus to the orchestrator for an episode already dealt with. Mirrors `orchestration/focus/006`, which pins the same contract for the `Ctrl+E` unlock — the flag is simply a second way to stop observing.
+- **Does not assert:** the real `src/ui.rs` per-frame call site (out of L1 `TabManager` reach, as `orchestration/focus/008` records); the gating of the keystroke path or the `Ctrl+E` binding (`orchestration/lock/014`).
+- **Platform coverage:** mac+linux+windows.
+
 #### orchestration/layout
 
 ##### orchestration/layout/001 — Seven decks fit the single-column orchestration card area without scrolling (PRD #147).

--- a/tests/e2e_orchestration_lock.rs
+++ b/tests/e2e_orchestration_lock.rs
@@ -1,7 +1,16 @@
 #![cfg(feature = "e2e")]
 
 //! L2 end-to-end coverage for the command-entry lock on Orchestration tabs.
-//! By default, a keystroke typed while a non-orchestrator role pane is focused
+//!
+//! **Every deck here launches with `DOT_AGENT_DECK_EXPERIMENTAL=1`.** The lock
+//! is gated behind the experimental flag (`features::show_command_entry_lock`,
+//! CLAUDE.md #9) while it is evaluated in real use, so without the env var
+//! these decks would observe the un-gated pre-lock behaviour and every
+//! assertion below would be testing the wrong thing. `orchestration/lock/014`
+//! is the deliberate exception — it launches WITHOUT the flag and pins that
+//! flag-off behaviour, so the gate stays covered from both sides.
+//!
+//! With the flag on: a keystroke typed while a non-orchestrator role pane is focused
 //! must not reach that pane's PTY; the orchestrator pane's own input is never
 //! gated; `Ctrl+d` then `Ctrl+e` toggles the lock; a pane reporting
 //! `WaitingForInput` is not gated at all; and the always-available
@@ -67,6 +76,7 @@ fn lock_008_forwarding_gated_by_lock_state() {
     const WORKER_UNLOCKED_SENTINEL: &str = "LOCK008_WORKER_UNLOCKED_c83e";
 
     let deck = TuiDeck::builder()
+        .with_env("DOT_AGENT_DECK_EXPERIMENTAL", "1")
         .with_pty_size(120, 40)
         .launch_with_fixture("orch-deck");
     deck.wait_for_string("No active sessions");
@@ -125,6 +135,7 @@ fn lock_009_ctrl_e_scoped_to_command_mode_on_real_panes() {
     const WORKER_UNLOCKED_SENTINEL: &str = "LOCK009_WORKER_UNLOCKED_7be2";
 
     let deck = TuiDeck::builder()
+        .with_env("DOT_AGENT_DECK_EXPERIMENTAL", "1")
         .with_pty_size(120, 40)
         .launch_with_fixture("orch-deck");
     deck.wait_for_string("No active sessions");
@@ -221,6 +232,7 @@ fn lock_009_ctrl_e_scoped_to_command_mode_on_real_panes() {
 #[test]
 fn lock_010_global_chord_unaffected_by_lock_state() {
     let deck = TuiDeck::builder()
+        .with_env("DOT_AGENT_DECK_EXPERIMENTAL", "1")
         .with_pty_size(120, 40)
         .launch_with_fixture("orch-deck");
     deck.wait_for_string("No active sessions");
@@ -359,6 +371,7 @@ fn lock_011_waiting_carve_out_on_real_panes() {
     const WORKER_RELOCKED_SENTINEL: &str = "LOCK011_RELOCKED_e814";
 
     let deck = TuiDeck::builder()
+        .with_env("DOT_AGENT_DECK_EXPERIMENTAL", "1")
         .with_pty_size(120, 40)
         .launch_with_fixture("orch-deck");
     deck.wait_for_string("No active sessions");
@@ -487,6 +500,7 @@ fn lock_012_real_agent_gated_by_lock_state() {
     skip_unless!(common::check_claude_available());
 
     let deck = TuiDeck::builder()
+        .with_env("DOT_AGENT_DECK_EXPERIMENTAL", "1")
         .with_pty_size(120, 40)
         .with_imported_claude_credentials()
         // The worker's cwd is the deck's own workdir (the copied
@@ -558,5 +572,56 @@ fn lock_012_real_agent_gated_by_lock_state() {
         "the locked-state directive's sentinel {LIVE_LOCKED_SENTINEL} appeared \
          after unlocking — the lock must drop gated keystrokes outright, not \
          queue them for delivery once unlocked"
+    );
+}
+
+/// Scenario: With the `experimental` flag OFF — the default — the whole
+/// command-entry lock surface is absent. On a real Orchestration tab
+/// (`orch-deck` fixture, two `cat` stub roles), focus the non-orchestrator
+/// worker and type: the keystrokes must reach its PTY immediately, with no
+/// unlock and no `Pane locked` message. Then send `Ctrl+e` in command mode and
+/// confirm the deck does not claim it — no `Pane entry:` report appears.
+#[spec("orchestration/lock/014")]
+#[test]
+fn lock_014_flag_off_leaves_worker_input_ungated() {
+    const WORKER_SENTINEL: &str = "LOCK014_WORKER_UNGATED_5b7d";
+
+    // Deliberately NO `.with_env("DOT_AGENT_DECK_EXPERIMENTAL", …)`: this test
+    // exists to pin what a DEFAULT install sees while PRD #393 is gated. Every
+    // other test in this file opts the flag ON; this is the other side of that
+    // gate, so a regression that shipped the lock unconditionally fails here
+    // rather than silently reaching every user.
+    let deck = TuiDeck::builder()
+        .with_pty_size(120, 40)
+        .launch_with_fixture("orch-deck");
+    deck.wait_for_string("No active sessions");
+
+    open_orchestration(&deck);
+    deck.wait_for_absence("New Agent");
+
+    focus_worker_role(&deck);
+
+    // The keystroke must reach the worker's PTY with no unlock chord at all.
+    deck.send_keys(format!("{WORKER_SENTINEL}\r").as_bytes());
+    deck.wait_for_string(WORKER_SENTINEL);
+
+    // And the lock's own status message must never have appeared.
+    assert!(
+        !deck.snapshot_grid().contains("Pane locked"),
+        "the deck reported the command-entry lock while the experimental flag \
+         was off — the surface must be entirely absent by default.\nGrid:\n{}",
+        deck.snapshot_grid()
+    );
+
+    // Ctrl+e must not be claimed either: in command mode it should toggle
+    // nothing, so no `Pane entry:` report can appear.
+    deck.send_bytes(b"\x04"); // Ctrl+d -> command mode
+    deck.send_bytes(b"\x05"); // Ctrl+e -> not claimed while the flag is off
+    let claimed = deck.wait_for_grid_string_within("Pane entry:", Duration::from_secs(2));
+    assert!(
+        !claimed,
+        "Ctrl+e toggled the command-entry lock while the experimental flag was \
+         off — the binding must not be claimed at all.\nGrid:\n{}",
+        deck.snapshot_grid()
     );
 }


### PR DESCRIPTION
Gates PRD #393's command-entry lock behind the `experimental` flag so it can be evaluated in real use before it reaches everyone. Graduation tracked in #445.

## Why

The lock shipped un-gated and **locked by default** in #404, and CLAUDE.md rule 9's experimental-flag question — which explicitly covers a new keybinding — was never put. It is a sharp default: it changes a reflex users already have, silently drops keystrokes until a chord is learned, and the unlock is not persisted, so the cost is re-paid every session.

**Nothing that has shipped changes.** The lock is not in v0.35.8, so no released version ever exposed it and no user is disrupted.

## What is gated

One wrapper, `features::show_command_entry_lock()`, read at three live-loop seams in `src/ui.rs`:

1. **the `Ctrl+E` binding resolution** — expressed through the existing orchestration-tab term, so one place decides whether the chord is claimed at all
2. **the `PaneInput` keystroke gate** — with the flag off this also skips building the status join, since the lock is its only reader
3. **the auto-focus chain** that steers toward waiting panes

The third seam is the one worth naming. The focus steering is part of the same surface rather than a separate feature, because it only ever ran while the lock was engaged. Gating it too is what makes flag-off behaviour identical to v0.35.8, rather than "no lock, but the deck still moves focus on its own for a lock you cannot see or reach".

## What is deliberately NOT gated

`UiState::command_entry_locked` still starts `true`, and `scope_command_entry_lock` / `gate_pane_input_key` stay flag-free. The flag decides whether that state is **consulted**, not what it is — which keeps this a presentation switch per rule 9 / PRD #139 M3.2, and lets the helpers' unit tests keep exercising the real logic rather than the gate.

## Docs

Both published pages presented the lock as default behaviour, which the gate makes wrong. `docs/keyboard-shortcuts.md` and `docs/orchestration.md` now carry the house-style experimental admonition (matching `docs/scheduled-tasks.md`) and say how to enable it; `docs/develop/experimental-flag.md` lists the new wrapper.

Both pages also now state that unlocking leaves you in command mode, so returning to the pane takes a third keypress — `Ctrl+d`, `Ctrl+e`, `Ctrl+d`. The docs previously described a two-chord flow that stops one key short of actually typing. The status **message** is untouched; that fix is recorded in #445 rather than changing a contributor's copy on a feature that has not been evaluated yet.

## Tests

All five existing L2 lock tests opt the flag ON via `.with_env("DOT_AGENT_DECK_EXPERIMENTAL", "1")` — without it they would assert against un-gated behaviour and quietly test the wrong thing.

New **`orchestration/lock/014`** launches *without* the flag and pins the default: a keystroke reaches the focused worker with no unlock chord, no `Pane locked` message appears, and `Ctrl+e` is not claimed. So the gate is covered from both sides and a regression that ships the lock unconditionally fails here rather than reaching every user silently.

Verified load-bearing: forcing the wrapper to `true` fails `lock/014` (and it passes again on restore).

## Gates

`cargo fmt --check` · `cargo clippy --workspace --all-targets --features e2e -- -D warnings` · `cargo test-fast` (1601 passed, 0 skipped) · `cargo xtask linkage-check` (479 catalog ids) — all clean.

`cargo test-e2e lock_008 lock_009 lock_010 lock_011 lock_012 lock_014` — **6 passed**, including `lock_012` against a real Claude Haiku worker (not skipped; credentials present).

## Cross-version note (rule 12)

No `PROTOCOL_VERSION` bump. This touches no daemon behaviour, protocol, or hook handling — it is a TUI-side presentation gate only.