### PR TITLE
xtask: assert repository state before linkage-check's catalog checks

### DIFF
--- a/xtask/linkage-check/src/main.rs
+++ b/xtask/linkage-check/src/main.rs
@@ -4,8 +4,18 @@
 //! Invoked as `cargo xtask <subcommand>` (alias in `.cargo/config.toml`).
 //! Subcommands:
 //!
-//! - `linkage-check` (default) — performs the seven checks listed
-//!   in Decision 7 + Decision 30:
+//! - `linkage-check` (default) — first runs a repository-state preflight
+//!   (issue #557; see [`repo_state`]), then performs the eight checks
+//!   listed in Decision 7 + Decision 30:
+//!
+//!   The preflight is deliberately not a ninth numbered check: it answers
+//!   "is this repository sane to reason about", a different question from
+//!   "does the catalog match the tests", and it runs first so a repository
+//!   in a state that would misdiagnose the checks below is caught before
+//!   any of them run. It asserts that the object store is not unexpectedly
+//!   shallow and that the worktree registry has not drifted from what is on
+//!   disk — both gated so a legitimately shallow, single-worktree CI clone
+//!   is exempt by construction. See [`repo_state`] for the full reasoning.
 //!
 //!   1. Every catalog ID has at least one `#[spec("...")]` referencing
 //!      it OR is on the allowlist (`m2.allowlist`).
@@ -53,6 +63,7 @@
 
 mod clean_tmp;
 mod list_tests;
+mod repo_state;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -206,6 +217,24 @@ fn main() -> ExitCode {
     }
 
     let root = repo_root();
+
+    // Repository-state preflight (issue #557): a different question from
+    // the catalog↔test checks below, and one worth answering before any of
+    // them spend seconds parsing the catalog. Runs first and short-circuits
+    // on its own rather than joining `failures` below, so it stays a
+    // preflight rather than becoming a ninth catalog check.
+    let repo_state_failures = repo_state::run(&root);
+    if !repo_state_failures.is_empty() {
+        eprintln!(
+            "linkage-check: repository-state preflight: {} failure(s):",
+            repo_state_failures.len()
+        );
+        for f in &repo_state_failures {
+            eprintln!("  {f}");
+        }
+        return ExitCode::FAILURE;
+    }
+
     let catalog_path = root.join(CATALOG_PATH);
     let allowlist_path = root.join(ALLOWLIST_PATH);
     let tests_dir = root.join(TESTS_DIR);

