### PR TITLE
fix(xtask): use a platform-absolute `--root` path in the clean_tmp test

### DIFF
--- a/xtask/linkage-check/src/clean_tmp.rs
+++ b/xtask/linkage-check/src/clean_tmp.rs
@@ -1372,6 +1372,21 @@ mod tests {
         }
     }
 
+    /// Two absolute paths that satisfy [`parse_args`]'s `is_absolute()` check on
+    /// the host platform. `is_absolute()` is platform-specific — a leading `/`
+    /// is absolute on Unix but NOT on Windows, which requires a drive prefix —
+    /// so a Unix-only literal here fails the very validation the test is
+    /// exercising, on Windows only (issue #511). Nothing touches the
+    /// filesystem; these directories need not exist.
+    #[cfg(windows)]
+    const SCRATCH_ONE: &str = r"C:\scratch\one";
+    #[cfg(windows)]
+    const SCRATCH_TWO: &str = r"C:\scratch\two";
+    #[cfg(not(windows))]
+    const SCRATCH_ONE: &str = "/scratch/one";
+    #[cfg(not(windows))]
+    const SCRATCH_TWO: &str = "/scratch/two";
+
     /// `--root` replaces the standard set rather than adding to it, so a
     /// deliberate scan of one directory cannot quietly also delete from
     /// `/var/tmp` or the system temp dir.
@@ -1379,15 +1394,15 @@ mod tests {
     fn explicit_roots_replace_the_standard_set() {
         let (_opts, roots) = parse_args(&[
             "--root".to_string(),
-            "/scratch/one".to_string(),
+            SCRATCH_ONE.to_string(),
             "--root".to_string(),
-            "/scratch/two".to_string(),
+            SCRATCH_TWO.to_string(),
         ])
         .expect("parse")
         .expect("options");
         assert_eq!(
             roots,
-            vec![PathBuf::from("/scratch/one"), PathBuf::from("/scratch/two")],
+            vec![PathBuf::from(SCRATCH_ONE), PathBuf::from(SCRATCH_TWO)],
         );
         assert!(
             parse_args(&[])


### PR DESCRIPTION
Fixes #511. Unblocks `build-windows`, which is currently **red on `main`** and inherited by every open PR on its merge commit.

## The bug

`parse_args` validates `--root` with `Path::is_absolute()` (`clean_tmp.rs:637`), which is **platform-specific**: a leading `/` is absolute on Unix but *not* on Windows, where an absolute path needs a drive prefix. The test hardcoded `/scratch/one`, so on Windows its own fixture failed the very validation the surrounding code exercises:

```
FAIL clean_tmp::tests::explicit_roots_replace_the_standard_set
  parse: "--root needs an absolute path, got \"/scratch/one\""
Summary 1579 tests run: 1578 passed, 1 failed
```

**Production behaviour was never wrong.** Rejecting `/scratch/one` on Windows is correct, and `--root C:\scratch\one` works. This is a test-fixture bug only.

## The fix

The two literals become `#[cfg(windows)]` / `#[cfg(not(windows))]` consts. Nothing touches the filesystem — the paths only need to satisfy the absoluteness check, so the directories need not exist.

Scoped to one test deliberately: it is the only call site that feeds *absolute* paths through `parse_args`. The other two are correct on every platform — one passes `&[]`, the other a deliberately-relative `"scratch"` asserting `is_err()`. That is why exactly 1 of 1579 failed rather than a cluster.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --check` | pass |
| `cargo clippy --workspace --all-targets --features e2e -- -D warnings` | pass |
| `cargo test-fast` | **2523 passed, 0 skipped** |
| `cargo test-fast explicit_roots_replace_the_standard_set` (rule 6, isolated) | pass |
| `cargo xtask linkage-check` | ok |
| `windows-cross-check.sh -p xtask-linkage-check` | compiles for `x86_64-pc-windows-msvc` |

**One limitation worth stating plainly:** the last row is a *type-check*, not a test run, so it proves the `cfg(windows)` branch compiles — not that the test passes on real Windows. Only this PR's `build-windows` job can show that. Note also that `windows-cross-check.sh` runs `cargo check --tests` **without `--workspace`**, so it does not cover `xtask/*` by default; I passed `-p xtask-linkage-check` explicitly. That is arguably a gap in the script worth a follow-up, given CLAUDE.md rule 2 widened the *clippy* gate to `--workspace` for exactly this reason.

## How it reached `main`

Introduced by `28d392b` (#472, "move harness temp roots off the RAM-backed tmpfs"), merged 16:09:52Z. Its own `main` CI run was **cancelled** three seconds later by a following push, so the red was never seen at merge time; `main` then went red at `3cf4b68`.

This is also the gap CLAUDE.md rule 2 describes: `xtask/linkage-check` was linted by no gate until #436 added `--workspace`, and `build-windows` deliberately stays on bare `cargo clippy`, so this member gets the least cross-platform scrutiny in the repo — while `cargo nextest run --workspace` on Windows does execute its tests.

## Notes

- **No changelog fragment.** Test-fixture only, zero user-visible effect, so it has no release-note story. Happy to add a `misc` fragment if you would rather every PR carry one.
- `clean_tmp.rs` is also modified by open #467 (PID-liveness reaping, #461), though not this test — whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)