### PR TITLE
fix: bound client-side frame read by MAX_FRAME_LEN (#478)

### DIFF
--- a/changelog.d/478.bugfix.md
+++ b/changelog.d/478.bugfix.md
@@ -1,0 +1,7 @@
+## Bounded Frame Length on the TUI's Synchronous Daemon Client
+
+The TUI's one-shot daemon queries now reject an over-long response frame instead of allocating from the length prefix on the wire. `read_frame` has always refused a frame larger than 16 MiB precisely so a forged or corrupted length cannot make the process allocate gigabytes; the synchronous client the TUI uses for its blocking queries read the same 5-byte header without that check and sized its buffer straight off the `u32`. Since the allocation happened before the body was read, a 5-byte header claiming 4 GiB was enough — no payload required.
+
+This ran on the `Ctrl+n` new-pane key path, where the deck asks the daemon which directories already host a live orchestration, so the visible failure was the TUI ballooning or being killed on a keystroke. Both sides now read the same bound and return the same `InvalidData` error, and every caller already treated a failed request as best-effort, so an over-long frame degrades to "no hint" or a `Run-now failed: …` status line rather than taking the TUI down.
+
+The wire format is unchanged. A daemon can never have sent a frame this affects — the writer has always enforced the same cap — so builds across versions interoperate exactly as before.

--- a/src/daemon_protocol.rs
+++ b/src/daemon_protocol.rs
@@ -197,7 +197,13 @@ pub const PROTOCOL_VERSION: u32 = 6;
 /// Hard cap on a single frame's payload length. Defends against a malicious
 /// or buggy peer trying to allocate gigabytes off a forged length prefix.
 /// 16 MiB is well above any reasonable PTY chunk or scrollback snapshot.
-const MAX_FRAME_LEN: usize = 16 * 1024 * 1024;
+///
+/// `pub(crate)` rather than private (issue #478) because the bound belongs to
+/// the *protocol*, not to [`read_frame`]: the TUI's synchronous one-shot client
+/// (`ui::send_daemon_request_blocking_with_timeout`) decodes the same 5-byte
+/// header without the async reader, and used to allocate straight off the u32.
+/// Both sides now read the one constant — do not re-spell the 16 MiB literal.
+pub(crate) const MAX_FRAME_LEN: usize = 16 * 1024 * 1024;
 
 /// Bounded timeout for a single STREAM_OUT/STREAM_END write to a client. If
 /// a client stops draining its socket, the OS send buffer fills and our

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -735,8 +735,8 @@ fn send_daemon_request_blocking_with_timeout(
     req: &crate::daemon_protocol::AttachRequest,
     timeout: std::time::Duration,
 ) -> std::io::Result<crate::daemon_protocol::AttachResponse> {
-    use crate::daemon_protocol::{KIND_REQ, KIND_RESP};
-    use std::io::{Read, Write};
+    use crate::daemon_protocol::KIND_REQ;
+    use std::io::Write;
 
     let path = config::attach_socket_path();
     let mut stream = crate::platform::ipc::IpcClient::connect(&path)?;
@@ -750,8 +750,35 @@ fn send_daemon_request_blocking_with_timeout(
     stream.write_all(&payload)?;
     stream.flush()?;
 
+    read_resp_frame_blocking(&mut stream)
+}
+
+/// Read one `KIND_RESP` frame off a synchronous reader and decode its body.
+///
+/// Split out of [`send_daemon_request_blocking_with_timeout`] so the framing
+/// can be exercised against a plain in-memory reader (issue #478) — the send
+/// path itself needs a live socket at [`config::attach_socket_path`].
+///
+/// The length prefix is checked against
+/// [`crate::daemon_protocol::MAX_FRAME_LEN`] BEFORE the body is allocated,
+/// mirroring [`crate::daemon_protocol::read_frame`] — same bound, same
+/// [`std::io::ErrorKind::InvalidData`], same message shape. Without it a
+/// 5-byte header claiming `u32::MAX` made this allocate ~4 GiB without the
+/// peer sending a single body byte, and this runs SYNCHRONOUSLY on the
+/// `Ctrl+n` new-pane key path (via [`live_orchestration_cwds`]), so the
+/// failure mode was the TUI ballooning or being OOM-killed on a keystroke.
+/// The socket is `0o600`, so the reachable case is a buggy or compromised
+/// same-uid daemon — exactly the "buggy peer" `MAX_FRAME_LEN` was written for.
+/// Every caller already treats `Err` as a failed request (best-effort hint,
+/// or a `Run-now failed: …` status line), so an over-long frame degrades
+/// instead of panicking.
+fn read_resp_frame_blocking<R: std::io::Read>(
+    r: &mut R,
+) -> std::io::Result<crate::daemon_protocol::AttachResponse> {
+    use crate::daemon_protocol::{KIND_RESP, MAX_FRAME_LEN};
+
     let mut resp_header = [0u8; 5];
-    stream.read_exact(&mut resp_header)?;
+    r.read_exact(&mut resp_header)?;
     if resp_header[0] != KIND_RESP {
         return Err(std::io::Error::other(format!(
             "expected RESP frame, got kind 0x{:02x}",
@@ -764,8 +791,14 @@ fn send_daemon_request_blocking_with_timeout(
         resp_header[3],
         resp_header[4],
     ]) as usize;
+    if len > MAX_FRAME_LEN {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("frame length {len} exceeds {MAX_FRAME_LEN}"),
+        ));
+    }
     let mut body = vec![0u8; len];
-    stream.read_exact(&mut body)?;
+    r.read_exact(&mut body)?;
     serde_json::from_slice(&body).map_err(std::io::Error::other)
 }
 
@@ -29615,5 +29648,97 @@ mod tests {
                  got {other:?}"
             ),
         }
+    }
+
+    /// Issue #478: the synchronous client's response read is bounded by the
+    /// SAME `MAX_FRAME_LEN` the async `read_frame` enforces. A forged 5-byte
+    /// header is all a peer needs — the allocation used to happen before
+    /// `read_exact`, so no body bytes had to follow. Mirrors
+    /// `daemon_protocol::tests::frame_rejects_oversize`.
+    #[test]
+    fn resp_frame_rejects_oversize_before_allocating() {
+        use crate::daemon_protocol::{KIND_RESP, MAX_FRAME_LEN};
+
+        for len in [MAX_FRAME_LEN as u32 + 1, u32::MAX] {
+            // Header only: five bytes, no body. If the bound were missing,
+            // `vec![0u8; len]` would run for up to ~4 GiB right here.
+            let mut buf: Vec<u8> = vec![KIND_RESP];
+            buf.extend_from_slice(&len.to_be_bytes());
+            let mut cursor = std::io::Cursor::new(buf);
+
+            let err = read_resp_frame_blocking(&mut cursor)
+                .expect_err("expected Err for an over-long response frame");
+            assert_eq!(
+                err.kind(),
+                std::io::ErrorKind::InvalidData,
+                "over-long frame must fail as InvalidData like read_frame does, got {err:?}"
+            );
+            assert!(
+                err.to_string().contains("exceeds"),
+                "error should name the bound it blew, got {err}"
+            );
+            // Nothing past the 5-byte header was consumed: the read bailed at
+            // the length check, so no body buffer was ever sized from `len`.
+            assert_eq!(
+                cursor.position(),
+                5,
+                "the body read must not be attempted once the length is rejected"
+            );
+        }
+    }
+
+    /// The bound is `>`, not `>=`: a frame of exactly `MAX_FRAME_LEN` is legal
+    /// and must reach the body read (which then fails as a truncated frame
+    /// here, since the test supplies no payload) rather than being rejected as
+    /// over-long. Guards the off-by-one between the two implementations.
+    #[test]
+    fn resp_frame_accepts_exactly_max_frame_len() {
+        use crate::daemon_protocol::{KIND_RESP, MAX_FRAME_LEN};
+
+        let mut buf: Vec<u8> = vec![KIND_RESP];
+        buf.extend_from_slice(&(MAX_FRAME_LEN as u32).to_be_bytes());
+        let mut cursor = std::io::Cursor::new(buf);
+
+        let err = read_resp_frame_blocking(&mut cursor)
+            .expect_err("no body supplied, so the read must still fail");
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::UnexpectedEof,
+            "at-limit frame must be truncated-body, not rejected as over-long, got {err:?}"
+        );
+    }
+
+    /// The happy path still decodes: a well-formed RESP frame round-trips
+    /// through the same helper the socket path now uses.
+    #[test]
+    fn resp_frame_decodes_well_formed_response() {
+        use crate::daemon_protocol::{AttachResponse, KIND_RESP};
+
+        let resp = AttachResponse {
+            ok: true,
+            ..Default::default()
+        };
+        let payload = serde_json::to_vec(&resp).unwrap();
+        let mut buf: Vec<u8> = vec![KIND_RESP];
+        buf.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        buf.extend_from_slice(&payload);
+        let mut cursor = std::io::Cursor::new(buf);
+
+        let decoded = read_resp_frame_blocking(&mut cursor).expect("well-formed frame must decode");
+        assert!(decoded.ok);
+    }
+
+    /// A non-RESP kind is still rejected up front — the bound was added
+    /// without disturbing the existing kind check.
+    #[test]
+    fn resp_frame_rejects_wrong_kind() {
+        use crate::daemon_protocol::KIND_STREAM_OUT;
+
+        let mut buf: Vec<u8> = vec![KIND_STREAM_OUT];
+        buf.extend_from_slice(&0u32.to_be_bytes());
+        let mut cursor = std::io::Cursor::new(buf);
+
+        let err = read_resp_frame_blocking(&mut cursor).expect_err("expected Err for wrong kind");
+        assert!(err.to_string().contains("expected RESP frame"), "got {err}");
     }
 }