--- a/xtask/linkage-check/src/repo_state.rs
+++ b/xtask/linkage-check/src/repo_state.rs
@@ -1,0 +1,515 @@
+//! Repository-state preflight for `cargo xtask linkage-check` (issue #557).
+//!
+//! A shallow object store breaks history operations across every worktree
+//! sharing it, and it does so silently: `git log` works, `git status` is
+//! clean, refs resolve to the SHAs you expect. The only symptom shows up
+//! later, somewhere else, as `fatal: refusing to merge unrelated histories`
+//! — which reads as a wrong or corrupt remote, not as a truncated object
+//! store. `.git/shallow` lives in the common dir, so one `git fetch
+//! --depth=…` in one linked worktree degrades every worktree in the clone
+//! at once. This preflight turns that into a named failure with a remedy at
+//! the next `linkage-check` run, instead of an arbitrarily delayed
+//! misdiagnosis.
+//!
+//! It also asserts worktree-registry drift: a `git worktree list` entry
+//! whose path no longer exists on disk is the only trace left behind when a
+//! worktree is removed without `git worktree prune`, and the degenerate
+//! case — the *current* checkout's own entry gone missing — gets its own
+//! message rather than leaving whatever runs next to fail with a confusing
+//! `no such file or directory`.
+//!
+//! # The gate
+//!
+//! Every `actions/checkout@v7` in CI clones at the default depth of 1, so a
+//! naive `if shallow { fail }` would fail every job in the matrix. This is
+//! resolved structurally, not with an environment-variable escape hatch —
+//! an env-gated check is indistinguishable from a passing one and is how a
+//! check quietly stops running in the places that matter. The shallow
+//! assertion applies only when the repository has more than one worktree,
+//! or the current checkout is itself a linked worktree ([`should_assert_shallow`]):
+//! the failure mode exists *because* several worktrees share one object
+//! store, and a CI runner clones fresh with exactly one, so it is exempt by
+//! construction rather than by trusting an environment variable.
+//!
+//! # Shape
+//!
+//! [`collect`] is the only part of this module that shells out to git; it
+//! turns three git invocations' worth of output into a plain [`RepoState`].
+//! Everything that decides pass/fail — [`should_assert_shallow`],
+//! [`preflight_failures`], [`is_linked_worktree`], [`parse_worktree_paths`]
+//! — is a pure function over already-collected values, so it is unit-tested
+//! without building a real git repository.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Named verbatim in the shallow-repository failure message (issue #557):
+/// every downstream symptom misdiagnoses as `fatal: refusing to merge
+/// unrelated histories`, which reads as a wrong or corrupt remote rather
+/// than a truncated one.
+const UNSHALLOW_REMEDY: &str = "git fetch --unshallow <remote>";
+
+/// The confirming probe for a shallow repository: returns the ref's own tip
+/// (i.e. the tip is parentless) when the history has been truncated.
+const SHALLOW_PROBE: &str = "git rev-list --max-parents=0 <ref>";
+
+/// Named verbatim in both worktree-drift failure messages.
+const PRUNE_REMEDY: &str = "git worktree prune";
+
+/// One `git worktree list --porcelain` entry: the registered path, and
+/// whether it still exists on disk. The existence check is done by the
+/// caller ([`collect`]) rather than inside the pure verdict functions below,
+/// so drift can be pinned by a test without touching the filesystem.
+struct WorktreeEntry {
+    path: PathBuf,
+    exists: bool,
+}
+
+/// Everything [`preflight_failures`] needs, already collected. Kept
+/// separate from the git-shelling [`collect`] so the decision logic is pure.
+struct RepoState {
+    is_shallow: bool,
+    worktrees: Vec<WorktreeEntry>,
+    /// This checkout's own top-level path (`git rev-parse --show-toplevel`),
+    /// matched against `worktrees` by equality for the degenerate case.
+    current_worktree: PathBuf,
+    /// True when this checkout IS a linked worktree — see
+    /// [`is_linked_worktree`].
+    is_linked_worktree: bool,
+}
+
+/// Whether `--git-common-dir` names a different directory than `--git-dir`
+/// — true only for a linked worktree.
+///
+/// For the primary checkout the two are one directory: measured directly, a
+/// plain clone prints `.git` for both (or `../.git` for both, from a
+/// subdirectory — relative output tracks cwd identically for both flags, so
+/// the comparison still holds). A linked worktree's `--git-dir` is always a
+/// `worktrees/<name>` subdirectory of `--git-common-dir` by construction, so
+/// the two can never be equal there, and `--git-common-dir` is printed as an
+/// absolute path in that case regardless of cwd depth.
+fn is_linked_worktree(git_common_dir: &str, git_dir: &str) -> bool {
+    git_common_dir != git_dir
+}
+
+/// Whether the shallow assertion applies at all (issue #557's gate). CI
+/// checkouts are legitimately shallow with exactly one worktree, and a
+/// shallow, single-worktree repository cannot yet exhibit the cross-worktree
+/// object-store damage this preflight exists to catch — so it is exempt by
+/// construction. `is_linked_worktree` is checked independently of the count:
+/// it is what we know for certain about *this* checkout even if the
+/// registry itself is the thing that turns out to be drifted.
+fn should_assert_shallow(state: &RepoState) -> bool {
+    state.worktrees.len() > 1 || state.is_linked_worktree
+}
+
+/// Parse `git worktree list --porcelain` output into the registered paths,
+/// in the order git reports them. Every entry block starts with a
+/// `worktree <path>` line; the `HEAD`, `branch`, `bare` and `detached` lines
+/// that can follow are not needed here.
+fn parse_worktree_paths(porcelain: &str) -> Vec<PathBuf> {
+    porcelain
+        .lines()
+        .filter_map(|line| line.strip_prefix("worktree "))
+        .map(PathBuf::from)
+        .collect()
+}
+
+/// The pure verdict: every failure found against an already-collected
+/// [`RepoState`]. Empty means clean.
+fn preflight_failures(state: &RepoState) -> Vec<String> {
+    let mut failures = Vec::new();
+
+    if should_assert_shallow(state) && state.is_shallow {
+        failures.push(format!(
+            "repository object store is shallow (`git rev-parse --is-shallow-repository` \
+             is true) in a checkout with more than one worktree, or that is itself a linked \
+             worktree — every worktree sharing this object store is affected, and it \
+             misdiagnoses downstream as `fatal: refusing to merge unrelated histories` rather \
+             than a truncated history. Confirm with `{SHALLOW_PROBE}` returning the ref's own \
+             tip, then fix with `{UNSHALLOW_REMEDY}`."
+        ));
+    }
+
+    let missing: Vec<&Path> = state
+        .worktrees
+        .iter()
+        .filter(|w| !w.exists)
+        .map(|w| w.path.as_path())
+        .collect();
+    if !missing.is_empty() {
+        let list = missing
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let (does, is) = if missing.len() == 1 {
+            ("does", "is")
+        } else {
+            ("do", "are")
+        };
+        failures.push(format!(
+            "worktree registry drift: {list} {does} no longer exist on disk but {is} still \
+             registered — a worktree was removed without pruning. Run `{PRUNE_REMEDY}`."
+        ));
+
+        if missing.contains(&state.current_worktree.as_path()) {
+            failures.push(format!(
+                "this checkout's own worktree, {}, is registered but no longer exists on disk \
+                 — whatever runs next will fail with a confusing `no such file or directory` \
+                 instead. Run `{PRUNE_REMEDY}`.",
+                state.current_worktree.display()
+            ));
+        }
+    }
+
+    failures
+}
+
+/// Shells out to git and turns the output into a [`RepoState`]. The only
+/// part of this module that is not a pure function.
+///
+/// Three invocations, kept to that count deliberately (issue #557: "stay
+/// cheap"): one combined `rev-parse` for the toplevel, both git-dir flags
+/// and the shallow check, plus one `worktree list --porcelain`.
+fn collect(root: &Path) -> Result<RepoState, String> {
+    let rev_parse = run_git(
+        root,
+        &[
+            "rev-parse",
+            "--show-toplevel",
+            "--git-common-dir",
+            "--git-dir",
+            "--is-shallow-repository",
+        ],
+    )?;
+    let mut lines = rev_parse.lines();
+    let show_toplevel = lines
+        .next()
+        .ok_or_else(|| "git rev-parse produced no output".to_string())?;
+    let git_common_dir = lines
+        .next()
+        .ok_or_else(|| "git rev-parse: missing --git-common-dir output".to_string())?;
+    let git_dir = lines
+        .next()
+        .ok_or_else(|| "git rev-parse: missing --git-dir output".to_string())?;
+    let is_shallow_raw = lines
+        .next()
+        .ok_or_else(|| "git rev-parse: missing --is-shallow-repository output".to_string())?;
+    let is_shallow = match is_shallow_raw {
+        "true" => true,
+        "false" => false,
+        other => {
+            return Err(format!(
+                "unexpected --is-shallow-repository output {other:?}"
+            ));
+        }
+    };
+
+    let porcelain = run_git(root, &["worktree", "list", "--porcelain"])?;
+    let worktrees = parse_worktree_paths(&porcelain)
+        .into_iter()
+        .map(|path| {
+            let exists = path.exists();
+            WorktreeEntry { path, exists }
+        })
+        .collect();
+
+    Ok(RepoState {
+        is_shallow,
+        worktrees,
+        current_worktree: PathBuf::from(show_toplevel),
+        is_linked_worktree: is_linked_worktree(git_common_dir, git_dir),
+    })
+}
+
+fn run_git(root: &Path, args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .map_err(|e| format!("failed to invoke `git {}`: {e}", args.join(" ")))?;
+    if !output.status.success() {
+        return Err(format!(
+            "`git {}` exited with {}: {}",
+            args.join(" "),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim(),
+        ));
+    }
+    String::from_utf8(output.stdout)
+        .map(|s| s.trim_end().to_string())
+        .map_err(|e| format!("`git {}` produced non-UTF-8 output: {e}", args.join(" ")))
+}
+
+/// Maps a [`collect`] result to the failures the preflight reports.
+///
+/// A git invocation that itself fails — not a repository at all, or git
+/// missing from `PATH` — is a deliberate PASS, not a failure: every other
+/// check in `linkage-check` already depends on the checkout being a working
+/// git repository just to read the catalog and the test sources, so a
+/// checkout broken badly enough to fail this preflight's git calls will not
+/// get further unnoticed. Crashing the whole build because this one
+/// preflight could not ask git a question would be worse than skipping it;
+/// the reason is still printed, not swallowed.
+fn failures_from(collected: Result<RepoState, String>) -> Vec<String> {
+    match collected {
+        Ok(state) => preflight_failures(&state),
+        Err(reason) => {
+            eprintln!("xtask linkage-check: repository-state preflight skipped: {reason}");
+            Vec::new()
+        }
+    }
+}
+
+/// Entry point `main.rs` calls before the catalog↔test checks. Every
+/// failure found (empty means clean).
+pub(crate) fn run(root: &Path) -> Vec<String> {
+    failures_from(collect(root))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(path: &str, exists: bool) -> WorktreeEntry {
+        WorktreeEntry {
+            path: PathBuf::from(path),
+            exists,
+        }
+    }
+
+    fn state(
+        is_shallow: bool,
+        worktrees: Vec<WorktreeEntry>,
+        current_worktree: &str,
+        is_linked_worktree: bool,
+    ) -> RepoState {
+        RepoState {
+            is_shallow,
+            worktrees,
+            current_worktree: PathBuf::from(current_worktree),
+            is_linked_worktree,
+        }
+    }
+
+    /// The gate this whole change exists for: a CI runner clones fresh with
+    /// exactly one worktree and no linked-worktree redirection, so a
+    /// shallow object store there is exempt by construction rather than
+    /// flagged.
+    #[test]
+    fn gate_exempts_a_single_worktree_shallow_repo() {
+        let s = state(true, vec![entry("/repo", true)], "/repo", false);
+        assert!(
+            preflight_failures(&s).is_empty(),
+            "{:?}",
+            preflight_failures(&s)
+        );
+    }
+
+    /// More than one registered worktree sharing a shallow object store is
+    /// exactly the damage shape the preflight exists to catch, and the
+    /// message must name the remedy verbatim.
+    #[test]
+    fn multi_worktree_shallow_repo_fails_and_names_the_remedy() {
+        let s = state(
+            true,
+            vec![entry("/repo", true), entry("/repo-other", true)],
+            "/repo",
+            false,
+        );
+        let failures = preflight_failures(&s);
+        assert_eq!(failures.len(), 1, "{failures:?}");
+        assert!(
+            failures[0].contains("git fetch --unshallow"),
+            "{}",
+            failures[0]
+        );
+        assert!(
+            failures[0].contains("git rev-list --max-parents=0"),
+            "{}",
+            failures[0]
+        );
+    }
+
+    /// A linked worktree that is shallow fails even when the registry only
+    /// lists one entry — `is_linked_worktree` is checked independently of
+    /// the count precisely so registry drift cannot mask this case.
+    #[test]
+    fn a_linked_worktree_that_is_shallow_fails_even_with_one_registered_entry() {
+        let s = state(true, vec![entry("/repo/wt", true)], "/repo/wt", true);
+        let failures = preflight_failures(&s);
+        assert_eq!(failures.len(), 1, "{failures:?}");
+        assert!(
+            failures[0].contains("git fetch --unshallow"),
+            "{}",
+            failures[0]
+        );
+    }
+
+    /// A shallow repository that is genuinely exempt AND has no drift stays
+    /// silent — the count/linked gate and the drift check are independent.
+    #[test]
+    fn a_shallow_single_worktree_repo_with_no_drift_is_silent() {
+        let s = state(true, vec![entry("/repo", true)], "/repo", false);
+        assert!(preflight_failures(&s).is_empty());
+    }
+
+    /// Registry drift: an entry whose path is gone is reported with the
+    /// path named and the prune remedy, even when the repository is not
+    /// shallow at all.
+    #[test]
+    fn registry_drift_reports_the_missing_path_by_name() {
+        let s = state(
+            false,
+            vec![entry("/repo/main", true), entry("/repo/gone", false)],
+            "/repo/main",
+            false,
+        );
+        let failures = preflight_failures(&s);
+        assert_eq!(failures.len(), 1, "{failures:?}");
+        assert!(failures[0].contains("/repo/gone"), "{}", failures[0]);
+        assert!(
+            failures[0].contains("git worktree prune"),
+            "{}",
+            failures[0]
+        );
+        // The current worktree is fine, so the degenerate-case message must
+        // not also fire.
+        assert!(
+            !failures[0].contains("this checkout's own worktree"),
+            "{}",
+            failures[0]
+        );
+    }
+
+    /// The degenerate case of drift: the CURRENT checkout's own registry
+    /// entry is the one that no longer exists on disk. Gets its own
+    /// message in addition to the general drift report, rather than
+    /// leaving whatever runs next to fail with a confusing `no such file or
+    /// directory`.
+    #[test]
+    fn current_worktree_missing_gets_its_own_message() {
+        let s = state(false, vec![entry("/repo/wt", false)], "/repo/wt", true);
+        let failures = preflight_failures(&s);
+        assert_eq!(failures.len(), 2, "{failures:?}");
+        assert!(failures[0].contains("/repo/wt"), "{}", failures[0]);
+        assert!(
+            failures[0].contains("git worktree prune"),
+            "{}",
+            failures[0]
+        );
+        assert!(
+            failures[1].contains("this checkout's own worktree"),
+            "{}",
+            failures[1]
+        );
+        assert!(failures[1].contains("/repo/wt"), "{}", failures[1]);
+        assert!(
+            failures[1].contains("git worktree prune"),
+            "{}",
+            failures[1]
+        );
+    }
+
+    /// A healthy multi-worktree, non-shallow repository passes with no
+    /// findings at all.
+    #[test]
+    fn a_healthy_multi_worktree_repo_passes() {
+        let s = state(
+            false,
+            vec![entry("/repo", true), entry("/repo-other", true)],
+            "/repo",
+            false,
+        );
+        assert!(preflight_failures(&s).is_empty());
+    }
+
+    /// Deliberate decision for the git-unavailable case (issue #557: "fail
+    /// closed, carefully"): a `collect` failure — git missing, not a
+    /// repository at all — is treated as a PASS rather than crashing the
+    /// build, because every other `linkage-check` rule already assumes a
+    /// working git checkout to run at all.
+    #[test]
+    fn a_git_invocation_failure_is_treated_as_a_pass_not_a_crash() {
+        let failures = failures_from(Err("git not found on PATH".to_string()));
+        assert!(failures.is_empty(), "{failures:?}");
+    }
+
+    /// A successful `collect` still runs the real verdict logic through
+    /// `failures_from` — the git-unavailable case is the only thing that
+    /// short-circuits to empty.
+    #[test]
+    fn a_successful_collect_still_reports_real_failures() {
+        let s = state(
+            true,
+            vec![entry("/repo", true), entry("/repo-other", true)],
+            "/repo",
+            false,
+        );
+        let failures = failures_from(Ok(s));
+        assert_eq!(failures.len(), 1, "{failures:?}");
+    }
+
+    /// The primary checkout: measured directly, `--git-common-dir` and
+    /// `--git-dir` print the identical string, whether relative (from a
+    /// subdirectory) or the historical `.git` form — never a linked
+    /// worktree.
+    #[test]
+    fn is_linked_worktree_is_false_for_the_primary_checkout() {
+        assert!(!is_linked_worktree(".git", ".git"));
+        assert!(!is_linked_worktree("../.git", "../.git"));
+        assert!(!is_linked_worktree(
+            "/Users/dev/repo/.git",
+            "/Users/dev/repo/.git"
+        ));
+    }
+
+    /// A linked worktree: measured directly, `--git-common-dir` is the
+    /// common dir's absolute path and `--git-dir` is its
+    /// `worktrees/<name>` subdirectory — always unequal by construction.
+    #[test]
+    fn is_linked_worktree_is_true_for_a_linked_worktree() {
+        assert!(is_linked_worktree(
+            "/Users/dev/repo/.git",
+            "/Users/dev/repo/.git/worktrees/repo-fix123"
+        ));
+    }
+
+    #[test]
+    fn parse_worktree_paths_extracts_only_the_worktree_lines() {
+        let porcelain = "worktree /repo/main\n\
+                          HEAD 9c131d5455485369f6b6b7c9ac8cdd9d5482241d\n\
+                          branch refs/heads/main\n\
+                          \n\
+                          worktree /repo/fix-123\n\
+                          HEAD 4e402c166433f702351f18e6e26c51205e19df1e\n\
+                          branch refs/heads/fix/123-something\n";
+        assert_eq!(
+            parse_worktree_paths(porcelain),
+            vec![PathBuf::from("/repo/main"), PathBuf::from("/repo/fix-123")]
+        );
+    }
+
+    /// A bare or detached entry omits `branch` in favour of `bare` /
+    /// `detached`; the parser only looks for the `worktree ` prefix, so
+    /// these shapes cannot break it.
+    #[test]
+    fn parse_worktree_paths_is_indifferent_to_bare_and_detached_entries() {
+        let porcelain = "worktree /repo/bare\n\
+                          bare\n\
+                          \n\
+                          worktree /repo/detached\n\
+                          HEAD 9c131d5455485369f6b6b7c9ac8cdd9d5482241d\n\
+                          detached\n";
+        assert_eq!(
+            parse_worktree_paths(porcelain),
+            vec![PathBuf::from("/repo/bare"), PathBuf::from("/repo/detached")]
+        );
+    }
+
+    #[test]
+    fn parse_worktree_paths_on_empty_input_is_empty() {
+        assert!(parse_worktree_paths("").is_empty());
+    }
+}

--- a/xtask/linkage-check/src/repo_state.rs
+++ b/xtask/linkage-check/src/repo_state.rs
@@ -34,12 +34,13 @@
 //! # Shape
 //!
 //! [`collect`] is the only part of this module that shells out to git; it
-//! turns three git invocations' worth of output into a plain [`RepoState`].
+//! turns two git invocations' worth of output into a plain [`RepoState`].
 //! Everything that decides pass/fail — [`should_assert_shallow`],
-//! [`preflight_failures`], [`is_linked_worktree`], [`parse_worktree_paths`]
+//! [`preflight_failures`], [`is_linked_worktree`], [`parse_worktree_entries`]
 //! — is a pure function over already-collected values, so it is unit-tested
 //! without building a real git repository.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -56,13 +57,21 @@ const SHALLOW_PROBE: &str = "git rev-list --max-parents=0 <ref>";
 /// Named verbatim in both worktree-drift failure messages.
 const PRUNE_REMEDY: &str = "git worktree prune";
 
-/// One `git worktree list --porcelain` entry: the registered path, and
-/// whether it still exists on disk. The existence check is done by the
-/// caller ([`collect`]) rather than inside the pure verdict functions below,
-/// so drift can be pinned by a test without touching the filesystem.
+/// One `git worktree list --porcelain` entry: the registered path, whether
+/// it still exists on disk, and git's own `prunable` reason when it already
+/// told us (see [`parse_worktree_entries`]). The existence check is done by
+/// the caller ([`collect`]) rather than inside the pure verdict functions
+/// below, so drift can be pinned by a test without touching the filesystem.
+#[derive(Debug)]
 struct WorktreeEntry {
     path: PathBuf,
     exists: bool,
+    /// `Some(reason)` when `git worktree list --porcelain` already reported
+    /// this entry `prunable <reason>` (git ≥ 2.36) — folded into the drift
+    /// message instead of composing our own explanation. `None` means
+    /// either a genuinely healthy entry or an older git that predates the
+    /// attribute; `exists` falls back to `Path::try_exists()` in that case.
+    prunable_reason: Option<String>,
 }
 
 /// Everything [`preflight_failures`] needs, already collected. Kept
