### PR TITLE
fix(ui): cut a producer-controlled session_id on a char boundary (#574)

### DIFF
--- a/changelog.d/574.bugfix.md
+++ b/changelog.d/574.bugfix.md
@@ -1,0 +1,7 @@
+## One agent's session id can no longer take the whole deck down
+
+A session id containing non-ASCII characters killed the entire TUI. The dashboard shortens a long id to fit the card title, and it did so by cutting at the 11th *byte* — which in Rust panics outright when that byte lands in the middle of a character. Nine Greek letters were enough. Because the cut happened inside the render loop, every subsequent frame panicked the same way, so the deck died taking every other agent's card with it, not just the one card that could not be drawn.
+
+Nothing validated the id on the way in: the deck stores whatever a hook posts to its socket verbatim. That socket is owner-only, so this was never a route in from outside the machine — but on this product every agent running on the deck is a same-uid process, which made it one agent's ability to terminate the operator's whole session with a single hook post. It was equally reachable by accident, from any agent that happened to mint a non-ASCII id.
+
+The same shape sat on the "Opened: …" status line that a Ctrl+click on an agent-emitted OSC-8 hyperlink leaves behind, where the URL — text the agent wrote into its own PTY — was cut at byte 57. Both now cut on a character boundary and mark the cut with an `…`, using the truncation the hook binary has always used on prompts. Ids and URLs short enough to fit are untouched.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5398,6 +5398,26 @@ fn screen_row_offset(screen: &vt100::Screen, pane_rect: Rect) -> u16 {
     effective_rows.saturating_sub(inner_h) as u16
 }
 
+/// The status line a Ctrl+click on an OSC-8 hyperlink leaves behind, with the
+/// URL shortened to fit the one-row status area.
+///
+/// Extracted out of the mouse arm so the L1 seam (`mouse/hyperlink/001`)
+/// exercises the same code the live click path runs rather than an agreeing
+/// copy of it.
+pub fn opened_link_status(url: &str) -> String {
+    // Issue #574: the URL is whatever the agent wrote into its own PTY as an
+    // OSC-8 hyperlink, so byte 57 is as arbitrary as the string — `&url[..57]`
+    // panicked the event loop the moment it landed inside a character. The
+    // `> 60` gate is kept so the set of URLs that get shortened at all is
+    // unchanged; only the cut itself moves to a character boundary.
+    let display = if url.len() > 60 {
+        crate::prompt_delivery::truncate_on_char_boundary(url, 57)
+    } else {
+        url.to_string()
+    };
+    format!("Opened: {display}")
+}
+
 /// Extract text from a vt100 screen for the given selection region.
 /// Selection coordinates are widget-relative; `row_offset` maps them to screen rows.
 fn extract_selection_text(screen: &vt100::Screen, sel: &TextSelection, row_offset: u16) -> String {
@@ -12884,13 +12904,8 @@ pub fn run_tui(
                                                 drop(parser);
                                                 drop(hmap);
                                                 if open::that(&url).is_ok() {
-                                                    let display = if url.len() > 60 {
-                                                        format!("{}...", &url[..57])
-                                                    } else {
-                                                        url
-                                                    };
                                                     ui.status_message = Some((
-                                                        format!("Opened: {display}"),
+                                                        opened_link_status(&url),
                                                         std::time::Instant::now(),
                                                     ));
                                                 }
@@ -17777,11 +17792,14 @@ fn render_session_card(
     };
     let status_color = status_style.fg.unwrap_or(Color::Reset);
 
-    let id_display = if session.session_id.len() > 11 {
-        &session.session_id[..11]
-    } else {
-        &session.session_id
-    };
+    // Issue #574: `session_id` is producer-controlled — `apply_event` keys the
+    // session map on whatever the hook socket sent, with no length, charset or
+    // boundary check between the socket and here. `&session_id[..11]` is a BYTE
+    // index, so an id whose 11th byte falls inside a character panicked this
+    // function — and because it runs inside the render loop, EVERY frame died
+    // and the whole deck went down with the one bad card. Same truncator the
+    // hook binary already uses on prompts, for the same reason.
+    let id_display = crate::prompt_delivery::truncate_on_char_boundary(&session.session_id, 11);
 
     let num_prefix = match card_number {
         Some(n) => format!("{n} "),

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -90,6 +90,13 @@ Demo-reel eligibility marker: a trailing ` [reel]` on an entry's `##### <id> —
 - **Does not assert:** that the tagged session keeps its accumulated history (the `pre_f9_hook_with_no_agent_id_*` unit tests in `src/state.rs` pin that half); the `WaitingForInput` command-entry carve-out that reads the collision-hardened join (`orchestration/lock/007`).
 - **Platform coverage:** mac+linux+windows.
 
+##### dashboard/pane/011 — A multi-byte-Unicode `session_id` truncates on a char boundary instead of panicking the whole deck (issue #574).
+- **Layer:** L1 (ratatui `TestBackend`).
+- **Agent:** none (a hook event carrying a non-ASCII `session_id`, replayed through `AppState::apply_event`).
+- **Asserts:** `apply_event` keys the session map on a producer-supplied `session_id` of nine `α` characters verbatim (no validation between the hook socket and the render), and rendering that card in a three-card deck draws ALL THREE cards — the poisoned card's id shortened to the longest char-boundary prefix within the 11-byte title budget plus an `…`, its two healthy neighbours untouched. Repeats the render across 2-, 3- and 4-byte characters at every ASCII offset that puts byte 11 mid-character. Before the fix `&session.session_id[..11]` panicked inside the render loop, so every frame died and the whole deck went down with it.
+- **Does not assert:** any rejection or sanitisation of the id upstream of the render (the id is stored verbatim by design); the OSC-8 hyperlink status line, which is the same defect on a different string (`mouse/hyperlink/001`).
+- **Platform coverage:** mac+linux+windows.
+
 #### dashboard/stats
 
 ##### dashboard/stats/001 — A narrow stats bar keeps the `tools` total and spends no width on a per-agent-type breakdown.
@@ -3169,6 +3176,15 @@ These entries cover PRD #80 (mouse parity for keyboard actions): every keyboard-
 - **Agent:** none.
 - **Asserts:** `global_ctrl_action(Ctrl+N)` and `hit_test_button` on a synthetic New-Pane button rect both yield `Action::NewPane`; a click that misses every rect yields `None`.
 - **Does not assert:** rendering or end-to-end dispatch side effects.
+- **Platform coverage:** mac+linux+windows.
+
+#### mouse/hyperlink
+
+##### mouse/hyperlink/001 — The Ctrl+click "Opened:" status shortens an agent-controlled URL on a char boundary (issue #574).
+- **Layer:** pure-data (plain logic, no TUI harness).
+- **Agent:** none (URL strings as they arrive from the embedded pane's OSC-8 hyperlink map).
+- **Asserts:** `opened_link_status` — the exact function the live Ctrl+click arm calls — leaves a short URL whole, and shortens an over-long one to the longest char-boundary prefix within its 57-byte budget plus an `…`, for 2-, 3- and 4-byte characters at every ASCII offset that puts byte 57 mid-character. Before the fix `&url[..57]` panicked the event loop on a URL an agent had written into its own PTY.
+- **Does not assert:** the hit-test that finds the URL under the cursor, or the `open::that` call itself (both are outside this seam); the session-card id, which is the same defect on a different string (`dashboard/pane/011`).
 - **Platform coverage:** mac+linux+windows.
 
 #### mouse/button

--- a/tests/mouse_dispatch.rs
+++ b/tests/mouse_dispatch.rs
@@ -18,7 +18,7 @@ use ratatui::layout::Rect;
 use ratatui::style::Modifier;
 
 use dot_agent_deck::keybindings::KeybindingConfig;
-use dot_agent_deck::ui::{Action, Button, global_action, hit_test_button};
+use dot_agent_deck::ui::{Action, Button, global_action, hit_test_button, opened_link_status};
 use spec::spec;
 
 /// Scenario: Build the Ctrl+N key event and run it through the keyboard
@@ -110,4 +110,62 @@ fn button_001_render_label_and_disabled_dim() {
         buf2[(1, 0)].modifier.contains(Modifier::DIM),
         "disabled button must render dimmed"
     );
+}
+
+/// The longest prefix of `s` that fits in `max` bytes without splitting a
+/// character, computed by walking characters rather than by slicing bytes — a
+/// deliberately different algorithm from the production truncator, so the
+/// expectation states independently what a char-boundary cut is.
+///
+/// Deliberately duplicated in `tests/render_dashboard.rs` rather than shared:
+/// `tests/common` is the 9k-line PTY harness, and neither of these pure-L1 test
+/// binaries links it today — pulling it in for nine lines would cost both of
+/// them that compile.
+fn char_boundary_prefix(s: &str, max: usize) -> String {
+    let mut out = String::new();
+    for ch in s.chars() {
+        if out.len() + ch.len_utf8() > max {
+            break;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// Scenario: Hand `opened_link_status` — the function the live Ctrl+click arm
+/// calls to build its status line — the URLs an agent can write into its own
+/// PTY as an OSC-8 hyperlink. A short URL is reported whole; an over-long one
+/// is cut on a character boundary and marked, rather than panicking the event
+/// loop on a byte index that lands inside a character.
+#[spec("mouse/hyperlink/001")]
+#[test]
+fn hyperlink_001_opened_status_cuts_a_long_url_on_a_char_boundary() {
+    // Issue #574, second site: `format!("{}...", &url[..57])`. The URL comes
+    // from the embedded pane's hyperlink map — text the agent emitted — so the
+    // 57th byte is as producer-controlled as the string itself.
+    let short = "https://example.com/ok";
+    assert_eq!(
+        opened_link_status(short),
+        format!("Opened: {short}"),
+        "a URL inside the budget must be reported verbatim"
+    );
+
+    // Exactly at the boundary of the shortening rule: 60 bytes is still whole.
+    let sixty = format!("https://example.com/{}", "a".repeat(40));
+    assert_eq!(sixty.len(), 60);
+    assert_eq!(opened_link_status(&sixty), format!("Opened: {sixty}"));
+
+    for filler in ['α', 'あ', '𝄞', '😀'] {
+        for pad in 0..4usize {
+            let url: String =
+                format!("https://ex.co/{}", "x".repeat(pad)) + &filler.to_string().repeat(40);
+            assert!(url.len() > 60, "the sweep must exercise the shortening arm");
+            let want = format!("Opened: {}…", char_boundary_prefix(&url, 57));
+            assert_eq!(
+                opened_link_status(&url),
+                want,
+                "URL `{url}` must be cut on a character boundary"
+            );
+        }
+    }
 }

--- a/tests/render_dashboard.rs
+++ b/tests/render_dashboard.rs
@@ -2140,3 +2140,156 @@ fn layout_001_seven_decks_fit_single_column() {
         "with {MANY} decks scrolling must still engage (only {many_visible} fit)"
     );
 }
+
+/// The longest prefix of `s` that fits in `max` bytes without splitting a
+/// character, computed by walking characters rather than by slicing bytes —
+/// deliberately a different algorithm from the production truncator, so the
+/// expectation is an independent statement of what a char-boundary cut is
+/// rather than a restatement of the code under test.
+///
+/// Deliberately duplicated in `tests/mouse_dispatch.rs` rather than shared: see
+/// the note there.
+fn char_boundary_prefix(s: &str, max: usize) -> String {
+    let mut out = String::new();
+    for ch in s.chars() {
+        if out.len() + ch.len_utf8() > max {
+            break;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// Expand `s` the way a ratatui buffer holds it: a double-width character
+/// occupies two cells, and `buffer_to_text` joins the second (padding) cell in
+/// as a space. Without this a sweep over wide characters would compare the
+/// rendered title against a string the renderer never produces.
+fn as_rendered_cells(s: &str) -> String {
+    let mut out = String::new();
+    for ch in s.chars() {
+        out.push(ch);
+        for _ in 1..ch.to_string().width().max(1) {
+            out.push(' ');
+        }
+    }
+    out
+}
+
+/// Scenario: A hook posts a session whose id is nine `α` characters, so byte 11
+/// — where the card title cuts the id — falls inside a character. Render that
+/// card between two healthy ones: the deck must draw all three cards with the
+/// Unicode id cut on a character boundary, instead of panicking the render loop
+/// and taking every other agent's card down with it. Repeated for 2-, 3- and
+/// 4-byte characters at every offset that puts byte 11 mid-character.
+#[spec("dashboard/pane/011")]
+#[test]
+fn pane_011_multibyte_session_id_renders_the_whole_deck() {
+    // Issue #574. `&session.session_id[..11]` is a BYTE index, and `str`
+    // indexing panics when it lands inside a character. The id is
+    // producer-controlled — `apply_event` keys the session map on whatever the
+    // hook socket sent, with no length, charset or boundary check anywhere in
+    // between — so this drives the real state transition first and renders
+    // whatever it produces, rather than hand-building the card list.
+    //
+    // The blast radius is the point: the slice runs inside the render loop, so
+    // one bad id killed EVERY frame. That is why the assertion is made on a
+    // three-card deck and not on the poisoned card alone.
+    const POISONED_ID: &str = "ααααααααα"; // 9 chars x 2 bytes = 18; byte 11 is mid-char
+    assert!(
+        !POISONED_ID.is_char_boundary(11),
+        "the fixture only reproduces the defect if byte 11 splits a character"
+    );
+
+    let mut state = AppState::default();
+    state.register_pane("2".to_string());
+    state.apply_event(AgentEvent {
+        session_id: POISONED_ID.to_string(),
+        agent_type: AgentType::ClaudeCode,
+        event_type: EventType::WaitingForInput,
+        tool_name: None,
+        tool_detail: None,
+        cwd: Some("/home/dev/worker".to_string()),
+        timestamp: chrono::Utc::now(),
+        user_prompt: None,
+        metadata: HashMap::new(),
+        pane_id: Some("2".to_string()),
+        agent_id: None,
+        agent_version: None,
+        schema_version: None,
+        live_target: None,
+    });
+    let poisoned = state
+        .sessions
+        .get(POISONED_ID)
+        .expect("apply_event keys the session map on the producer's id verbatim")
+        .clone();
+
+    // Two ordinary neighbours, so a panic in the middle card is visible as the
+    // loss of cards that have nothing wrong with them.
+    let mut healthy_a = poisoned.clone();
+    healthy_a.session_id = "sess-alpha".to_string();
+    healthy_a.pane_id = Some("1".to_string());
+    let mut healthy_b = poisoned.clone();
+    healthy_b.session_id = "sess-gamma".to_string();
+    healthy_b.pane_id = Some("3".to_string());
+
+    // No display name on the poisoned card: the id is what the title renders
+    // only when the card has no friendlier label.
+    let cards: [(&SessionState, Option<&str>); 3] = [
+        (&healthy_a, Some("example-alpha")),
+        (&poisoned, None),
+        (&healthy_b, Some("example-gamma")),
+    ];
+    let rendered = buffer_to_text(&render_dashboard_cards_to_buffer(
+        &cards,
+        Some(0),
+        CardDensityKind::Normal,
+        0,
+        80,
+    ));
+
+    // One status badge per card, so counting badges counts surviving cards.
+    assert_eq!(
+        rendered.matches("Needs Input").count(),
+        3,
+        "one bad session id must not cost the other agents their cards:\n{rendered}"
+    );
+    let expected = format!(
+        "{}…",
+        as_rendered_cells(&char_boundary_prefix(POISONED_ID, 11))
+    );
+    assert!(
+        rendered.contains(&expected),
+        "the title must cut the id on a character boundary and mark the cut, expected `{expected}`:\n{rendered}"
+    );
+    assert!(
+        rendered.contains("example-alpha") && rendered.contains("example-gamma"),
+        "both neighbouring cards must still render their titles:\n{rendered}"
+    );
+
+    // Property sweep: every character width, at every ASCII offset that moves
+    // the cut inside a character. `session_id` is arbitrary bytes from the
+    // socket, so no single fixture proves the render is boundary-safe.
+    for filler in ['α', 'あ', '𝄞', '😀'] {
+        for pad in 0..4usize {
+            let id: String = "x".repeat(pad) + &filler.to_string().repeat(12);
+            let mut session = poisoned.clone();
+            session.session_id = id.clone();
+            let card = buffer_to_text(&render_card_to_buffer(
+                &session,
+                None,
+                Some(1),
+                CardDensityKind::Normal,
+                0,
+                false,
+                80,
+                CardDensityKind::Normal.rendered_height(),
+            ));
+            let want = format!("{}…", as_rendered_cells(&char_boundary_prefix(&id, 11)));
+            assert!(
+                card.contains(&want),
+                "id `{id}` must render as `{want}`:\n{card}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #574.

## The defect

`render_session_card` shortened a long `session_id` with `&session.session_id[..11]` — a **byte** index. `str` indexing panics when the index is not a UTF-8 char boundary, so a session id of nine `α` characters (2 bytes each; byte 11 lands mid-character) panicked the render. Because the slice runs **inside the render loop**, every frame panicked the same way and the whole deck died, taking every other agent's card with it.

Nothing validates the id on the way in: `AppState::apply_event` keys the session map on whatever the hook socket sent, with no length, charset or boundary check between the socket and the render. The socket is owner-only (0600), so the threat set is same-uid processes — which on this product is every agent running on the deck. It is equally reachable by accident from any agent that mints a non-ASCII id.

Second site, same shape: `format!("{}...", &url[..57])` on the Ctrl+click `Opened: …` status line, where the URL comes from the embedded pane's OSC-8 hyperlink map — text an agent wrote into its own PTY.

## The fix

Both sites now go through `prompt_delivery::truncate_on_char_boundary`, which `src/hook.rs` already uses on prompts for exactly this reason.

The set of strings that get shortened **at all** is unchanged — the `> 11` and `> 60` gates are preserved, so short ids and URLs are still reported verbatim. Only the cut itself moves to a character boundary, and it is now marked with `…` (replacing the URL path's literal `...`).

The URL arm is extracted into `opened_link_status` so the test drives the same function the live click path calls rather than an agreeing copy — the pattern `scroll_focused_agent_pane` already uses for the mouse arms.

**Swept the rest of `src/`**: no other byte-index slice or `String::truncate` is boundary-unsafe. `orchestrator_ext.rs:87` and `login_shell.rs:176` are `find`-derived; `state.rs:618` is ASCII by construction; `daemon_client.rs:225` and `ui.rs:5456` already snap back to a boundary.

## Reproduced first

Per `/reproduce-first`, the failing tests came before the fix. Both failed with the reported panic at the reported site:

```
pane_011      -> panicked at src/ui.rs:17791: end byte index 11 is not a char boundary; it is inside 'α'
hyperlink_001 -> panicked at src/ui.rs:5409:  end byte index 57 is not a char boundary; it is inside 'α'
```

Each fix was then reverted **individually** and the corresponding test went red again while the other stayed green, so neither change is decorative.

## Tests (rule 4 — L1)

- **`dashboard/pane/011`** — replays a hook event carrying a non-ASCII `session_id` through the real `AppState::apply_event`, then renders the resulting card **between two healthy ones**. The blast radius is the point, so the assertion is that all three cards survive with their titles, not just that the poisoned card draws.
- **`mouse/hyperlink/001`** — `opened_link_status` on the URLs an agent can emit.

Both sweep 2-, 3- and 4-byte characters (`α`, `あ`, `𝄞`, `😀`) at every ASCII offset that moves the cut inside a character — the property/fuzz-style coverage the issue asked for. Expected values are computed by walking `chars()`, a deliberately different algorithm from the production truncator, so the test states what a boundary cut *is* rather than restating the code under test.

## Rule 12

No TUI↔daemon protocol or handler-contract change — this is a render site and a status string. No `PROTOCOL_VERSION` bump and no `.breaking.md`; `changelog.d/574.bugfix.md` added.

## Gates

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets --features e2e -- -D warnings` ✅
- `cargo xtask linkage-check` ✅ (535 catalog ids, 463 annotations)
- `cargo test-fast` ✅ **2723 passed, 0 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)