### PR DESCRIPTION
Closes #478.

`read_frame` refuses a frame over 16 MiB precisely so a forged or corrupted length prefix cannot make us allocate gigabytes. The TUI's synchronous one-shot client read the same 5-byte header and sized its body buffer straight off the `u32` with no such check. The allocation happened *before* `read_exact`, so a 5-byte header claiming ~4 GiB was enough — the peer never had to send a byte of payload. This runs synchronously on the `Ctrl+n` new-pane key path (via `live_orchestration_cwds`), so the failure mode was the TUI ballooning or being OOM-killed on a keystroke.

Threat model is as @prageethw scoped it in the issue: the attach socket is `0o600`, so this needs a same-uid peer or a buggy/compromised daemon rather than a remote attacker. It is worth fixing because it is a guard the codebase already decided it wanted, applied on one side of the protocol and not the other — and "a buggy peer", the case `MAX_FRAME_LEN`'s own comment names, covers the unguarded path exactly.

## What changed

- **`src/daemon_protocol.rs`** — `MAX_FRAME_LEN` widened from private to `pub(crate)`, with a note that the bound belongs to the *protocol*, not to `read_frame`. The 16 MiB literal is still spelled exactly once.
- **`src/ui.rs`** — the response decode is split out of `send_daemon_request_blocking_with_timeout` into `read_resp_frame_blocking`, which checks the length against `MAX_FRAME_LEN` before `vec![0u8; len]` and returns the same `io::ErrorKind::InvalidData` in the same message shape (`frame length {len} exceeds {MAX_FRAME_LEN}`) as `read_frame`. Splitting it out is what makes the framing testable — the send path itself needs a live socket at `config::attach_socket_path()`.
- **`changelog.d/478.bugfix.md`**.

