### PR TITLE
fix(verify-pr): count indented SKIP lines, so vacuous e2e greens stop reading as verified

### DIFF
--- a/.claude/skills/verify-pr/checks.sh
+++ b/.claude/skills/verify-pr/checks.sh
@@ -244,12 +244,21 @@ else
     # `|| true`, not `|| echo 0`: grep -c already PRINTS "0" when it matches
     # nothing and only then exits 1, so `|| echo 0` produces "0\n0" and the
     # numeric test below dies with "integer expression expected".
-    skips=$(grep -c '^SKIP: ' "$e2e_log" 2>/dev/null || true)
+    #
+    # `^[[:space:]]*`, not `^`: `--success-output=final` INDENTS captured test
+    # output by four spaces, so a column-0 anchor never matches and this whole
+    # safeguard silently reports zero (issues #452, #490 — measured on real
+    # logs from verifying #391 and #467, where four genuine skips counted 0).
+    skips=$(grep -cE '^[[:space:]]*SKIP: ' "$e2e_log" 2>/dev/null || true)
     [[ "$skips" =~ ^[0-9]+$ ]] || skips=0
     printf 'E2E_RUNTIME_SKIPS=%s\n' "$skips" >>"${out}/env.txt"
     printf 'E2E_RUNTIME_SKIPS=%s\n' "$skips"
     if [ "$skips" -gt 0 ]; then
-      grep '^SKIP: ' "$e2e_log" | sort -u >"${out}/e2e-skips.txt"
+      # Strip the indent BEFORE `sort -u`, so the file reads cleanly and two
+      # identical reasons captured at different depths dedupe to one line.
+      grep -E '^[[:space:]]*SKIP: ' "$e2e_log" \
+        | sed -E 's/^[[:space:]]+//' \
+        | sort -u >"${out}/e2e-skips.txt"
       record e2e-real-coverage ATTENTION 0 "${out}/e2e-skips.txt" \
         "${skips} real-agent test(s) skipped and still counted as PASSED. If any covers this PR's surface, rerun it with DOT_AGENT_DECK_REQUIRE_REAL_E2E=1 and treat 'cannot run' as UNVERIFIED, not green."
     fi


### PR DESCRIPTION
## What this fixes

`.claude/skills/verify-pr/checks.sh` detects real-agent e2e tests that skipped at runtime. Those tests print `SKIP: <reason>` and **return normally**, so nextest counts them as PASSED — a green e2e run that proved nothing. The `e2e-real-coverage ATTENTION` row exists to surface exactly that, and the skill's hard rule 4 is "Never present a skipped check as a passed one."

The detection was anchored at column 0 (`grep -c '^SKIP: '`), but `--success-output=final` — the flag `checks.sh` itself passes, two lines above, specifically to make these skips visible — **indents captured test output by four spaces**. So the anchor never matched and the safeguard silently reported zero, every single run.