@@ -81,14 +90,23 @@ struct RepoState {
 /// Whether `--git-common-dir` names a different directory than `--git-dir`
 /// — true only for a linked worktree.
 ///
-/// For the primary checkout the two are one directory: measured directly, a
-/// plain clone prints `.git` for both (or `../.git` for both, from a
-/// subdirectory — relative output tracks cwd identically for both flags, so
-/// the comparison still holds). A linked worktree's `--git-dir` is always a
-/// `worktrees/<name>` subdirectory of `--git-common-dir` by construction, so
-/// the two can never be equal there, and `--git-common-dir` is printed as an
-/// absolute path in that case regardless of cwd depth.
-fn is_linked_worktree(git_common_dir: &str, git_dir: &str) -> bool {
+/// This is sound BECAUSE [`collect`] always passes `--path-format=absolute`,
+/// not merely because it currently happens to be invoked from the git
+/// toplevel. Measured directly on git 2.55.0: WITHOUT `--path-format`, from
+/// a subdirectory of a primary checkout, `--git-common-dir` stays relative
+/// (`../../.git`) while `--git-dir` is printed absolute
+/// (`/abs/.../.git`) — the two compare unequal, so this function would
+/// wrongly return `true` for a primary checkout. That is the dangerous
+/// direction: it would turn the shallow assertion on for a fresh, shallow,
+/// single-worktree CI clone, which is exactly the outcome
+/// [`should_assert_shallow`]'s exemption exists to prevent. With
+/// `--path-format=absolute`, both flags are forced absolute regardless of
+/// cwd depth, and a linked worktree's `--git-dir` is always a
+/// `worktrees/<name>` subdirectory of `--git-common-dir` by construction —
+/// so the two are equal for the primary checkout and unequal for a linked
+/// one, always, not just when `collect`'s caller happens to invoke it from
+/// the toplevel.
+fn is_linked_worktree(git_common_dir: &Path, git_dir: &Path) -> bool {
     git_common_dir != git_dir
 }
 
@@ -103,16 +121,75 @@ fn should_assert_shallow(state: &RepoState) -> bool {
     state.worktrees.len() > 1 || state.is_linked_worktree
 }
 
-/// Parse `git worktree list --porcelain` output into the registered paths,
-/// in the order git reports them. Every entry block starts with a
-/// `worktree <path>` line; the `HEAD`, `branch`, `bare` and `detached` lines
-/// that can follow are not needed here.
-fn parse_worktree_paths(porcelain: &str) -> Vec<PathBuf> {
-    porcelain
-        .lines()
-        .filter_map(|line| line.strip_prefix("worktree "))
-        .map(PathBuf::from)
-        .collect()
+/// Builds an [`OsString`] from raw git output bytes without the hard UTF-8
+/// failure `String::from_utf8` would give: a single non-UTF-8 byte in one
+/// worktree's path (legal on Linux — ext4/xfs accept any byte but `/` and
+/// NUL) must degrade only that path, not the whole preflight, including the
+/// shallow assertion that has nothing to do with paths. Unix keeps the
+/// bytes exactly (`OsStrExt::from_bytes`), so equality comparisons
+/// ([`is_linked_worktree`], the degenerate-case match in
+/// [`preflight_failures`]) stay byte-exact instead of corrupted by a lossy
+/// round-trip; non-Unix falls back to lossy UTF-8 — this crate's existing
+/// idiom elsewhere (`list_tests.rs`) — which is moot in practice since
+/// `cargo xtask linkage-check` runs in CI on Linux only.
+fn os_string_from_bytes(bytes: &[u8]) -> OsString {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        std::ffi::OsStr::from_bytes(bytes).to_os_string()
+    }
+    #[cfg(not(unix))]
+    {
+        OsString::from(String::from_utf8_lossy(bytes).into_owned())
+    }
+}
+
+/// One `git worktree list --porcelain` entry as parsed, before the
+/// filesystem existence check ([`collect`] does that).
+#[derive(Debug)]
+struct ParsedWorktree {
+    path: PathBuf,
+    prunable_reason: Option<String>,
+}
+
+/// Parse `git worktree list --porcelain` output into per-entry records, in
+/// the order git reports them. Every block starts with a `worktree <path>`
+/// line; `HEAD`, `branch`, `bare`, `detached` and `locked` lines are
+/// ignored, and a `prunable <reason>` line (git ≥ 2.36) attaches to the
+/// block it appears in — preferred over re-deriving drift with
+/// `Path::exists()`/`try_exists()` in [`collect`] because it survives a
+/// corrupted `path` field: git accepts a literal newline inside a worktree
+/// path and porcelain emits it unescaped, splitting one entry's block
+/// across two lines. `path` is truncated at the newline in that case, but
+/// the `prunable` line — several lines later in the SAME block — is
+/// unaffected, so keying off it instead of the mangled path is what makes a
+/// genuinely-removed worktree with a newline in its path still report as
+/// drift rather than fail green. Any line that starts none of the
+/// recognised prefixes — including the tail end of a newline-split path —
+/// is silently skipped rather than treated as a new entry, since only a
+/// `worktree ` line ever starts one.
+fn parse_worktree_entries(porcelain: &[u8]) -> Vec<ParsedWorktree> {
+    let mut out = Vec::new();
+    let mut current: Option<ParsedWorktree> = None;
+    for line in porcelain.split(|&b| b == b'\n') {
+        if let Some(rest) = line.strip_prefix(b"worktree ") {
+            if let Some(entry) = current.take() {
+                out.push(entry);
+            }
+            current = Some(ParsedWorktree {
+                path: PathBuf::from(os_string_from_bytes(rest)),
+                prunable_reason: None,
+            });
+        } else if let Some(rest) = line.strip_prefix(b"prunable ")
+            && let Some(entry) = current.as_mut()
+        {
+            entry.prunable_reason = Some(String::from_utf8_lossy(rest).into_owned());
+        }
+    }
+    if let Some(entry) = current.take() {
+        out.push(entry);
+    }
+    out
 }
 
 /// The pure verdict: every failure found against an already-collected
@@ -131,16 +208,18 @@ fn preflight_failures(state: &RepoState) -> Vec<String> {
         ));
     }
 