Apart from the new bound, `read_resp_frame_blocking` is the original code moved verbatim, so every frame within the cap decodes exactly as before.

## Other client-side readers

`src/ui.rs:761` was the only unbounded reader in production. Every other consumer — `daemon_client.rs`, `embedded_pane.rs` — goes through `read_frame`, which was already bounded. `tests/common/mod.rs` has two near-identical copies, but they read from a daemon the test itself spawned, so there is no untrusted peer, and `pub(crate)` deliberately does not reach the integration-test crate. Left alone; happy to widen if you'd rather they share the constant.

## Surfaced as a failed request, not a panic

All four callers already treat `Err` as a failed request: `live_schedule_names` returns `HashSet::new()`, `live_orchestration_cwds` uses `let Ok(..) else { return Vec::new() }` (fails open — the form opens with no hint), `ScheduleRunNow` shows `Run-now failed: {e}`, and the reload-after-delete discards with `let _`. An over-long frame therefore degrades rather than taking the TUI down.

## Cross-version contract (CLAUDE.md rule 12)

**Not a break — no `PROTOCOL_VERSION` bump, and no `.breaking.md` fragment.** Checked rather than assumed:

- **No wire shape change.** Same 5-byte header (1 kind + 4 BE length), same payload, no field added, removed, or retyped.
- **No semantic break behind a stable wire.** No field changes meaning; this only rejects input.
- **The newly-rejected input is unreachable from any conformant daemon.** The sole daemon-side RESP writer is `daemon_protocol.rs:1814`, which goes through `write_frame` — and `write_frame` has always returned `InvalidInput` for a payload over the same `MAX_FRAME_LEN`. No released daemon can emit a frame this client now refuses.