**This has been silently degrading every verification run in this repo, including several today, by reporting skipped real-agent tests as passed.** That is why this matters: the mechanism meant to stop a vacuous green from being presented as verification has never once fired. Both issues caught it while the run they were *themselves* verifying was under-reporting (#452 during #391, #490 during #467), each measuring four genuine skips counted as zero.

Closes #452. Closes #490. **These two issues are independent duplicates of each other** — filed separately, same root cause, same remedy, and their measurements corroborate each other.

## The fix

Three lines in one block:

- `grep -c '^SKIP: '` → `grep -cE '^[[:space:]]*SKIP: '` (the count)
- `grep '^SKIP: '` → `grep -E '^[[:space:]]*SKIP: '` (the listing)
- `| sed -E 's/^[[:space:]]+//'` before `sort -u`, so `e2e-skips.txt` reads cleanly

The `|| true` guard and the comment explaining why it is not `|| echo 0` are **preserved verbatim**, per #490's note that the guard is correct and only the pattern is wrong. I verified the guard is still load-bearing rather than assuming it (see Control 1) — with `grep -cE`, `|| echo 0` still yields `"0\n0"` and would still break the numeric test.

Stripping the indent *before* `sort -u` also fixes a latent dedup bug: two identical reasons captured at different depths would otherwise not collapse.

## Proof it works

No real e2e log was available and all four agent CLIs are present on this machine (so no CLI-absence skip occurs naturally), and I did not want the evidence to depend on credential state or cost LLM money. So I measured nextest's indentation **from nextest itself** with a zero-dependency fixture project whose test mirrors `tests/common/mod.rs:2734` exactly — `eprintln!("SKIP: {reason}")`, then returns normally — run under the exact flag `checks.sh` uses.

nextest's own verdict, reproducing the whole problem in one line:

```
Summary [0.004s] 3 tests run: 3 passed, 0 skipped
```

Three passed, zero skipped — while two of the three had in fact skipped. `cat -A` on the captured log shows the four literal spaces, under a `stderr` section (consistent with `eprintln!`):

```
        PASS [   0.003s] (2/3) skipfix::e2e_fixture codex_delegate_001_skips
  stderr ───
    SKIP: Codex could not reach model gpt-5.1-codex-mini with the current authentication$
```

Old pattern vs new, on that real log:

```
$ grep -c  '^SKIP: '              e2e.log   # what checks.sh used
0
$ grep -cE '^[[:space:]]*SKIP: '  e2e.log   # what it uses now
2
```

That independently reproduces both issues' measurement. I then executed **the patched block extracted verbatim from `checks.sh` by line range** (not a retyped copy) against that log:

| | before | after |
|---|---|---|
| `E2E_RUNTIME_SKIPS` | `0` | `2` |
| `e2e-real-coverage` row | never appeared | `ATTENTION` fires |
| `e2e-skips.txt` | never written | written, indent stripped, deduped |

### Controls

Each change reverted one at a time, to confirm it is load-bearing rather than incidental:

- **Revert the pattern, keep the strip** → `E2E_RUNTIME_SKIPS=0`, no row. Red again; the pattern change is load-bearing.
- **Keep the pattern, drop the strip** → count correct but the four-space indent survives into `e2e-skips.txt`. The strip is load-bearing.
- **Control 1 — the `|| true` guard.** `grep -cE` on a no-match file prints `0` and exits 1, so `|| echo 0` still produces two lines. Guard correctly preserved.
- **Control 2 — zero-skip path must not regress.** A clean log yields `E2E_RUNTIME_SKIPS=0`, no ATTENTION row, no `integer expression expected`.
- **Control 3 — no false positives.** Given a log with tab-, four-space-, and eight-space-indented `SKIP:` lines plus the decoy `this line mentions SKIP: but not at the start`, the count is **3** — every real indent depth matched, the mid-line decoy correctly ignored.

Control 3 also shows the new pattern is a **strict superset** of the old: an unindented `SKIP:` still matches, so nothing that previously counted stops counting.

## Audit for the same mistake elsewhere

I checked every text-extraction call in `checks.sh`, `scan.sh` and `setup.sh` for the same class of defect — a column-0 anchor applied to nextest-captured output. **Only these two sites had it.** Two other anchors exist and both are correct, verified rather than assumed:

- `setup.sh:180` — `grep -q "^branch refs/heads/…"` reads `git worktree list --porcelain`, confirmed column-0 via `cat -A`.
- `scan.sh:165` — `sed -n 's/^PR_HEAD_SHA=//p'` reads scan.sh's own generated `KEY=value` text, column-0 by construction.

## Regression guard: considered, proposing as follow-up

`checks.sh` has no test harness and the repo has **no shell test tooling at all** (no bats, shunit2, or shellcheck anywhere in the build, devbox, or CI config), so I did not add one. Specifically:

- **shellcheck would not catch this.** The old pattern is perfectly valid shell; the defect is semantic — a correct regex applied to data shaped differently than assumed. Ruled out on effectiveness, not cost.
- **bats/shunit2 would** catch it, but means a new dev dependency plus devbox and CI wiring for a two-line fix, in a repo with zero shell tests.
- **A `cargo xtask linkage-check` rule** is the closest existing fit, since linkage-check already makes textual assertions over source files — but its remit is `tests/`↔CATALOG linkage and test-file hygiene, so asserting a grep pattern inside a `.claude/skills` script would open a new rule category. Worth doing deliberately, not smuggled into a bug fix.

What did land is the cheapest guard that fits today: a comment naming the failure mode, the flag that causes it, and both issue numbers, directly above the pattern — so the next person tempted to re-tighten the anchor reads why it is loose. The fixture is four commands and reproducible from the PR description.

## Noted for a follow-up issue, deliberately not fixed here

**The safeguard's own operation is unobservable.** `e2e-real-coverage` is recorded *only* when `skips > 0`, so "check ran, found zero skips" and "check is broken and found nothing" produce byte-identical output: no row. That is precisely why this bug survived so long — its failure mode is indistinguishable from its success. Recording an affirmative OK row when `skips == 0` would make it self-evidencing. That is a behaviour change beyond this fix, so I left it out.

## Gates

- `cargo fmt --check` — pass (clean)
- `cargo clippy --workspace --all-targets --features e2e -- -D warnings` — pass, exit 0 (all three flags per rule 2)
- `cargo test-fast` — pass, `1673 tests run: 1673 passed, 0 skipped`
- `bash -n .claude/skills/verify-pr/checks.sh` — valid; exec bit preserved

`cargo test-e2e` was not run: this change touches no Rust and cannot affect it. Rule 12's cross-version contract check does not apply either — no daemon, protocol, orchestration, or hook code is touched.

**No changelog fragment**, matching this repo's established convention: none of the five prior commits touching `.claude/skills/verify-pr/` added one, including `8341a6f` and `5c70454`, which changed *this very file* for the same kind of reason (fixing what the verification gate actually checks). Changelog fragments feed user-facing release notes; this is contributor-only tooling that ships in no release artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
