### PR TITLE
fix(verify-pr): match indented SKIP lines in the vacuous-skip detector

### DIFF
--- a/.claude/skills/verify-pr/checks.sh
+++ b/.claude/skills/verify-pr/checks.sh
@@ -241,15 +241,31 @@ else
 
   e2e_log="${logs}/e2e.log"
   if [ -f "$e2e_log" ]; then
+    # The leading `[[:space:]]*` is load-bearing, NOT defensive padding:
+    # nextest INDENTS captured test output by four spaces under
+    # `--success-output=final`, so a `^SKIP: ` anchored at column 0 matches
+    # nothing and this detector silently reports 0 on a run that really did
+    # skip. That is exactly what happened while verifying #391 and #467 —
+    # four real-agent tests skipped ("Codex could not reach model
+    # gpt-5.1-codex-mini …"), were counted as PASSED, and the ATTENTION row
+    # below never appeared (issues #452, #490). The same pattern appears at
+    # both match sites; keep them in sync, or the row's count will describe a
+    # different set of lines than the file it points at.
+    #
     # `|| true`, not `|| echo 0`: grep -c already PRINTS "0" when it matches
     # nothing and only then exits 1, so `|| echo 0` produces "0\n0" and the
     # numeric test below dies with "integer expression expected".
-    skips=$(grep -c '^SKIP: ' "$e2e_log" 2>/dev/null || true)
+    skips=$(grep -cE '^[[:space:]]*SKIP: ' "$e2e_log" 2>/dev/null || true)
     [[ "$skips" =~ ^[0-9]+$ ]] || skips=0
     printf 'E2E_RUNTIME_SKIPS=%s\n' "$skips" >>"${out}/env.txt"
     printf 'E2E_RUNTIME_SKIPS=%s\n' "$skips"
     if [ "$skips" -gt 0 ]; then
-      grep '^SKIP: ' "$e2e_log" | sort -u >"${out}/e2e-skips.txt"
+      # `sed` strips nextest's indent so the file reads as bare `SKIP: …`
+      # lines; it runs before `sort -u` so reasons that differ only by
+      # indentation still collapse to one entry. Note `sort -u` dedupes: N
+      # tests failing the same precondition report as N in the row above but
+      # one line here, which is the intended reading (occurrences vs reasons).
+      grep -E '^[[:space:]]*SKIP: ' "$e2e_log" | sed 's/^[[:space:]]*//' | sort -u >"${out}/e2e-skips.txt"
       record e2e-real-coverage ATTENTION 0 "${out}/e2e-skips.txt" \
         "${skips} real-agent test(s) skipped and still counted as PASSED. If any covers this PR's surface, rerun it with DOT_AGENT_DECK_REQUIRE_REAL_E2E=1 and treat 'cannot run' as UNVERIFIED, not green."
     fi

--- a/changelog.d/490.misc.md
+++ b/changelog.d/490.misc.md
@@ -1,0 +1,7 @@
+## `/verify-pr` Detects Vacuous E2E Runs Again
+
+The `/verify-pr` reviewer skill flags e2e runs where a real-agent test skipped at runtime instead of executing. Those tests print `SKIP: <reason>` and return normally, so nextest counts them as **passed** — a fully green e2e tier that proved nothing about the surface under review.
+
+That safeguard had been silently inert. The detector in `checks.sh` matched `SKIP:` anchored at column 0, but nextest indents captured test output by four spaces under `--success-output=final`, so the pattern never matched. Every review recorded `E2E_RUNTIME_SKIPS=0`, never wrote `e2e-skips.txt`, and never emitted the `e2e-real-coverage` **ATTENTION** row — including two reviews that each had four genuinely skipped real-agent tests to report.
+
+Both match sites now allow leading whitespace, and the indent is stripped when writing `e2e-skips.txt` so the file reads as plain `SKIP: <reason>` lines. Reviewers once again see which real-agent tests declined to run, and can rerun them with `DOT_AGENT_DECK_REQUIRE_REAL_E2E=1` to turn a skip into a hard failure.


### PR DESCRIPTION
## Problem

`.claude/skills/verify-pr/checks.sh` counts real-agent e2e tests that skipped at runtime, so a reviewer is told when a "green" e2e tier actually proved nothing. Those tests print `SKIP: <reason>` and **return normally**, so nextest counts them as **PASSED** — which is exactly what the skill's hard rule 4 ("never present a skipped check as a passed one") exists to catch.

The detector never fired. Both match sites anchored the pattern at column 0:

```sh
skips=$(grep -c '^SKIP: ' "$e2e_log" 2>/dev/null || true)
grep '^SKIP: ' "$e2e_log" | sort -u >"${out}/e2e-skips.txt"
```

…but nextest indents captured test output by four spaces under `--success-output=final`, so `^SKIP: ` matched nothing. Every review recorded `E2E_RUNTIME_SKIPS=0`, never wrote `e2e-skips.txt`, and never emitted the `e2e-real-coverage` **ATTENTION** row — including the runs verifying #391 and #467, which each had four genuinely skipped real-agent tests to report (*"Codex could not reach model gpt-5.1-codex-mini with the current authentication"*).

## Fix

Both patterns become `^[[:space:]]*SKIP: `, and a `sed 's/^[[:space:]]*//'` runs before `sort -u` so `e2e-skips.txt` reads as bare `SKIP: <reason>` lines. The adjacent `|| true` guard is deliberately **untouched** — as #490 notes, it is correct: `grep -c` already prints `0` on no match, so `|| echo 0` would produce `"0\n0"` and break the numeric test below it.

## How this was proved, not assumed

Built a probe crate whose tests print `SKIP: …` (one via stderr, one via stdout) and captured `cargo nextest run --success-output=final` **to a file**, exactly as `checks.sh` does. nextest 0.9.140 indents by four spaces — confirmed via `cat -A`, with no ANSI escapes since the sink is a file, not a TTY.

The detector block was then extracted **from the shipped script by pattern** (not copied into a test double) and run against that log, so what ran is the text that ships:

| | `E2E_RUNTIME_SKIPS` | `e2e-skips.txt` | ATTENTION row |
|---|---|---|---|
| before | `0` | not written | absent |
| after | `2` | written, un-indented | present in `summary.tsv` |

A control log containing no skips still yields `0`, no file, and no row — so this does not trade a false negative for a false positive.

## Sweep for the same bug elsewhere

- `checks.sh` — no other log-content parsing. Its other anchored reads are `head -1` on `--version` output, which is genuinely unindented.
- `scan.sh` — parses no command logs.
- `setup.sh:180` — its `grep -q "^branch refs/heads/…"` is against `git worktree list --porcelain`, which really is column-0. Correct as written.

Also confirmed `SKIP: ` is the only runtime-skip marker worth matching: it has a single emission site, `eprintln!("SKIP: {reason}")` in `_skip_if_err` (`tests/common/mod.rs:2543`), reached only via the `skip_unless!` macro. The pattern was right; only the anchor was wrong.

## Gates

- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets --features e2e -- -D warnings` — pass
- `cargo test-fast` — 1657 tests run, 1657 passed, 0 skipped
- `bash -n .claude/skills/verify-pr/checks.sh` — parses

Changelog fragment added as `changelog.d/490.misc.md` (`misc`: reviewer tooling, not shipped product behavior, and not a cross-process contract change so not `breaking` per `docs/develop/versioning.md`).

Rule 12 does not apply — no daemon, protocol, orchestration, or hook code is touched. Rule 13 is satisfied: `verify-pr` is a project-local skill, not a `dot-ai-*` synced mirror, so this edit will not be clobbered by a sync commit.

Closes #490
Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)