Old daemon ↔ new TUI and new daemon ↔ old TUI therefore behave exactly as before, so the manual previous-release-daemon run does not apply here. If a reviewer disagrees with that reading, the run is the next step and I'll do it.

## Gates

- `cargo fmt --check` — clean.
- `cargo clippy --workspace --all-targets --features e2e -- -D warnings` — clean.
- `cargo test-fast` — **1661 passed, 0 failed**.
- `cargo test-e2e` — 3698 run, 3694 passed, **4 failed**. All four investigated and none is from this change:
  - `chain_smoke_pi_002_worker_receives_delegate_and_signals_work_done` — flake; **passed on rerun**.
  - `focus_007_lock_governed_focus_contract_on_real_binary`, `idle_worker_011_silent_worker_prompt_is_visible_in_attached_tui`, `card_stats_005_real_agent_card_narrows_without_restructuring` — fail consistently, and **fail identically on the pre-change baseline `a33ff21`**, which I checked out and ran to confirm. They are pre-existing on `main` and all three are TUI focus/render assertions that never touch the sync daemon-client decode path. Flagging them here since they are not this PR's to fix.

## Tests

Four unit tests next to the code, mirroring `daemon_protocol::tests::frame_rejects_oversize`:

- `resp_frame_rejects_oversize_before_allocating` — feeds a **header-only** 5-byte frame claiming `MAX_FRAME_LEN + 1` and `u32::MAX`, asserts `InvalidData`, and asserts the cursor never advanced past byte 5, i.e. the body read was never attempted and no buffer was ever sized from the forged length.
- `resp_frame_accepts_exactly_max_frame_len` — pins `>` vs `>=`: an at-limit frame must reach the body read (failing as `UnexpectedEof` here) rather than being rejected as over-long.
- `resp_frame_decodes_well_formed_response` and `resp_frame_rejects_wrong_kind` — the happy path and the pre-existing kind check still hold.

I verified the oversize test genuinely gates the fix by removing the bound and watching it fail (`UnexpectedEof` instead of `InvalidData`) before restoring it.

No TUI test under rule 4: the guard has no observable effect in normal operation — it is reachable only from a malfunctioning peer — so the framing seam is the right level. `read_resp_frame_blocking` and its callers are private, so an integration test could not reach them anyway.

## Not addressed

The issue's **second point** — `set_timeouts` being a per-syscall timeout rather than a total deadline, so a slow-drip peer keeps `read_exact` alive indefinitely while every individual read stays inside the timeout — is untouched here, as @prageethw suggested. It still applies after this change, including to the `DAEMON_HINT_TIMEOUT` call site whose doc comment describes it as bounded ("can't freeze form-open for more than a quarter second"), which remains accurate for a *silent* peer and not for a *slow* one. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)