-    let missing: Vec<&Path> = state
-        .worktrees
-        .iter()
-        .filter(|w| !w.exists)
-        .map(|w| w.path.as_path())
-        .collect();
+    let missing: Vec<&WorktreeEntry> = state.worktrees.iter().filter(|w| !w.exists).collect();
     if !missing.is_empty() {
+        // `{:?}` rather than `.display()`: porcelain preserves control
+        // characters verbatim, and `Debug` for `Path` escapes them so a
+        // trailing-space, `\r` or ANSI-escape path is visible in the
+        // message instead of corrupting the terminal or CI log it lands in.
         let list = missing
             .iter()
-            .map(|p| p.display().to_string())
+            .map(|w| match &w.prunable_reason {
+                Some(reason) => format!("{:?} ({reason})", w.path),
+                None => format!("{:?}", w.path),
+            })
             .collect::<Vec<_>>()
             .join(", ");
         let (does, is) = if missing.len() == 1 {
@@ -153,12 +232,12 @@ fn preflight_failures(state: &RepoState) -> Vec<String> {
              registered — a worktree was removed without pruning. Run `{PRUNE_REMEDY}`."
         ));
 
-        if missing.contains(&state.current_worktree.as_path()) {
+        if missing.iter().any(|w| w.path == state.current_worktree) {
             failures.push(format!(
-                "this checkout's own worktree, {}, is registered but no longer exists on disk \
+                "this checkout's own worktree, {:?}, is registered but no longer exists on disk \
                  — whatever runs next will fail with a confusing `no such file or directory` \
                  instead. Run `{PRUNE_REMEDY}`.",
-                state.current_worktree.display()
+                state.current_worktree
             ));
         }
     }
@@ -169,21 +248,24 @@ fn preflight_failures(state: &RepoState) -> Vec<String> {
 /// Shells out to git and turns the output into a [`RepoState`]. The only
 /// part of this module that is not a pure function.
 ///
-/// Three invocations, kept to that count deliberately (issue #557: "stay
+/// Two invocations, kept to that count deliberately (issue #557: "stay
 /// cheap"): one combined `rev-parse` for the toplevel, both git-dir flags
 /// and the shallow check, plus one `worktree list --porcelain`.
+/// `--path-format=absolute` is what makes [`is_linked_worktree`]'s
+/// comparison sound rather than incidental — see its doc comment.
 fn collect(root: &Path) -> Result<RepoState, String> {
     let rev_parse = run_git(
         root,
         &[
             "rev-parse",
+            "--path-format=absolute",
             "--show-toplevel",
             "--git-common-dir",
             "--git-dir",
             "--is-shallow-repository",
         ],
     )?;
-    let mut lines = rev_parse.lines();
+    let mut lines = rev_parse.split(|&b| b == b'\n');
     let show_toplevel = lines
         .next()
         .ok_or_else(|| "git rev-parse produced no output".to_string())?;
@@ -197,33 +279,52 @@ fn collect(root: &Path) -> Result<RepoState, String> {
         .next()
         .ok_or_else(|| "git rev-parse: missing --is-shallow-repository output".to_string())?;
     let is_shallow = match is_shallow_raw {
-        "true" => true,
-        "false" => false,
+        b"true" => true,
+        b"false" => false,
         other => {
             return Err(format!(
-                "unexpected --is-shallow-repository output {other:?}"
+                "unexpected --is-shallow-repository output {:?}",
+                String::from_utf8_lossy(other)
             ));
         }
     };
+    let git_common_dir = PathBuf::from(os_string_from_bytes(git_common_dir));
+    let git_dir = PathBuf::from(os_string_from_bytes(git_dir));
 
     let porcelain = run_git(root, &["worktree", "list", "--porcelain"])?;
-    let worktrees = parse_worktree_paths(&porcelain)
+    let worktrees = parse_worktree_entries(&porcelain)
         .into_iter()
-        .map(|path| {
-            let exists = path.exists();
-            WorktreeEntry { path, exists }
+        .map(|parsed| {
+            // Unreadable (e.g. EACCES on a live worktree under an unreadable
+            // parent) is not evidence of drift — degrade to "present"
+            // rather than the false positive `Path::exists()` gives here
+            // (it returns `false` on ANY error, permission denied
+            // included).
+            let exists = match &parsed.prunable_reason {
+                Some(_) => false,
+                None => parsed.path.try_exists().unwrap_or(true),
+            };
+            WorktreeEntry {
+                path: parsed.path,
+                exists,
+                prunable_reason: parsed.prunable_reason,
+            }
         })
         .collect();
 
     Ok(RepoState {
         is_shallow,
         worktrees,
-        current_worktree: PathBuf::from(show_toplevel),
-        is_linked_worktree: is_linked_worktree(git_common_dir, git_dir),
+        current_worktree: PathBuf::from(os_string_from_bytes(show_toplevel)),
+        is_linked_worktree: is_linked_worktree(&git_common_dir, &git_dir),
     })
 }
 
-fn run_git(root: &Path, args: &[&str]) -> Result<String, String> {
+/// Runs `git` and returns raw stdout bytes (trailing newline/carriage
+/// return trimmed). No UTF-8 validation here — see
+/// [`os_string_from_bytes`] for why a hard UTF-8 failure on one path must
+/// not disable the whole preflight.
+fn run_git(root: &Path, args: &[&str]) -> Result<Vec<u8>, String> {
     let output = Command::new("git")
         .args(args)
         .current_dir(root)
@@ -237,26 +338,50 @@ fn run_git(root: &Path, args: &[&str]) -> Result<String, String> {
             String::from_utf8_lossy(&output.stderr).trim(),
         ));
     }
-    String::from_utf8(output.stdout)
-        .map(|s| s.trim_end().to_string())
-        .map_err(|e| format!("`git {}` produced non-UTF-8 output: {e}", args.join(" ")))
+    let mut stdout = output.stdout;
+    while matches!(stdout.last(), Some(b'\n') | Some(b'\r')) {
+        stdout.pop();
+    }
+    Ok(stdout)
 }
 
 /// Maps a [`collect`] result to the failures the preflight reports.
 ///
-/// A git invocation that itself fails — not a repository at all, or git
-/// missing from `PATH` — is a deliberate PASS, not a failure: every other
-/// check in `linkage-check` already depends on the checkout being a working
-/// git repository just to read the catalog and the test sources, so a
-/// checkout broken badly enough to fail this preflight's git calls will not
-/// get further unnoticed. Crashing the whole build because this one
-/// preflight could not ask git a question would be worse than skipping it;
-/// the reason is still printed, not swallowed.
+/// A git invocation that itself fails is a deliberate PASS, not a failure —
+/// but the bucket routed here is wider than "not a repository, or git
+/// missing from `PATH`". It also covers: a **bare** repository
+/// (`--show-toplevel` fails outright there); `safe.directory` / "detected
+/// dubious ownership" refusals, which a container or CI runner executing as
+/// a different uid than the checkout's owner hits on an otherwise perfectly
+/// healthy repository — an ordinary state, not an exotic one; any other
+/// non-zero git exit; and an unrecognised `rev-parse` flag on an older git,
+/// which git echoes verbatim to stdout while exiting 0, failing the
+/// positional parse in [`collect`] and routing here too. `collect` now
+/// requires git ≥ 2.31 (`--path-format`, added that release) — the higher
+/// of the two floors in play, since `--is-shallow-repository` alone only
+/// needs ≥ 2.15; below 2.31 the whole preflight silently skips rather than
+/// announcing the version gap.
+///
+/// The reason to fail open: crashing the whole build because this one
+/// preflight could not ask git a question would be worse than skipping it.
+/// The reason is NOT — as this comment used to claim — that every other
+/// `linkage-check` rule already depends on git and would therefore catch a
+/// broken checkout anyway. It would not: every one of the eight catalog
+/// rules reads `tests/CATALOG.md` and the test sources off the filesystem,
+/// not through git, so a checkout where git fails but files are readable —
+/// exactly the `dubious ownership` case — runs the whole suite to a green
+/// exit with this preflight silently absent. The reason is still printed,
+/// not swallowed, in a `linkage-check:`-prefixed block shaped like the
+/// failure path's in `main.rs`, so a skip is not the one outcome with no
+/// machine-readable trace.
 fn failures_from(collected: Result<RepoState, String>) -> Vec<String> {
     match collected {
         Ok(state) => preflight_failures(&state),
         Err(reason) => {
-            eprintln!("xtask linkage-check: repository-state preflight skipped: {reason}");
+            eprintln!(
+                "linkage-check: repository-state preflight: skipped (git unavailable or not usable):"
+            );
+            eprintln!("  {reason}");
             Vec::new()
         }
     }
@@ -276,6 +401,7 @@ mod tests {
         WorktreeEntry {
             path: PathBuf::from(path),
             exists,
+            prunable_reason: None,
         }
     }
 
@@ -347,14 +473,6 @@ mod tests {
         );
     }
 
-    /// A shallow repository that is genuinely exempt AND has no drift stays
-    /// silent — the count/linked gate and the drift check are independent.
-    #[test]
-    fn a_shallow_single_worktree_repo_with_no_drift_is_silent() {
-        let s = state(true, vec![entry("/repo", true)], "/repo", false);
-        assert!(preflight_failures(&s).is_empty());
-    }
-
     /// Registry drift: an entry whose path is gone is reported with the
     /// path named and the prune remedy, even when the repository is not
     /// shallow at all.
@@ -412,6 +530,29 @@ mod tests {
         );
     }
 
+    /// git's own `prunable` reason, when present, is folded into the drift
+    /// message instead of a message we compose from scratch.
+    #[test]
+    fn registry_drift_message_includes_gits_own_reason_when_present() {
+        let s = state(
+            false,
+            vec![WorktreeEntry {
+                path: PathBuf::from("/repo/gone"),
+                exists: false,
+                prunable_reason: Some("gitdir file points to non-existent location".to_string()),
+            }],
+            "/repo/main",
+            false,
+        );
+        let failures = preflight_failures(&s);
+        assert_eq!(failures.len(), 1, "{failures:?}");
+        assert!(
+            failures[0].contains("gitdir file points to non-existent location"),
+            "{}",
+            failures[0]
+        );
+    }
+
     /// A healthy multi-worktree, non-shallow repository passes with no
     /// findings at all.
     #[test]
@@ -427,9 +568,10 @@ mod tests {
 
     /// Deliberate decision for the git-unavailable case (issue #557: "fail
     /// closed, carefully"): a `collect` failure — git missing, not a
-    /// repository at all — is treated as a PASS rather than crashing the
-    /// build, because every other `linkage-check` rule already assumes a
-    /// working git checkout to run at all.
+    /// repository at all, a bare repo, dubious ownership, an old git — is
+    /// treated as a PASS rather than crashing the build. See
+    /// [`failures_from`]'s doc comment for why, and for why that is NOT
+    /// because another `linkage-check` rule would catch the same breakage.
     #[test]
     fn a_git_invocation_failure_is_treated_as_a_pass_not_a_crash() {
         let failures = failures_from(Err("git not found on PATH".to_string()));
@@ -451,33 +593,36 @@ mod tests {
         assert_eq!(failures.len(), 1, "{failures:?}");
     }
 
-    /// The primary checkout: measured directly, `--git-common-dir` and
-    /// `--git-dir` print the identical string, whether relative (from a
-    /// subdirectory) or the historical `.git` form — never a linked
-    /// worktree.
+    /// The primary checkout: measured directly against git 2.55.0 with
+    /// `--path-format=absolute` (which [`collect`] always passes), both
+    /// dir flags print the identical absolute path — from the toplevel AND
+    /// from a subdirectory. Unlike before this fix, there is no
+    /// relative-form fixture here: with `--path-format=absolute` in play, a
+    /// relative pair is not a shape git can produce, so pinning one would
+    /// pin a fiction again (fork PR #558 review, F1/F2).
     #[test]
     fn is_linked_worktree_is_false_for_the_primary_checkout() {
-        assert!(!is_linked_worktree(".git", ".git"));
-        assert!(!is_linked_worktree("../.git", "../.git"));
         assert!(!is_linked_worktree(
-            "/Users/dev/repo/.git",
-            "/Users/dev/repo/.git"
+            Path::new("/Users/dev/repo/.git"),
+            Path::new("/Users/dev/repo/.git")
         ));
     }
 
     /// A linked worktree: measured directly, `--git-common-dir` is the
     /// common dir's absolute path and `--git-dir` is its
-    /// `worktrees/<name>` subdirectory — always unequal by construction.
+    /// `worktrees/<name>` subdirectory — always unequal by construction,
+    /// from the worktree's own toplevel AND from a subdirectory of it
+    /// (verified at both depths against real git 2.55.0).
     #[test]
     fn is_linked_worktree_is_true_for_a_linked_worktree() {
         assert!(is_linked_worktree(
-            "/Users/dev/repo/.git",
-            "/Users/dev/repo/.git/worktrees/repo-fix123"
+            Path::new("/Users/dev/repo/.git"),
+            Path::new("/Users/dev/repo/.git/worktrees/repo-fix123")
         ));
     }
 
     #[test]
-    fn parse_worktree_paths_extracts_only_the_worktree_lines() {
+    fn parse_worktree_entries_extracts_only_the_worktree_lines() {
         let porcelain = "worktree /repo/main\n\
                           HEAD 9c131d5455485369f6b6b7c9ac8cdd9d5482241d\n\
                           branch refs/heads/main\n\
@@ -485,8 +630,12 @@ mod tests {
                           worktree /repo/fix-123\n\
                           HEAD 4e402c166433f702351f18e6e26c51205e19df1e\n\
                           branch refs/heads/fix/123-something\n";
+        let paths: Vec<PathBuf> = parse_worktree_entries(porcelain.as_bytes())
+            .into_iter()
+            .map(|e| e.path)
+            .collect();
         assert_eq!(
-            parse_worktree_paths(porcelain),
+            paths,
             vec![PathBuf::from("/repo/main"), PathBuf::from("/repo/fix-123")]
         );
     }
@@ -495,21 +644,92 @@ mod tests {
     /// `detached`; the parser only looks for the `worktree ` prefix, so
     /// these shapes cannot break it.
     #[test]
-    fn parse_worktree_paths_is_indifferent_to_bare_and_detached_entries() {
+    fn parse_worktree_entries_is_indifferent_to_bare_and_detached_entries() {
         let porcelain = "worktree /repo/bare\n\
                           bare\n\
                           \n\
                           worktree /repo/detached\n\
                           HEAD 9c131d5455485369f6b6b7c9ac8cdd9d5482241d\n\
                           detached\n";
+        let paths: Vec<PathBuf> = parse_worktree_entries(porcelain.as_bytes())
+            .into_iter()
+            .map(|e| e.path)
+            .collect();
         assert_eq!(
-            parse_worktree_paths(porcelain),
+            paths,
             vec![PathBuf::from("/repo/bare"), PathBuf::from("/repo/detached")]
         );
     }
 
     #[test]
-    fn parse_worktree_paths_on_empty_input_is_empty() {
-        assert!(parse_worktree_paths("").is_empty());
+    fn parse_worktree_entries_on_empty_input_is_empty() {
+        assert!(parse_worktree_entries(b"").is_empty());
+    }
+
+    /// git ≥ 2.36 reports drift itself; the `prunable` line attaches to the
+    /// block it appears in, and an entry with none gets `None` (the
+    /// [`collect`] caller falls back to `Path::try_exists()` for those).
+    #[test]
+    fn parse_worktree_entries_attaches_prunable_reason_to_its_block() {
+        let porcelain = "worktree /repo/main\n\
+                          HEAD 9c131d5455485369f6b6b7c9ac8cdd9d5482241d\n\
+                          branch refs/heads/main\n\
+                          \n\
+                          worktree /repo/gone\n\
+                          HEAD 4e402c166433f702351f18e6e26c51205e19df1e\n\
+                          branch refs/heads/gone\n\
+                          prunable gitdir file points to non-existent location\n";
+        let entries = parse_worktree_entries(porcelain.as_bytes());
+        assert_eq!(entries.len(), 2, "{entries:?}");
+        assert_eq!(entries[0].prunable_reason, None);
+        assert_eq!(
+            entries[1].prunable_reason.as_deref(),
+            Some("gitdir file points to non-existent location")
+        );
+    }
+
+    /// Reproduces the fail-green case a security audit found in the first
+    /// version of this preflight (fork PR #558 review, auditor F1): git
+    /// accepts a literal newline inside a worktree path, and `--porcelain`
+    /// emits it unescaped, splitting one entry's block across two lines —
+    /// `junk` here is the tail of the real path, not a new entry, since it
+    /// does not start with `worktree `. The `path` field this parser
+    /// produces is therefore truncated and wrong, but the `prunable` line
+    /// several lines later is still correctly attached to the SAME block —
+    /// which is what lets [`collect`] report the drift correctly even
+    /// though the path used for display is mangled. Byte-for-byte against
+    /// real `git worktree list --porcelain` output.
+    #[test]
+    fn parse_worktree_entries_still_flags_drift_when_the_path_contains_a_newline() {
+        let porcelain = "worktree /repo/green/keep\n\
+                          junk\n\
+                          HEAD 1fb69e17f2d79d384969cdb648969ab3459524da\n\
+                          branch refs/heads/sneaky\n\
+                          prunable gitdir file points to non-existent location\n";
+        let entries = parse_worktree_entries(porcelain.as_bytes());
+        assert_eq!(entries.len(), 1, "{entries:?}");
+        assert_eq!(entries[0].path, PathBuf::from("/repo/green/keep"));
+        assert_eq!(
+            entries[0].prunable_reason.as_deref(),
+            Some("gitdir file points to non-existent location")
+        );
+    }
+
+    /// A single non-UTF-8 byte in a git-reported path (legal on Linux;
+    /// ext4/xfs accept any byte but `/` and NUL) must not corrupt the path
+    /// through a lossy round-trip — that would break the byte-exact equality
+    /// [`is_linked_worktree`] and the degenerate-case match in
+    /// [`preflight_failures`] depend on, and `String::from_utf8` would hard-
+    /// fail the whole preflight over one unrelated worktree's odd byte
+    /// (fork PR #558 review, auditor F4). Unix-only: [`os_string_from_bytes`]
+    /// falls back to lossy UTF-8 off Unix, where this preflight does not run
+    /// in CI anyway.
+    #[cfg(unix)]
+    #[test]
+    fn os_string_from_bytes_preserves_non_utf8_bytes_exactly() {
+        use std::os::unix::ffi::OsStrExt;
+        let bytes = [b'/', b'r', b'e', b'p', 0xFF, b'o'];
+        let os = os_string_from_bytes(&bytes);
+        assert_eq!(os.as_bytes(), &bytes[..]);
     }
 }

--- a/xtask/linkage-check/src/repo_state.rs
+++ b/xtask/linkage-check/src/repo_state.rs
@@ -36,9 +36,9 @@
 //! [`collect`] is the only part of this module that shells out to git; it
 //! turns two git invocations' worth of output into a plain [`RepoState`].
 //! Everything that decides pass/fail — [`should_assert_shallow`],
-//! [`preflight_failures`], [`is_linked_worktree`], [`parse_worktree_entries`]
-//! — is a pure function over already-collected values, so it is unit-tested
-//! without building a real git repository.
+//! [`preflight_failures`], [`is_linked_worktree`], [`parse_worktree_entries`],
+//! [`parse_rev_parse`] — is a pure function over already-collected values, so
+//! it is unit-tested without building a real git repository.
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -245,78 +245,161 @@ fn preflight_failures(state: &RepoState) -> Vec<String> {
     failures
 }
 
-/// Shells out to git and turns the output into a [`RepoState`]. The only
-/// part of this module that is not a pure function.
+/// What [`parse_rev_parse`] reads out of the combined `rev-parse` output.
+#[derive(Debug, PartialEq)]
+struct RevParse {
+    is_shallow: bool,
+    current_worktree: PathBuf,
+    is_linked_worktree: bool,
+    /// True when the path fields could not be trusted because one of them
+    /// contained a literal newline — see [`parse_rev_parse`]. `is_shallow`
+    /// is still exact; `is_linked_worktree` has been forced to the
+    /// fail-safe value.
+    paths_degraded: bool,
+}
+
+/// Positional parse of the combined `rev-parse` output.
 ///
-/// Two invocations, kept to that count deliberately (issue #557: "stay
-/// cheap"): one combined `rev-parse` for the toplevel, both git-dir flags
-/// and the shallow check, plus one `worktree list --porcelain`.
-/// `--path-format=absolute` is what makes [`is_linked_worktree`]'s
-/// comparison sound rather than incidental — see its doc comment.
-fn collect(root: &Path) -> Result<RepoState, String> {
-    let rev_parse = run_git(
-        root,
-        &[
-            "rev-parse",
-            "--path-format=absolute",
-            "--show-toplevel",
-            "--git-common-dir",
-            "--git-dir",
-            "--is-shallow-repository",
-        ],
-    )?;
-    let mut lines = rev_parse.split(|&b| b == b'\n');
-    let show_toplevel = lines
-        .next()
-        .ok_or_else(|| "git rev-parse produced no output".to_string())?;
-    let git_common_dir = lines
-        .next()
-        .ok_or_else(|| "git rev-parse: missing --git-common-dir output".to_string())?;
-    let git_dir = lines
-        .next()
-        .ok_or_else(|| "git rev-parse: missing --git-dir output".to_string())?;
-    let is_shallow_raw = lines
-        .next()
-        .ok_or_else(|| "git rev-parse: missing --is-shallow-repository output".to_string())?;
-    let is_shallow = match is_shallow_raw {
-        b"true" => true,
-        b"false" => false,
-        other => {
+/// **`--is-shallow-repository` is requested FIRST, and the order is
+/// load-bearing** (Greptile P1 on PR #558). git accepts a literal newline
+/// inside a worktree path, and `rev-parse` emits path values unescaped, so
+/// a newline in the current checkout's own path splits one value across two
+/// lines and shifts every field after it. When the shallow flag was
+/// requested last it absorbed that shift, landed on a path instead of
+/// `true`/`false`, and returned `Err` — which [`failures_from`] turns into
+/// a **silent skip of the entire preflight**, shallow assertion included.
+/// Measured against real git 2.55.0 in a worktree whose path contains a
+/// newline: five output lines, not four. That is a fail-green in exactly
+/// the configuration the preflight is supposed to be unconditionally active
+/// in — a linked worktree.
+///
+/// Asking for the fixed-shape value first makes it line 0, where no amount
+/// of path weirdness can displace it. The path fields can still shift, so
+/// when more of them arrive than were asked for, this reports
+/// `is_linked_worktree = true` rather than comparing two mismatched
+/// strings: that is the fail-SAFE direction (it only makes
+/// [`should_assert_shallow`] assert more), where the old behaviour failed
+/// green. This is the same principle the byte-level handling already
+/// follows — one odd path degrades that path, never the shallow assertion,
+/// which has nothing to do with paths.
+///
+/// A trailing `\r` is stripped per line: the previous `String`-based
+/// implementation went through `str::lines()`, which strips it, and the
+/// move to a byte split silently dropped that. Without it, CRLF output
+/// would leave every field with a trailing `\r` and make
+/// [`is_linked_worktree`] compare unequal for a primary checkout — the same
+/// false positive `--path-format=absolute` exists to prevent.
+fn parse_rev_parse(stdout: &[u8]) -> Result<RevParse, String> {
+    let lines: Vec<&[u8]> = stdout
+        .split(|&b| b == b'\n')
+        .map(|line| line.strip_suffix(b"\r").unwrap_or(line))
+        .collect();
+
+    let is_shallow = match lines.first().copied() {
+        None => return Err("git rev-parse produced no output".to_string()),
+        Some(b"true") => true,
+        Some(b"false") => false,
+        Some(other) => {
             return Err(format!(
                 "unexpected --is-shallow-repository output {:?}",
                 String::from_utf8_lossy(other)
             ));
         }
     };
-    let git_common_dir = PathBuf::from(os_string_from_bytes(git_common_dir));
-    let git_dir = PathBuf::from(os_string_from_bytes(git_dir));
+
+    // `--show-toplevel --git-common-dir --git-dir`, in that order.
+    let paths = &lines[1..];
+    if paths.len() < 3 {
+        return Err(format!(
+            "git rev-parse: expected 3 path values after --is-shallow-repository, got {}",
+            paths.len()
+        ));
+    }
+    let current_worktree = PathBuf::from(os_string_from_bytes(paths[0]));
+    if paths.len() > 3 {
+        return Ok(RevParse {
+            is_shallow,
+            current_worktree,
+            is_linked_worktree: true,
+            paths_degraded: true,
+        });
+    }
+    let git_common_dir = PathBuf::from(os_string_from_bytes(paths[1]));
+    let git_dir = PathBuf::from(os_string_from_bytes(paths[2]));
+    Ok(RevParse {
+        is_shallow,
+        current_worktree,
+        is_linked_worktree: is_linked_worktree(&git_common_dir, &git_dir),
+        paths_degraded: false,
+    })
+}
+
+/// Shells out to git and turns the output into a [`RepoState`]. The only
+/// part of this module that is not a pure function.
+///
+/// Two invocations, kept to that count deliberately (issue #557: "stay
+/// cheap"): one combined `rev-parse` for the shallow check, the toplevel
+/// and both git-dir flags, plus one `worktree list --porcelain`.
+/// `--path-format=absolute` is what makes [`is_linked_worktree`]'s
+/// comparison sound rather than incidental — see its doc comment — and the
+/// **argument order** is what keeps a newline in a path from disabling the
+/// whole preflight; see [`parse_rev_parse`].
+fn collect(root: &Path) -> Result<RepoState, String> {
+    let rev_parse = run_git(
+        root,
+        &[
+            "rev-parse",
+            "--path-format=absolute",
+            "--is-shallow-repository",
+            "--show-toplevel",
+            "--git-common-dir",
+            "--git-dir",
+        ],
+    )?;
+    let parsed = parse_rev_parse(&rev_parse)?;
+    if parsed.paths_degraded {
+        eprintln!(
+            "linkage-check: repository-state preflight: a git-reported path contains a newline; \
+             treating this checkout as a linked worktree so the shallow assertion still applies."
+        );
+    }
 
     let porcelain = run_git(root, &["worktree", "list", "--porcelain"])?;
     let worktrees = parse_worktree_entries(&porcelain)
         .into_iter()
-        .map(|parsed| {
+        .map(|entry| {
             // Unreadable (e.g. EACCES on a live worktree under an unreadable
             // parent) is not evidence of drift — degrade to "present"
             // rather than the false positive `Path::exists()` gives here
             // (it returns `false` on ANY error, permission denied
             // included).
-            let exists = match &parsed.prunable_reason {
+            //
+            // `paths_degraded` gets the same treatment for the same reason.
+            // A newline in a git-reported path truncates the `path` field
+            // here exactly as it does in `rev-parse`, so `try_exists()`
+            // would be asking about a path that was never on disk and would
+            // report a live worktree as drifted. git's own `prunable`
+            // verdict is unaffected by the mangling — that is why drift
+            // keys off it — so when the path text cannot be trusted, trust
+            // only what git said.
+            let exists = match &entry.prunable_reason {
                 Some(_) => false,
-                None => parsed.path.try_exists().unwrap_or(true),
+                None if parsed.paths_degraded => true,
+                None => entry.path.try_exists().unwrap_or(true),
             };
             WorktreeEntry {
-                path: parsed.path,
+                path: entry.path,
                 exists,
-                prunable_reason: parsed.prunable_reason,
+                prunable_reason: entry.prunable_reason,
             }
         })
         .collect();
 
     Ok(RepoState {
-        is_shallow,
+        is_shallow: parsed.is_shallow,
         worktrees,
-        current_worktree: PathBuf::from(os_string_from_bytes(show_toplevel)),
-        is_linked_worktree: is_linked_worktree(&git_common_dir, &git_dir),
+        current_worktree: parsed.current_worktree,
+        is_linked_worktree: parsed.is_linked_worktree,
     })
 }
 
@@ -355,8 +438,8 @@ fn run_git(root: &Path, args: &[&str]) -> Result<Vec<u8>, String> {
 /// a different uid than the checkout's owner hits on an otherwise perfectly
 /// healthy repository — an ordinary state, not an exotic one; any other
 /// non-zero git exit; and an unrecognised `rev-parse` flag on an older git,
-/// which git echoes verbatim to stdout while exiting 0, failing the
-/// positional parse in [`collect`] and routing here too. `collect` now
+/// which git echoes verbatim to stdout while exiting 0, failing
+/// [`parse_rev_parse`] and routing here too. `collect` now
 /// requires git ≥ 2.31 (`--path-format`, added that release) — the higher
 /// of the two floors in play, since `--is-shallow-repository` alone only
 /// needs ≥ 2.15; below 2.31 the whole preflight silently skips rather than
@@ -713,6 +796,109 @@ mod tests {
             entries[0].prunable_reason.as_deref(),
             Some("gitdir file points to non-existent location")
         );
+    }
+
+    /// The ordinary shape: shallow flag first, then the three path values.
+    #[test]
+    fn parse_rev_parse_reads_the_primary_checkout() {
+        let out = b"false\n/repo\n/repo/.git\n/repo/.git" as &[u8];
+        let parsed = parse_rev_parse(out).expect("parses");
+        assert_eq!(
+            parsed,
+            RevParse {
+                is_shallow: false,
+                current_worktree: PathBuf::from("/repo"),
+                is_linked_worktree: false,
+                paths_degraded: false,
+            }
+        );
+    }
+
+    /// A linked worktree: `--git-dir` is the `worktrees/<name>`
+    /// subdirectory, so the two dir flags compare unequal.
+    #[test]
+    fn parse_rev_parse_reads_a_linked_worktree() {
+        let out = b"true\n/repo/wt\n/repo/.git\n/repo/.git/worktrees/wt" as &[u8];
+        let parsed = parse_rev_parse(out).expect("parses");
+        assert!(parsed.is_shallow);
+        assert!(parsed.is_linked_worktree);
+        assert!(!parsed.paths_degraded);
+    }
+
+    /// **The Greptile P1 regression test.** Byte-for-byte the output real
+    /// git 2.55.0 produced from a linked worktree whose path contains a
+    /// literal newline, with `--is-shallow-repository` requested FIRST:
+    /// five lines instead of four. Before the reorder the shallow flag was
+    /// last, absorbed the shift, landed on a path instead of
+    /// `true`/`false`, and returned `Err` — which `failures_from` turns
+    /// into a silent skip of the WHOLE preflight. Now the flag is exact,
+    /// nothing returns `Err`, and the untrustworthy path comparison
+    /// degrades to the fail-safe `is_linked_worktree = true` instead of the
+    /// old fail-green.
+    #[test]
+    fn parse_rev_parse_survives_a_newline_inside_a_path() {
+        let out = b"false\n/probe/wt\nnewline\n/probe/origin/.git\n\
+                    /probe/origin/.git/worktrees/wt-newline" as &[u8];
+        let parsed = parse_rev_parse(out).expect("must NOT be an Err — Err means a silent skip");
+        assert!(!parsed.is_shallow, "the shallow flag must still be exact");
+        assert!(
+            parsed.is_linked_worktree,
+            "must degrade to the fail-safe direction, not fail green"
+        );
+        assert!(parsed.paths_degraded);
+    }
+
+    /// The same shift, in a repository that IS shallow: the whole point of
+    /// the reorder is that this case now reports the shallow failure rather
+    /// than skipping silently.
+    #[test]
+    fn a_shallow_repo_with_a_newline_path_still_reports_the_shallow_failure() {
+        let out = b"true\n/probe/wt\nnewline\n/probe/origin/.git\n\
+                    /probe/origin/.git/worktrees/wt-newline" as &[u8];
+        let parsed = parse_rev_parse(out).expect("parses");
+        let s = state(
+            parsed.is_shallow,
+            vec![entry("/probe/wt", true)],
+            "/probe/wt",
+            parsed.is_linked_worktree,
+        );
+        let failures = preflight_failures(&s);
+        assert_eq!(failures.len(), 1, "{failures:?}");
+        assert!(
+            failures[0].contains("git fetch --unshallow"),
+            "{}",
+            failures[0]
+        );
+    }
+
+    /// A trailing `\r` per line is stripped. `str::lines()` used to do this
+    /// for free; the byte split does not, and without it CRLF output would
+    /// make the two dir flags compare unequal for a primary checkout — the
+    /// same false positive `--path-format=absolute` exists to prevent
+    /// (fork PR #558 review, R2-2).
+    #[test]
+    fn parse_rev_parse_strips_carriage_returns() {
+        let out = b"false\r\n/repo\r\n/repo/.git\r\n/repo/.git" as &[u8];
+        let parsed = parse_rev_parse(out).expect("parses");
+        assert_eq!(parsed.current_worktree, PathBuf::from("/repo"));
+        assert!(
+            !parsed.is_linked_worktree,
+            "a stray \\r must not read as a linked worktree"
+        );
+    }
+
+    /// An older git echoes an unrecognised flag verbatim to stdout while
+    /// exiting 0. That is not `true`/`false`, so it is an honest `Err` —
+    /// routed to the documented fail-open skip rather than guessed at.
+    #[test]
+    fn parse_rev_parse_rejects_output_that_is_not_the_shallow_flag() {
+        let out = b"--path-format=absolute\n/repo\n/repo/.git\n/repo/.git" as &[u8];
+        assert!(parse_rev_parse(out).is_err());
+    }
+
+    #[test]
+    fn parse_rev_parse_rejects_truncated_output() {
+        assert!(parse_rev_parse(b"false\n/repo").is_err());
     }
 
     /// A single non-UTF-8 byte in a git-reported path (legal on Linux;

--- a/xtask/linkage-check/src/repo_state.rs
+++ b/xtask/linkage-check/src/repo_state.rs
@@ -144,6 +144,17 @@ fn os_string_from_bytes(bytes: &[u8]) -> OsString {
     }
 }
 
+/// Record terminator for `git worktree list --porcelain -z` (git ≥ 2.36).
+/// NUL cannot occur inside a path on any supported platform, so a newline
+/// in a worktree path is unambiguous here — which is the whole reason to
+/// prefer it.
+const RECORD_NUL: u8 = b'\0';
+
+/// Record terminator for plain `--porcelain`, the git < 2.36 fallback.
+/// A newline inside a path is indistinguishable from a record break in this
+/// form, which is what [`ParsedWorktree::path_maybe_truncated`] exists for.
+const RECORD_LF: u8 = b'\n';
+
 /// One `git worktree list --porcelain` entry as parsed, before the
 /// filesystem existence check ([`collect`] does that).
 #[derive(Debug)]
@@ -194,10 +205,15 @@ fn is_known_attribute_line(line: &[u8]) -> bool {
 /// recognised prefixes — including the tail end of a newline-split path —
 /// is silently skipped rather than treated as a new entry, since only a
 /// `worktree ` line ever starts one.
-fn parse_worktree_entries(porcelain: &[u8]) -> Vec<ParsedWorktree> {
+///
+/// `sep` is the record terminator: [`RECORD_NUL`] when [`collect`] got the
+/// `-z` output (git ≥ 2.36), where a newline inside a path cannot split a
+/// record at all and `path_maybe_truncated` is therefore never set;
+/// [`RECORD_LF`] on the older fallback, where it can and is.
+fn parse_worktree_entries(porcelain: &[u8], sep: u8) -> Vec<ParsedWorktree> {
     let mut out = Vec::new();
     let mut current: Option<ParsedWorktree> = None;
-    for line in porcelain.split(|&b| b == b'\n') {
+    for line in porcelain.split(|&b| b == sep) {
         if let Some(rest) = line.strip_prefix(b"worktree ") {
             if let Some(entry) = current.take() {
                 out.push(entry);
@@ -356,10 +372,25 @@ fn parse_rev_parse(stdout: &[u8]) -> Result<RevParse, String> {
     }
     let current_worktree = PathBuf::from(os_string_from_bytes(paths[0]));
     if paths.len() > 3 {
+        // A path field occupied more than one line, so `git_common_dir` and
+        // `git_dir` cannot be identified and `is_linked_worktree` is not
+        // answerable from this output. Report it as FALSE rather than true.
+        //
+        // Forcing `true` here looks like the fail-safe choice and is not:
+        // it turns the shallow assertion on for a shallow, single-worktree
+        // PRIMARY checkout that merely has a newline in its path, which is
+        // precisely the exemption issue #557 requires to hold structurally
+        // (Greptile P1 on PR #558, against the previous commit). The
+        // multi-worktree case does not need this term anyway —
+        // `should_assert_shallow` also fires on `worktrees.len() > 1`, and a
+        // linked worktree always implies at least two registry entries, so
+        // the count carries it. What is genuinely lost is only the
+        // belt-and-braces for a checkout that is BOTH linked AND has a
+        // registry too drifted to show two entries.
         return Ok(RevParse {
             is_shallow,
             current_worktree,
-            is_linked_worktree: true,
+            is_linked_worktree: false,
             paths_degraded: true,
         });
     }
@@ -398,13 +429,25 @@ fn collect(root: &Path) -> Result<RepoState, String> {
     let parsed = parse_rev_parse(&rev_parse)?;
     if parsed.paths_degraded {
         eprintln!(
-            "linkage-check: repository-state preflight: a git-reported path contains a newline; \
-             treating this checkout as a linked worktree so the shallow assertion still applies."
+            "linkage-check: repository-state preflight: a git-reported path contains a newline, \
+             so this checkout's linked-worktree status could not be determined; the shallow \
+             assertion still applies via the worktree count."
         );
     }
 
-    let porcelain = run_git(root, &["worktree", "list", "--porcelain"])?;
-    let worktrees = parse_worktree_entries(&porcelain)
+    // `-z` (git ≥ 2.36) terminates each record with NUL, so a newline inside
+    // a worktree path cannot split a record and every path arrives exact.
+    // That is what makes the truncation handling below dead code on any
+    // modern git rather than merely well-tested. Older git rejects the flag,
+    // so fall back to the newline form and accept its ambiguity there.
+    let (porcelain, sep) = match run_git(root, &["worktree", "list", "--porcelain", "-z"]) {
+        Ok(out) => (out, RECORD_NUL),
+        Err(_) => (
+            run_git(root, &["worktree", "list", "--porcelain"])?,
+            RECORD_LF,
+        ),
+    };
+    let worktrees = parse_worktree_entries(&porcelain, sep)
         .into_iter()
         .map(|entry| {
             // Unreadable (e.g. EACCES on a live worktree under an unreadable
@@ -756,7 +799,7 @@ mod tests {
                           worktree /repo/fix-123\n\
                           HEAD 4e402c166433f702351f18e6e26c51205e19df1e\n\
                           branch refs/heads/fix/123-something\n";
-        let paths: Vec<PathBuf> = parse_worktree_entries(porcelain.as_bytes())
+        let paths: Vec<PathBuf> = parse_worktree_entries(porcelain.as_bytes(), RECORD_LF)
             .into_iter()
             .map(|e| e.path)
             .collect();
@@ -777,7 +820,7 @@ mod tests {
                           worktree /repo/detached\n\
                           HEAD 9c131d5455485369f6b6b7c9ac8cdd9d5482241d\n\
                           detached\n";
-        let paths: Vec<PathBuf> = parse_worktree_entries(porcelain.as_bytes())
+        let paths: Vec<PathBuf> = parse_worktree_entries(porcelain.as_bytes(), RECORD_LF)
             .into_iter()
             .map(|e| e.path)
             .collect();
@@ -789,7 +832,7 @@ mod tests {
 
     #[test]
     fn parse_worktree_entries_on_empty_input_is_empty() {
-        assert!(parse_worktree_entries(b"").is_empty());
+        assert!(parse_worktree_entries(b"", RECORD_LF).is_empty());
     }
 
     /// git ≥ 2.36 reports drift itself; the `prunable` line attaches to the
@@ -805,7 +848,7 @@ mod tests {
                           HEAD 4e402c166433f702351f18e6e26c51205e19df1e\n\
                           branch refs/heads/gone\n\
                           prunable gitdir file points to non-existent location\n";
-        let entries = parse_worktree_entries(porcelain.as_bytes());
+        let entries = parse_worktree_entries(porcelain.as_bytes(), RECORD_LF);
         assert_eq!(entries.len(), 2, "{entries:?}");
         assert_eq!(entries[0].prunable_reason, None);
         assert_eq!(
@@ -832,7 +875,7 @@ mod tests {
                           HEAD 1fb69e17f2d79d384969cdb648969ab3459524da\n\
                           branch refs/heads/sneaky\n\
                           prunable gitdir file points to non-existent location\n";
-        let entries = parse_worktree_entries(porcelain.as_bytes());
+        let entries = parse_worktree_entries(porcelain.as_bytes(), RECORD_LF);
         assert_eq!(entries.len(), 1, "{entries:?}");
         assert_eq!(entries[0].path, PathBuf::from("/repo/green/keep"));
         assert_eq!(
@@ -866,7 +909,7 @@ mod tests {
                           worktree /repo/ordinary-stale\n\
                           HEAD 4e402c166433f702351f18e6e26c51205e19df1e\n\
                           branch refs/heads/stale\n";
-        let entries = parse_worktree_entries(porcelain.as_bytes());
+        let entries = parse_worktree_entries(porcelain.as_bytes(), RECORD_LF);
         assert_eq!(entries.len(), 2, "{entries:?}");
         assert!(entries[0].path_maybe_truncated);
         assert!(
@@ -874,6 +917,48 @@ mod tests {
             "an ordinary sibling entry must keep its real existence check"
         );
         assert_eq!(entries[1].prunable_reason, None);
+    }
+
+    /// **The structural fix for the newline class.** Byte-for-byte the
+    /// record layout real `git worktree list --porcelain -z` produces on
+    /// git 2.55.0 for a worktree whose path contains a literal newline:
+    /// records are NUL-terminated, so the newline sits harmlessly INSIDE
+    /// the `worktree ` record instead of splitting it. The path arrives
+    /// exact, nothing is truncated, and `path_maybe_truncated` — with it,
+    /// the whole "which entry can I not verify" question that produced two
+    /// Greptile P1s — is unreachable on any git ≥ 2.36.
+    #[test]
+    fn nul_terminated_records_keep_a_newline_path_intact() {
+        let porcelain = b"worktree /repo/wt\nnewline\0\
+                          HEAD 9c131d5455485369f6b6b7c9ac8cdd9d5482241d\0\
+                          branch refs/heads/sneaky\0\0\
+                          worktree /repo/ordinary\0\
+                          HEAD 4e402c166433f702351f18e6e26c51205e19df1e\0\0"
+            as &[u8];
+        let entries = parse_worktree_entries(porcelain, RECORD_NUL);
+        assert_eq!(entries.len(), 2, "{entries:?}");
+        assert_eq!(entries[0].path, PathBuf::from("/repo/wt\nnewline"));
+        assert!(
+            !entries[0].path_maybe_truncated,
+            "NUL records cannot truncate a path"
+        );
+        assert_eq!(entries[1].path, PathBuf::from("/repo/ordinary"));
+        assert!(!entries[1].path_maybe_truncated);
+    }
+
+    /// The same input read with the OLD newline terminator, to show what
+    /// `-z` actually buys: the path is truncated and the entry is flagged
+    /// unverifiable. This is the git < 2.36 fallback's behaviour, kept
+    /// honest rather than pretended away.
+    #[test]
+    fn the_lf_fallback_still_truncates_the_same_input() {
+        let porcelain = b"worktree /repo/wt\nnewline\n\
+                          HEAD 9c131d5455485369f6b6b7c9ac8cdd9d5482241d\n"
+            as &[u8];
+        let entries = parse_worktree_entries(porcelain, RECORD_LF);
+        assert_eq!(entries.len(), 1, "{entries:?}");
+        assert_eq!(entries[0].path, PathBuf::from("/repo/wt"));
+        assert!(entries[0].path_maybe_truncated);
     }
 
     /// Every attribute line git can emit inside an entry block must be
@@ -934,26 +1019,50 @@ mod tests {
     /// five lines instead of four. Before the reorder the shallow flag was
     /// last, absorbed the shift, landed on a path instead of
     /// `true`/`false`, and returned `Err` — which `failures_from` turns
-    /// into a silent skip of the WHOLE preflight. Now the flag is exact,
-    /// nothing returns `Err`, and the untrustworthy path comparison
-    /// degrades to the fail-safe `is_linked_worktree = true` instead of the
-    /// old fail-green.
+    /// into a silent skip of the WHOLE preflight. Now the flag is exact and
+    /// nothing returns `Err`; the unanswerable linked-worktree question
+    /// reports `false` and leaves the worktree count to carry the
+    /// multi-worktree case.
     #[test]
     fn parse_rev_parse_survives_a_newline_inside_a_path() {
         let out = b"false\n/probe/wt\nnewline\n/probe/origin/.git\n\
                     /probe/origin/.git/worktrees/wt-newline" as &[u8];
         let parsed = parse_rev_parse(out).expect("must NOT be an Err — Err means a silent skip");
         assert!(!parsed.is_shallow, "the shallow flag must still be exact");
-        assert!(
-            parsed.is_linked_worktree,
-            "must degrade to the fail-safe direction, not fail green"
-        );
         assert!(parsed.paths_degraded);
+        assert!(
+            !parsed.is_linked_worktree,
+            "an unanswerable question must not be answered `true` — that fires the shallow \
+             assertion on an exempt single-worktree primary checkout"
+        );
     }
 
-    /// The same shift, in a repository that IS shallow: the whole point of
-    /// the reorder is that this case now reports the shallow failure rather
-    /// than skipping silently.
+    /// **Greptile P1 regression test.** A shallow, single-worktree PRIMARY
+    /// checkout whose path contains a newline must stay EXEMPT. Forcing
+    /// `is_linked_worktree = true` on degradation broke exactly this: it
+    /// failed an otherwise-exempt `linkage-check`, which is the CI-breaking
+    /// direction issue #557 requires to be impossible by construction.
+    #[test]
+    fn a_newline_path_does_not_defeat_the_single_worktree_shallow_exemption() {
+        let out = b"true\n/probe/wt\nnewline\n/probe/.git\n/probe/.git" as &[u8];
+        let parsed = parse_rev_parse(out).expect("parses");
+        let s = state(
+            parsed.is_shallow,
+            vec![entry("/probe/wt", true)],
+            "/probe/wt",
+            parsed.is_linked_worktree,
+        );
+        assert!(
+            preflight_failures(&s).is_empty(),
+            "{:?}",
+            preflight_failures(&s)
+        );
+    }
+
+    /// The same shift in a repository that IS shallow AND has two registry
+    /// entries: the reorder means this now reports the shallow failure
+    /// rather than skipping silently, and the count — not the unanswerable
+    /// `is_linked_worktree` — is what carries it.
     #[test]
     fn a_shallow_repo_with_a_newline_path_still_reports_the_shallow_failure() {
         let out = b"true\n/probe/wt\nnewline\n/probe/origin/.git\n\
@@ -961,7 +1070,7 @@ mod tests {
         let parsed = parse_rev_parse(out).expect("parses");
         let s = state(
             parsed.is_shallow,
-            vec![entry("/probe/wt", true)],
+            vec![entry("/probe/origin", true), entry("/probe/wt", true)],
             "/probe/wt",
             parsed.is_linked_worktree,
         );

--- a/xtask/linkage-check/src/repo_state.rs
+++ b/xtask/linkage-check/src/repo_state.rs
@@ -150,6 +150,32 @@ fn os_string_from_bytes(bytes: &[u8]) -> OsString {
 struct ParsedWorktree {
     path: PathBuf,
     prunable_reason: Option<String>,
+    /// True when a line inside this entry's block matched none of the
+    /// attributes git emits — the signature of a path containing a literal
+    /// newline, which splits the `worktree <path>` line and leaves `path`
+    /// truncated. See [`is_known_attribute_line`].
+    path_maybe_truncated: bool,
+}
+
+/// Whether `line` is one of the attribute lines `git worktree list
+/// --porcelain` can emit inside an entry's block, or the blank separator.
+///
+/// Anything else is the tail of a path that contained a literal newline.
+/// The list is closed deliberately: treating an unrecognised line as "some
+/// attribute a future git added" would silently restore the fail-green this
+/// exists to catch, whereas treating a genuinely new attribute as a
+/// truncated path only costs one entry its existence check — the same
+/// fail-safe direction the rest of this module takes.
+fn is_known_attribute_line(line: &[u8]) -> bool {
+    line.is_empty()
+        || line == b"bare"
+        || line == b"detached"
+        || line == b"locked"
+        || line == b"prunable"
+        || line.starts_with(b"HEAD ")
+        || line.starts_with(b"branch ")
+        || line.starts_with(b"locked ")
+        || line.starts_with(b"prunable ")
 }
 
 /// Parse `git worktree list --porcelain` output into per-entry records, in
@@ -179,11 +205,24 @@ fn parse_worktree_entries(porcelain: &[u8]) -> Vec<ParsedWorktree> {
             current = Some(ParsedWorktree {
                 path: PathBuf::from(os_string_from_bytes(rest)),
                 prunable_reason: None,
+                path_maybe_truncated: false,
             });
         } else if let Some(rest) = line.strip_prefix(b"prunable ")
             && let Some(entry) = current.as_mut()
         {
             entry.prunable_reason = Some(String::from_utf8_lossy(rest).into_owned());
+        } else if !is_known_attribute_line(line)
+            && let Some(entry) = current.as_mut()
+        {
+            // A line matching none of the attributes git can emit is the
+            // tail of a path that contained a literal newline, so THIS
+            // entry's `path` is truncated. Recorded per-entry rather than
+            // globally: a sibling entry with an ordinary path is unaffected
+            // and must still get a normal existence check, or a genuinely
+            // stale worktree goes unreported (Greptile P1 on PR #558,
+            // against the first version of this fix, which suppressed drift
+            // for every entry at once).
+            entry.path_maybe_truncated = true;
         }
     }
     if let Some(entry) = current.take() {
@@ -374,17 +413,21 @@ fn collect(root: &Path) -> Result<RepoState, String> {
             // (it returns `false` on ANY error, permission denied
             // included).
             //
-            // `paths_degraded` gets the same treatment for the same reason.
-            // A newline in a git-reported path truncates the `path` field
-            // here exactly as it does in `rev-parse`, so `try_exists()`
-            // would be asking about a path that was never on disk and would
-            // report a live worktree as drifted. git's own `prunable`
-            // verdict is unaffected by the mangling — that is why drift
-            // keys off it — so when the path text cannot be trusted, trust
-            // only what git said.
+            // A truncated path gets the same treatment for the same reason:
+            // a newline in a git-reported path leaves `path` cut short, so
+            // `try_exists()` would be asking about a path that was never on
+            // disk and would report a live worktree as drifted. git's own
+            // `prunable` verdict is unaffected by the mangling — that is
+            // why drift keys off it — so where the path text cannot be
+            // trusted, trust only what git said.
+            //
+            // Gated per ENTRY, not on the whole run: an unrelated entry
+            // with an ordinary path still gets a real existence check, so a
+            // genuinely stale worktree is still reported even while a
+            // sibling entry's path is unreadable (Greptile P1 on PR #558).
             let exists = match &entry.prunable_reason {
                 Some(_) => false,
-                None if parsed.paths_degraded => true,
+                None if entry.path_maybe_truncated => true,
                 None => entry.path.try_exists().unwrap_or(true),
             };
             WorktreeEntry {
@@ -796,6 +839,66 @@ mod tests {
             entries[0].prunable_reason.as_deref(),
             Some("gitdir file points to non-existent location")
         );
+        assert!(
+            entries[0].path_maybe_truncated,
+            "the `junk` tail line must mark this entry's path untrustworthy"
+        );
+    }
+
+    /// **Greptile P1 regression test**, filed against the first version of
+    /// this fix: suppressing the existence check for the whole run whenever
+    /// ANY path was untrustworthy meant a separate, ordinary stale entry
+    /// went unreported, so `linkage-check` exited clean without ever
+    /// recommending `git worktree prune`. The suppression is now per-entry,
+    /// so the newline entry is spared the meaningless check while its
+    /// sibling is still tested normally.
+    ///
+    /// Reachable on any git that omits the `prunable` attribute for a stale
+    /// entry — git < 2.36, which predates it, and a **locked** worktree,
+    /// which git never marks prunable at any version.
+    #[test]
+    fn a_truncated_path_does_not_suppress_drift_for_an_unrelated_entry() {
+        let porcelain = "worktree /repo/newline/keep\n\
+                          junk\n\
+                          HEAD 1fb69e17f2d79d384969cdb648969ab3459524da\n\
+                          branch refs/heads/sneaky\n\
+                          \n\
+                          worktree /repo/ordinary-stale\n\
+                          HEAD 4e402c166433f702351f18e6e26c51205e19df1e\n\
+                          branch refs/heads/stale\n";
+        let entries = parse_worktree_entries(porcelain.as_bytes());
+        assert_eq!(entries.len(), 2, "{entries:?}");
+        assert!(entries[0].path_maybe_truncated);
+        assert!(
+            !entries[1].path_maybe_truncated,
+            "an ordinary sibling entry must keep its real existence check"
+        );
+        assert_eq!(entries[1].prunable_reason, None);
+    }
+
+    /// Every attribute line git can emit inside an entry block must be
+    /// recognised, or it would be mistaken for the tail of a newline-split
+    /// path and cost that entry its existence check.
+    #[test]
+    fn known_attribute_lines_are_not_mistaken_for_a_truncated_path() {
+        for line in [
+            &b""[..],
+            b"bare",
+            b"detached",
+            b"locked",
+            b"locked because I am testing",
+            b"prunable",
+            b"prunable gitdir file points to non-existent location",
+            b"HEAD 9c131d5455485369f6b6b7c9ac8cdd9d5482241d",
+            b"branch refs/heads/main",
+        ] {
+            assert!(
+                is_known_attribute_line(line),
+                "{:?} must be recognised",
+                String::from_utf8_lossy(line)
+            );
+        }
+        assert!(!is_known_attribute_line(b"tail-of-a-split-path"));
     }
 
     /// The ordinary shape: shallow flag first, then the three path values.


### PR DESCRIPTION
## Summary

A shallow object store breaks history operations across every worktree sharing it, and does so silently. `git log` works, `git status` is clean, refs resolve to the expected SHAs. The only symptom appears later, elsewhere, as `fatal: refusing to merge unrelated histories` — which reads as a wrong or corrupt remote, not as a truncated history. `.git/shallow` lives in the common dir, so one shallow fetch in one linked worktree degrades every worktree in the clone at once.

This adds a repository-state preflight to `cargo xtask linkage-check` that runs before the catalog/test checks and asserts:

- the object store is not unexpectedly shallow, naming the confirming probe (`git rev-list --max-parents=0 <ref>`) and the remedy (`git fetch --unshallow <remote>`) verbatim;
- the worktree registry has not drifted from what's on disk, naming the stale paths and `git worktree prune`;
- the current checkout's own worktree entry in particular still exists, since that's the degenerate case that would otherwise surface as a confusing "no such file or directory" from whatever runs next.

## The gate

The shallow assertion is gated structurally, not with an environment-variable escape hatch: it only applies when the repository has more than one worktree, or the current checkout is itself a linked worktree. Every `actions/checkout@v7` in `ci.yml` clones at the default depth of 1 with exactly one worktree, so CI is exempt by construction rather than by trusting an env var — which would be indistinguishable from a passing check and is how a check quietly stops running in the places that matter.

**The exemption is made true, not merely currently-satisfied.** `collect()` now passes `git rev-parse --path-format=absolute` alongside the toplevel/git-dir/shallow flags. Without it, `--git-common-dir` prints relative from a subdirectory of a primary checkout while `--git-dir` prints absolute — the two compare unequal, so `is_linked_worktree` would wrongly return `true`, which would turn the shallow assertion ON for a fresh, shallow, single-worktree CI clone. That never happened in practice because `collect()`'s caller (`repo_root()`) always resolves to the git toplevel in this repository today — but nothing asserted that invariant, and a nested/vendored layout would have hit it. With `--path-format=absolute` the comparison is sound regardless of where `collect()` is invoked from.

Verified this end-to-end against real git behavior (not just the unit tests below):
- a real `--depth 1` clone with one worktree → preflight passes, exit 0.
- the same shallow clone with the cargo workspace root pinned to a **nested subdirectory** (root ≠ git toplevel — the scenario the paragraph above describes) → preflight still passes; this is the case that would have false-positived before the `--path-format=absolute` fix.
- adding a second linked worktree to a shallow clone → preflight fails, names `git fetch --unshallow` and the confirming probe.
- running from inside the linked worktree itself → also fails, confirming `is_linked_worktree` catches it independently of the worktree count.
- ordinary worktree-registry drift (removed without `git worktree prune`) → reported, including git's own `prunable <reason>` text folded into the message.
- a worktree path containing an embedded newline, removed without pruning → still correctly reported as drift (see Design below for why this used to fail green).

Also ran unchanged against this branch's own worktree — a linked worktree in an 11-worktree, non-shallow repository — which exercises the healthy path for real and passed.

## Non-goals (per the issue)

- No auto-repair: neither `git fetch --unshallow` nor `git worktree prune` is ever run automatically.
- Fails, does not warn: exits non-zero.
- Detection, not prevention: a raw shallow fetch still succeeds; this only turns the resulting state into a named failure at the next `linkage-check` run.

## Design

`xtask/linkage-check/src/repo_state.rs` mirrors `clean_tmp.rs`'s shape: a thin `collect()` that shells out to git (one combined `rev-parse --path-format=absolute --show-toplevel --git-common-dir --git-dir --is-shallow-repository`, one `worktree list --porcelain` — two invocations total), handing already-collected values to pure verdict functions (`preflight_failures`, `should_assert_shallow`, `is_linked_worktree`, `parse_worktree_entries`) that are unit-tested without touching git or the filesystem.

`is_linked_worktree` compares `--git-common-dir` against `--git-dir` as absolute paths (`--path-format=absolute`, see "The gate" above for why that flag matters): in the primary checkout the two are always equal; in a linked worktree `--git-dir` is always a `worktrees/<name>` subdirectory of `--git-common-dir`, so they can never be equal there.

**Worktree-registry drift prefers git's own verdict.** `git worktree list --porcelain` already emits `prunable <reason>` for a drifted entry (git ≥ 2.36); the preflight keys off that instead of re-deriving drift with a bare `Path::exists()` call. Two reasons: git's `prunable` line survives a corrupted path field — git accepts a literal newline inside a worktree path and porcelain emits it unescaped, splitting one entry's block across two lines, which truncates the parsed `path` but not the `prunable` line several lines later in the same block, so a genuinely-removed worktree with a newline in its path is still correctly reported as drift rather than failing green; and `Path::try_exists()` (used as the fallback when git doesn't report `prunable` — either the entry is genuinely healthy, or the git is older than 2.36) degrades a permission error to "present" rather than the false positive `Path::exists()` gives on `EACCES`, which would otherwise point a developer at `git worktree prune` for a live worktree they simply can't stat.

Non-UTF-8 handling: git output is read as raw bytes and converted with an `OsStr`-based helper rather than `String::from_utf8`, so a single non-UTF-8 byte in one worktree's path (legal on Linux; ext4/xfs accept any byte but `/` and NUL) degrades only that path's display text rather than hard-failing the entire preflight, including the shallow assertion that has nothing to do with paths.

Git-unavailable case: a `collect()` failure is treated as a deliberate pass rather than a crash — crashing the whole build because this one preflight could not ask git a question would be worse than skipping it. The bucket routed here is wider than "not a repository, or git missing from PATH": it also covers a bare repository, `safe.directory`/"detected dubious ownership" refusals (an ordinary state in containerized CI running as a different uid than the checkout's owner), and an unrecognised `rev-parse` flag on an older git, which git echoes to stdout while exiting 0 — this preflight now requires git ≥ 2.31 for `--path-format`, the higher of the two version floors in play. None of the eight catalog checks below depend on git — they read `tests/CATALOG.md` and the test sources off the filesystem — so a checkout where git fails but files are readable runs the whole suite to a green exit with this preflight silently absent; the skip reason is printed with a `linkage-check:`-prefixed block (matching the failure path's shape) so that absence has a machine-readable trace. Pinned by `a_git_invocation_failure_is_treated_as_a_pass_not_a_crash`.

## Testing

All 13 unit tests in `repo_state.rs` run in CI: `ci.yml`'s `cargo nextest run --workspace` is what pulls `xtask/linkage-check`'s tests in (`--workspace` is exactly the flag that does it), so these gate every PR rather than being merely present.

## Known follow-ups (not addressed in this PR)

- **`list-tests` is the subcommand most exposed to shallow damage, and it doesn't get this preflight.** `main.rs` routes `docs`, `list-tests` and `clean-e2e-tmp` before the preflight runs. That's correct for `docs` and `clean-e2e-tmp` (neither touches git history), but `list-tests` runs `git merge-base HEAD origin/main` — exactly the history operation a shallow store breaks — so it can silently report a wrong "which tests changed" answer in the one subcommand most exposed to this issue's damage shape. Worth a follow-up.
- **The degenerate case (the current checkout's own registry entry gone missing) appears unreachable through the real CLI entry point.** With the current working directory deleted out from under the process, `getcwd()` fails and `repo_root()`'s `current_dir()` call panics before the preflight runs; from anywhere else, `--show-toplevel` names a directory that by definition exists. This is pre-existing behavior in `repo_root()`, not a defect in this change, and the branch is exercised by a synthetic unit test rather than an integration path — noting it so it isn't mistaken for dead code later.
- **Issue #557 names the single-worktree user as affected, then this preflight exempts exactly that user** (see "The gate" above — a single-worktree checkout is never asserted). The issue also acknowledges this ("keeps the check inert for the single-worktree user who has no exposure"), so this is intentional, not an oversight — noting it so a later reader doesn't "fix" the exemption into a CI break.

Closes #557


### One residual case the `prunable` switch does *not* fix

Disclosed rather than left for a reader to hit: **`EACCES` on the *parent* of an otherwise-healthy worktree still reports as drift.**

The paragraph above is accurate about the fallback path, but it would be easy to read as "the permission false-positive is fixed", and it isn't in this one permutation. Measured: when a worktree's parent directory is unreadable, `git worktree list --porcelain` *itself* emits `prunable gitdir file points to non-existent location` for a live worktree it merely cannot stat. Because `prunable` is treated as authoritative, the `try_exists().unwrap_or(true)` fallback is never reached, so the false positive survives — now sourced from git's own verdict rather than ours.

**No regression:** the previous `Path::exists()`-only code had the identical false positive here, since `exists()` also swallows `EACCES` on an ancestor. And it fails **red** — it reports drift that isn't there, pointing at `git worktree prune` for a live worktree — which is the annoying direction, not the dangerous one.

Left as-is deliberately. Second-guessing git's own stated verdict is a larger design question than this change should settle, and the alternative (verifying every `prunable` claim against the filesystem) would reintroduce exactly the `exists()`-based reasoning the switch was meant to retire. Worth a narrow follow-up if it bites anyone.


---

## Review record

Four Greptile P1s were found and fixed across four heads. Recording them together because the shape matters more than any one of them: **every one was a fail-green** — a state in which the preflight silently did not run, or silently under-reported — which is the exact failure this check exists to prevent, reproduced inside the check itself.

| Head | Finding | Direction |
|---|---|---|
| `1e790a02` | Newline in a path shifted the positional `rev-parse` parse → `Err` → whole preflight silently skipped | fail-green |
| `c0c52bfe` | Run-wide degraded-paths gate suppressed drift for unrelated entries | fail-green |
| `4c9177b3` | Forcing `is_linked_worktree = true` fired the shallow assertion on an exempt single-worktree primary checkout | fail-red |
| `4c9177b3` | A locked, removed, newline-pathed entry has no `prunable` and was treated as present | fail-green |

The first three heads patched *consequences* of an ambiguous parse and each drew a new P1 in the opposite direction. `3e179daf` fixes the cause: `git worktree list --porcelain -z` (git ≥ 2.36) terminates records with NUL, which cannot occur in a path, so a newline sits inside the record instead of splitting it. The truncation machinery survives only as the pre-2.36 fallback, so the git floor does not move.

**Two things worth carrying forward**, since they cost four rounds to learn:

1. **Green unit tests were the weakest available evidence here.** `c0c52bfe` had a fully green 10-check board with a live P1 against it. Every one of the four was found only by running the built binary against real repositories — not by reasoning about the parser, which two independent review passes did carefully and still missed the newline case.
2. **This preflight would benefit from an integration test over temp repositories** rather than more pure-function tests. Deliberately not added here to keep the change reviewable, but it is the gap that let all four through.

An unrelated macOS fast-tier flake surfaced during this work and is filed separately as #564; it is not caused by this branch.
