### PR TITLE
fix(hook): retry transient socket read errors instead of reporting no daemon

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,8 +3,17 @@ retries = 0
 slow-timeout = { period = "60s", terminate-after = 3 }
 fail-fast = false
 
+# Issue #564: `path` is resolved RELATIVE TO the profile's store directory
+# (`target/nextest/<profile>/`), so the previous value of
+# "target/nextest/default/junit.xml" actually wrote
+# `target/nextest/default/target/nextest/default/junit.xml`. Nothing read the
+# file, so the doubling went unnoticed — and that is the point: this is the one
+# structured, per-test, machine-readable record of a run (per-test durations and
+# the full failure message), and CI now uploads it per run_attempt so that a
+# job-level re-run cannot erase a failing attempt's evidence the way it erased
+# the first `socket_004` occurrence.
 [profile.default.junit]
-path = "target/nextest/default/junit.xml"
+path = "junit.xml"
 
 # PRD #140 M5.1: `orchestration/route/001` boots SIX interactive Haiku panes
 # across two orchestration tabs and drives two concurrent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,17 @@ jobs:
       # inert and the gap survived #436. Costs nothing measurable: all 48 are
       # under 40ms and the tier's wall clock is set by its slowest test.
       - run: cargo nextest run --workspace
+      # Issue #564: keep this attempt's results after a job-level re-run
+      # overwrites the conclusion. Full rationale on the identical step in
+      # `build-macos` below — the masking is a property of re-running any job,
+      # not of macOS, so all three test jobs carry it.
+      - name: Preserve this attempt's test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nextest-linux-attempt-${{ github.run_attempt }}
+          path: target/nextest/default/junit.xml
+          if-no-files-found: warn
       # CLAUDE.md rule 7 has always SAID this runs in CI ("CI's linkage-check
       # rule 7 fails the build if the Scenario comment is missing or the
       # generator fails"), and the build-macos/build-windows comment says these
@@ -349,6 +360,17 @@ jobs:
       # dependency (`symlinks_named_like_owned_dirs_are_skipped`) is already
       # `#[cfg(unix)]`; the rest are in-memory or tempdir-based.
       - run: cargo nextest run --workspace
+      # Issue #564: keep this attempt's results after a job-level re-run
+      # overwrites the conclusion. Full rationale on the identical step in
+      # `build-macos` below — the masking is a property of re-running any job,
+      # not of macOS, so all three test jobs carry it.
+      - name: Preserve this attempt's test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nextest-windows-attempt-${{ github.run_attempt }}
+          path: target/nextest/default/junit.xml
+          if-no-files-found: warn
 
   # macOS (host = aarch64-apple-darwin) compile + clippy + unit-test gate,
   # mirroring build-windows. macOS is otherwise built ONLY in the release
@@ -388,6 +410,45 @@ jobs:
       # there is nothing to match-and-narrow here — the clippy divergence is
       # about `--all-targets --features e2e`, not about package selection.
       - run: cargo nextest run --workspace
+      # Issue #564: preserve THIS attempt's test results, so a job-level re-run
+      # cannot destroy the evidence from a failing one.
+      #
+      # A job-level re-run overwrites the job's conclusion in place. After
+      # re-running this job on the same commit, `gh run list` and the PR's
+      # check board both read `success`, and the failure that prompted the
+      # re-run survives only under `actions/runs/<id>/attempts/<n>`, whose logs
+      # age out. So the standard remedy for a one-off timing blip — and with
+      # `retries = 0` in .config/nextest.toml and every build job blocking, a
+      # re-run is the ONLY remedy on offer — is also the thing that erases the
+      # record of it, which makes the observed rate of such failures
+      # systematically under-counted. #564 nearly lost its first occurrence
+      # that way, and #402 recorded the same masking for `delegate_011`.
+      #
+      # `${{ github.run_attempt }}` in the artifact NAME is the load-bearing
+      # part, twice over: artifacts are scoped to the run rather than the
+      # attempt, and upload-artifact v4+ refuses to overwrite an existing name,
+      # so a fixed name would make the re-run's upload fail outright. With the
+      # attempt in the name, attempt 1's results sit alongside attempt 2's and
+      # the failing attempt stays readable after its conclusion is gone.
+      #
+      # The payload is nextest's JUnit XML — the only structured record of a
+      # run: per-test WALL CLOCK plus the full failure message. The duration is
+      # not incidental, it is what diagnosed #564. Both macOS failures of
+      # `socket_004` took ~0.4s against that test's 5s budget, which is what
+      # showed the deadline was never in play and a read error had ended the
+      # exchange instead. That number appears nowhere but this artifact and a
+      # nextest log line.
+      #
+      # `always()` so it runs on the failing path, which is the only path that
+      # matters here; `if-no-files-found: warn` because a job that dies before
+      # the test step has no results and must not fail on that.
+      - name: Preserve this attempt's test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: nextest-macos-attempt-${{ github.run_attempt }}
+          path: target/nextest/default/junit.xml
+          if-no-files-found: warn
 
   # `cargo audit` reads Cargo.lock, which a devbox-only PR cannot touch.
   security:

--- a/changelog.d/564.bugfix.md
+++ b/changelog.d/564.bugfix.md
@@ -1,0 +1,9 @@
+## A daemon that answers slowly is no longer mistaken for one that isn't there
+
+The hook socket's request/reply path — the one `get-seed` uses to ask the daemon for a pane's seed, and the one `delegate` uses to await its reply — gave up on the whole exchange the moment a single `read` returned an error, whatever that error was. Two of the errors it can return say nothing at all about the peer: `EINTR`, which only means a signal arrived on the waiting thread, and the socket's own per-read timeout, which is a different and shorter clock than the five-second budget the operation actually advertises. Either one ended the exchange with seconds of budget left, and the caller was told what it is told when there is no daemon at all.
+
+That was a silent failure by design. `get-seed` treats "no reply" and "no daemon" alike, both falling back to injecting the prompt through the PTY, so a reply that was written and then dropped looked exactly like an older daemon that never knew the verb — no error, no log line, nothing to distinguish a fallback taken for a good reason from one taken for none.
+
+A read failure is now reconciled with the deadline before it is allowed to end anything: an interrupted read is retried, a per-read timeout is retried while the operation's own budget still has time left, and only a genuinely exhausted budget, a peer that closes without answering, or a real I/O error ends the exchange. The five-second bound is unchanged and still bounds the whole operation, so a wedged or absent daemon fails exactly as promptly as before — and when the deck now does give up, it records which of those reasons applied.
+
+Nothing on the wire changed, and no caller sees a new outcome, so a daemon and a deck from either side of this change interoperate exactly as they did.

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -833,6 +833,16 @@ fn read_reply_line(
             // that still had seconds left. Consult the deadline instead: while
             // budget remains, go back and read again; once it is gone, the
             // loop head above returns `DeadlineExpired`.
+            //
+            // This cannot spin. A `WouldBlock` from a `SO_RCVTIMEO` armed at
+            // `remaining` has by definition just consumed `remaining`, so the
+            // loop head finds no budget and ends the operation on the very
+            // next pass — the ordinary case costs exactly one extra trip round
+            // the loop. The retry earns its keep only when a fire is EARLY,
+            // which is the case that has no other defence, and even a fire
+            // that were somehow instant is bounded by the same deadline rather
+            // than by a retry count. `socket_003`/`socket_005` pin that end of
+            // it: both still return at ~5.01s, unchanged by this.
             Err(err) if is_transient_read_error(&err, deadline) => continue,
             Err(err) => return Err(ReplyReadError::Io(err)),
         };
@@ -1489,8 +1499,9 @@ mod tests {
         }
 
         let outcome = result_rx.recv_timeout(ASSERT_CEILING);
+        // Safe to release now: the signalling loop above has finished, so no
+        // further `pthread_kill` can race the thread's exit.
         let _ = release_tx.send(());
-        let _ = client_thread.join();
         let daemon_report = daemon_thread
             .join()
             .unwrap_or_else(|_| "the stub daemon thread panicked".to_string());
@@ -1511,6 +1522,13 @@ mod tests {
              during connect/write instead of during the read, which the {SIGNAL_LEAD_IN:?} \
              lead-in is sized to prevent."
         );
+
+        // Joined last, deliberately. If the client thread ever failed to
+        // return within the ceiling the assertions above are the only thing
+        // that can say so, and joining a wedged thread first would hang the
+        // test until nextest killed it — losing exactly the diagnostic the
+        // failure exists to produce.
+        let _ = client_thread.join();
     }
 
     #[test]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -635,6 +635,23 @@ fn request_from_socket_at(
     json: &str,
     timeout: Option<std::time::Duration>,
 ) -> SocketReply {
+    request_from_socket_at_detailed(path, json, timeout).0
+}
+
+/// [`request_from_socket_at`], plus the [`ReplyReadError`] behind a
+/// [`SocketReply::NoReply`] when there is one.
+///
+/// The extra half is diagnostic only — `request_from_socket_at` above is
+/// literally this function's first return value and nothing else, so
+/// production behavior is unchanged. Issue #564: the socket tests assert on the reason as well
+/// as the outcome, so a future failure prints *which* branch ended the
+/// exchange rather than a bare `None` that four different causes could
+/// produce.
+fn request_from_socket_at_detailed(
+    path: &std::path::Path,
+    json: &str,
+    timeout: Option<std::time::Duration>,
+) -> (SocketReply, Option<ReplyReadError>) {
     // The total-operation deadline starts here, before connect, rather than
     // being re-armed with a fresh full budget once the connection is
     // established and the request written below. Connect and the write are
@@ -646,7 +663,7 @@ fn request_from_socket_at(
     let deadline = timeout.map(|budget| std::time::Instant::now() + budget);
     let mut stream = match crate::platform::ipc::IpcClient::connect(path) {
         Ok(stream) => stream,
-        Err(_) => return SocketReply::Unreachable,
+        Err(_) => return (SocketReply::Unreachable, None),
     };
     if let Some(deadline) = deadline {
         // Zero/negative remaining budget: do not hand the socket a zero
@@ -656,15 +673,15 @@ fn request_from_socket_at(
         // during connect folds into `NoReply`, matching how the read loop
         // treats a deadline that expires mid-operation.
         let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
-            return SocketReply::NoReply;
+            return (SocketReply::NoReply, Some(ReplyReadError::DeadlineExpired));
         };
         if stream.set_timeouts(remaining).is_err() {
-            return SocketReply::Unreachable;
+            return (SocketReply::Unreachable, None);
         }
     }
     let msg = format!("{json}\n");
     if stream.write_all(msg.as_bytes()).is_err() || stream.flush().is_err() {
-        return SocketReply::Unreachable;
+        return (SocketReply::Unreachable, None);
     }
     // Half-close our write side so the daemon's line reader sees EOF after our
     // single request and doesn't block waiting for more (it reads in a loop).
@@ -684,8 +701,52 @@ fn request_from_socket_at(
     // fold into `SocketReply::NoReply` here / the caller's documented "no
     // seed" → PTY-injection fallback for `get-seed`.
     match read_reply_line(&mut stream, deadline) {
-        Some(line) => SocketReply::Line(line),
-        None => SocketReply::NoReply,
+        Ok(line) => (SocketReply::Line(line), None),
+        Err(err) => {
+            // Every reason still folds into the one `NoReply` the callers
+            // already handle — the wire contract is unchanged. It is only
+            // recorded on the way past, because issue #564's two occurrences
+            // both had to be diagnosed from a nextest *duration* (0.4s of a 5s
+            // budget) after the fact: the reply path had no way to say which of
+            // its four terminal branches fired.
+            tracing::debug!(reason = %err, "hook socket request read no reply line");
+            (SocketReply::NoReply, Some(err))
+        }
+    }
+}
+
+/// Why [`read_reply_line`] returned no reply line.
+///
+/// Every variant folds into [`SocketReply::NoReply`] at the boundary, so this
+/// changes no caller's behavior; it exists so a failure names itself instead
+/// of collapsing four distinct causes into one `None`. Issue #564: a
+/// `get-seed` that silently degrades to PTY injection looks identical to one
+/// that never had a daemon to talk to, which is exactly the ambiguity that
+/// made a macOS-only flake take two occurrences and a log excavation to place.
+#[derive(Debug)]
+enum ReplyReadError {
+    /// The total-operation budget was gone before a reply line completed —
+    /// a genuinely wedged or unreachably slow daemon.
+    DeadlineExpired,
+    /// The peer closed without writing a single byte: an older daemon that
+    /// does not know this verb. See [`SocketReply::NoReply`].
+    ClosedWithoutReply,
+    /// A read, or the per-read timeout re-arm, failed for a reason that is
+    /// not transient — transient ones are retried, see
+    /// [`is_transient_read_error`].
+    Io(std::io::Error),
+    /// A reply line arrived but was not valid UTF-8.
+    InvalidUtf8,
+}
+
+impl std::fmt::Display for ReplyReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DeadlineExpired => write!(f, "total-operation deadline expired"),
+            Self::ClosedWithoutReply => write!(f, "peer closed without writing any bytes"),
+            Self::Io(err) => write!(f, "read failed: {err} (kind {:?})", err.kind()),
+            Self::InvalidUtf8 => write!(f, "reply line was not valid UTF-8"),
+        }
     }
 }
 
@@ -702,13 +763,22 @@ fn request_from_socket_at(
 /// against `deadline` and re-arms the socket's per-read timeout to whatever
 /// is left before each individual read, so the *operation as a whole* —
 /// regardless of how the peer paces its bytes — cannot run past `deadline`.
-/// Once the deadline has passed, any read fails, the peer closes before
-/// sending a single byte, or the line is not valid UTF-8, this returns
-/// `None`; the caller folds that into `SocketReply::NoReply` exactly as it
-/// already did for a timed-out read — see [`request_from_socket`]. A peer
-/// that closes *after* writing part of a line, but before the newline, is a
-/// distinct case: the partial line is still returned as `Some(partial)`, not
-/// folded into `None`.
+/// Once the deadline has passed, a read fails non-transiently, the peer
+/// closes before sending a single byte, or the line is not valid UTF-8, this
+/// returns the matching [`ReplyReadError`]; the caller folds every one of
+/// them into `SocketReply::NoReply` exactly as it already did for a timed-out
+/// read — see [`request_from_socket`]. The typed reason exists only so a
+/// failure can say which of the four it was (issue #564). A peer that closes
+/// *after* writing part of a line, but before the newline, is a distinct
+/// case: the partial line is still returned as `Ok(partial)`, not folded into
+/// an error.
+///
+/// "A read fails" is deliberately narrower than "`read` returned `Err`":
+/// `EINTR`, and a per-read timeout that fires while the operation's own
+/// budget still has time on it, are retried rather than treated as the end of
+/// the exchange — see [`is_transient_read_error`]. Reading `Err` as final
+/// regardless is what let a daemon replying 300ms into a 5s budget be
+/// reported as an absent one on macOS CI.
 ///
 /// `deadline` is computed once by the caller — [`request_from_socket_at`] —
 /// from a point **before** it connects, not re-derived here from a fresh
@@ -717,20 +787,55 @@ fn request_from_socket_at(
 /// actually be bounded and the exchange as a whole could run past what the
 /// caller's `timeout` advertises.
 ///
-/// `None` falls back to unbounded blocking reads with no re-arming, for
-/// callers that pass no deadline at all.
+/// A `deadline` of `None` falls back to unbounded blocking reads with no
+/// re-arming, for callers that pass no deadline at all.
 fn read_reply_line(
     stream: &mut crate::platform::ipc::IpcClient,
     deadline: Option<std::time::Instant>,
-) -> Option<String> {
+) -> Result<String, ReplyReadError> {
     let mut buf = [0u8; 512];
     let mut line = Vec::new();
     loop {
         if let Some(deadline) = deadline {
-            let remaining = deadline.checked_duration_since(std::time::Instant::now())?;
-            stream.set_timeouts(remaining).ok()?;
+            // `checked_duration_since` yields `Some(ZERO)` at the exact instant
+            // the deadline lands, and `set_read_timeout(ZERO)` is an
+            // `InvalidInput` error rather than a timeout — so an exhausted
+            // budget is reported as what it is instead of as an I/O failure.
+            let remaining = match deadline.checked_duration_since(std::time::Instant::now()) {
+                Some(remaining) if !remaining.is_zero() => remaining,
+                _ => return Err(ReplyReadError::DeadlineExpired),
+            };
+            stream.set_timeouts(remaining).map_err(ReplyReadError::Io)?;
         }
-        let n = stream.read(&mut buf).ok()?;
+        let n = match stream.read(&mut buf) {
+            Ok(n) => n,
+            // Issue #564: a read error is NOT on its own evidence that the
+            // exchange is over. Two classes have to be reconciled with the
+            // deadline before they can end it, and folding them straight into
+            // "no reply" is what let a daemon replying 300ms into a 5s budget
+            // be reported as an absent one.
+            //
+            // `Interrupted` (EINTR) is transient by definition — a signal
+            // landed on this thread while it sat in `read(2)`. It says nothing
+            // about the peer and nothing about the clock, and `std` does not
+            // retry it for us here the way `Write::write_all` does on the send
+            // side. Retrying is always correct: the loop re-arms from
+            // `deadline` on the next pass, so the operation stays bounded.
+            //
+            // `WouldBlock`/`TimedOut` (EAGAIN/EWOULDBLOCK/ETIMEDOUT) are the
+            // socket's OWN per-read `SO_RCVTIMEO` firing, which is a different
+            // clock from the total-operation deadline this function
+            // advertises. Normally the two coincide, because the re-arm above
+            // sets the per-read timeout to exactly the remaining budget — but
+            // treating the per-read result as final regardless meant the
+            // operation ended on the socket's word rather than on the
+            // deadline's, so any early or spurious fire cut an exchange short
+            // that still had seconds left. Consult the deadline instead: while
+            // budget remains, go back and read again; once it is gone, the
+            // loop head above returns `DeadlineExpired`.
+            Err(err) if is_transient_read_error(&err, deadline) => continue,
+            Err(err) => return Err(ReplyReadError::Io(err)),
+        };
         if n == 0 {
             // EOF with nothing received at all: the daemon closed without
             // answering — exactly the "old daemon that doesn't know this
@@ -743,7 +848,7 @@ fn read_reply_line(
             // `Line(partial)` unchanged: that is a distinct scenario this fix
             // does not touch.
             if line.is_empty() {
-                return None;
+                return Err(ReplyReadError::ClosedWithoutReply);
             }
             break;
         }
@@ -753,9 +858,25 @@ fn read_reply_line(
         }
         line.extend_from_slice(&buf[..n]);
     }
-    String::from_utf8(line)
-        .ok()
-        .map(|s| s.trim_end_matches('\r').to_string())
+    match String::from_utf8(line) {
+        Ok(line) => Ok(line.trim_end_matches('\r').to_string()),
+        Err(_) => Err(ReplyReadError::InvalidUtf8),
+    }
+}
+
+/// Should this `read(2)` failure send [`read_reply_line`] back for another
+/// pass rather than ending the exchange? See the call site for why each class
+/// is here; `deadline` is what decides the timeout-class ones, so a caller
+/// that passed no deadline at all (unbounded blocking reads) keeps treating
+/// them as final rather than spinning on them forever.
+fn is_transient_read_error(err: &std::io::Error, deadline: Option<std::time::Instant>) -> bool {
+    match err.kind() {
+        std::io::ErrorKind::Interrupted => true,
+        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut => {
+            deadline.is_some_and(|deadline| deadline > std::time::Instant::now())
+        }
+        _ => false,
+    }
 }
 
 #[cfg(test)]
@@ -1060,41 +1181,69 @@ mod tests {
     #[test]
     #[cfg(unix)]
     fn socket_004_slow_but_replying_daemon_still_returns_the_reply() {
+        const REPLY_DELAY: std::time::Duration = std::time::Duration::from_millis(300);
+
         let _tmp = tempfile::tempdir().expect("create temp dir for stub daemon socket");
         let socket_path = _tmp.path().join("s.sock");
         let listener =
             std::os::unix::net::UnixListener::bind(&socket_path).expect("bind stub daemon socket");
 
         // Stub daemon: read the request line, wait a short delay comfortably
-        // inside the 5s bound the fix will add, then reply with one line.
-        let daemon_thread = std::thread::spawn(move || {
-            if let Ok((mut stream, _)) = listener.accept() {
+        // inside the 5s bound, then reply with one line. It reports what it
+        // actually managed to do rather than swallowing every error into `_`,
+        // so a failure can separate "the client dropped a reply that WAS
+        // written" from "the daemon never wrote one" — a distinction issue
+        // #564 had no way to make from either of its CI occurrences.
+        let daemon_thread = std::thread::spawn(move || match listener.accept() {
+            Err(err) => format!("accept failed: {err}"),
+            Ok((mut stream, _)) => {
                 let mut reader = std::io::BufReader::new(&stream);
                 let mut line = String::new();
-                let _ = std::io::BufRead::read_line(&mut reader, &mut line);
-                std::thread::sleep(std::time::Duration::from_millis(300));
-                let _ = std::io::Write::write_all(&mut stream, br#"{"seed":"abc123"}"#);
-                let _ = std::io::Write::write_all(&mut stream, b"\n");
-                let _ = std::io::Write::flush(&mut stream);
+                if let Err(err) = std::io::BufRead::read_line(&mut reader, &mut line) {
+                    return format!("reading the request line failed: {err}");
+                }
+                std::thread::sleep(REPLY_DELAY);
+                // Two writes, not one: this also keeps the client's read loop
+                // going round a second time for the newline, which is the
+                // path that has to survive a transient read error.
+                let written = std::io::Write::write_all(&mut stream, br#"{"seed":"abc123"}"#)
+                    .and_then(|()| std::io::Write::write_all(&mut stream, b"\n"))
+                    .and_then(|()| std::io::Write::flush(&mut stream));
+                match written {
+                    Ok(()) => "wrote and flushed the reply line".to_string(),
+                    Err(err) => format!("writing the reply failed: {err}"),
+                }
             }
         });
 
-        let result = match request_from_socket_at(
+        let started = std::time::Instant::now();
+        let (reply, read_error) = request_from_socket_at_detailed(
             &socket_path,
             r#"{"type":"get-seed"}"#,
             Some(GET_SEED_REQUEST_TIMEOUT),
-        ) {
-            SocketReply::Line(line) => Some(line),
-            SocketReply::NoReply | SocketReply::Unreachable => None,
-        };
+        );
+        let elapsed = started.elapsed();
+        let daemon_report = daemon_thread
+            .join()
+            .unwrap_or_else(|_| "the stub daemon thread panicked".to_string());
 
-        let _ = daemon_thread.join();
-
-        assert_eq!(
-            result,
-            Some(r#"{"seed":"abc123"}"#.to_string()),
+        // Deliberately NOT collapsed into `Option<String>` before asserting.
+        // The old assertion printed a bare `left: None` — a value `NoReply`
+        // and `Unreachable` produce alike, naming neither the cause nor how
+        // much of the budget had been spent. Both of issue #564's macOS
+        // occurrences had to be placed by reading the *duration* out of a
+        // nextest line after the fact (0.435s and 0.401s of a 5s budget,
+        // against a 0.307s honest cost), which is what showed the deadline
+        // was never in play and the exchange had been ended by a read error
+        // instead. That should come out of the assertion itself next time.
+        assert!(
+            matches!(&reply, SocketReply::Line(line) if line == r#"{"seed":"abc123"}"#),
             "a daemon that replies well inside the timeout bound must not be mistaken for \
-             an absent one"
+             an absent one — got {reply:?} (read error: {read_error:?}) after {elapsed:?} of \
+             a {GET_SEED_REQUEST_TIMEOUT:?} budget, having slept {REPLY_DELAY:?} before \
+             replying; the stub daemon reports: {daemon_report}. An elapsed time well short \
+             of the budget means something other than the deadline ended the exchange — see \
+             `is_transient_read_error`."
         );
     }
 
@@ -1232,6 +1381,135 @@ mod tests {
             "a daemon that closes without writing any bytes must fold into \
              SocketReply::NoReply, matching its own doc comment's \"daemon closed without \
              answering\" case, not SocketReply::Line(\"\") — got {result:?}"
+        );
+    }
+
+    /// Scenario: A stub daemon accepts the connection, reads the request line,
+    /// waits 300ms and then replies — while the test hammers the *client*
+    /// thread with `SIGUSR1`, whose handler is installed deliberately without
+    /// `SA_RESTART` so that every signal landing while the client sits in
+    /// `read(2)` surfaces as `EINTR`. The reply must still come back intact:
+    /// a signal on the reading thread says nothing about the peer and nothing
+    /// about the clock, so it must not be mistaken for an absent daemon.
+    #[spec("error/socket/007")]
+    #[test]
+    #[cfg(unix)]
+    fn socket_007_signal_interrupted_read_still_returns_the_reply() {
+        /// Long enough that the client is parked in `read(2)` for the whole
+        /// signalling window below, and still ~16x inside the 5s budget.
+        const REPLY_DELAY: std::time::Duration = std::time::Duration::from_millis(300);
+        /// Let connect + write + `shutdown_write` finish before the first
+        /// signal. Those are sub-millisecond on an already-bound local socket,
+        /// so this is a ~50x margin; it matters because `UnixStream::connect`
+        /// does not retry `EINTR` and a signal landing there would fail the
+        /// test as `Unreachable` for an unrelated reason (called out in the
+        /// assertion message so that case is not mysterious).
+        const SIGNAL_LEAD_IN: std::time::Duration = std::time::Duration::from_millis(50);
+        const SIGNAL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(10);
+        const SIGNAL_ROUNDS: usize = 25;
+        /// Generous: the operation itself is bounded at 5s, so this only has
+        /// to fail before nextest's own kill window rather than pin any
+        /// timing.
+        const ASSERT_CEILING: std::time::Duration = std::time::Duration::from_secs(15);
+
+        extern "C" fn noop_signal_handler(_signum: libc::c_int) {}
+
+        let _tmp = tempfile::tempdir().expect("create temp dir for stub daemon socket");
+        let socket_path = _tmp.path().join("s.sock");
+        let listener =
+            std::os::unix::net::UnixListener::bind(&socket_path).expect("bind stub daemon socket");
+
+        // Install the handler WITHOUT `SA_RESTART`. With it (or with the
+        // default disposition) the kernel would restart the interrupted
+        // `read(2)` itself and there would be no `EINTR` for the code under
+        // test to mishandle — clearing it is the whole point. Scoped: the
+        // previous disposition is restored at the end, and `SIGUSR1` is used
+        // nowhere else in the crate.
+        let mut previous: libc::sigaction = unsafe { std::mem::zeroed() };
+        unsafe {
+            let mut action: libc::sigaction = std::mem::zeroed();
+            action.sa_sigaction = noop_signal_handler as *const () as libc::sighandler_t;
+            libc::sigemptyset(&mut action.sa_mask);
+            action.sa_flags = 0;
+            assert_eq!(
+                libc::sigaction(libc::SIGUSR1, &action, &mut previous),
+                0,
+                "installing the SIGUSR1 handler must succeed"
+            );
+        }
+
+        let daemon_thread = std::thread::spawn(move || match listener.accept() {
+            Err(err) => format!("accept failed: {err}"),
+            Ok((mut stream, _)) => {
+                let mut reader = std::io::BufReader::new(&stream);
+                let mut line = String::new();
+                if let Err(err) = std::io::BufRead::read_line(&mut reader, &mut line) {
+                    return format!("reading the request line failed: {err}");
+                }
+                std::thread::sleep(REPLY_DELAY);
+                let written = std::io::Write::write_all(&mut stream, br#"{"seed":"abc123"}"#)
+                    .and_then(|()| std::io::Write::write_all(&mut stream, b"\n"))
+                    .and_then(|()| std::io::Write::flush(&mut stream));
+                match written {
+                    Ok(()) => "wrote and flushed the reply line".to_string(),
+                    Err(err) => format!("writing the reply failed: {err}"),
+                }
+            }
+        });
+
+        let (thread_tx, thread_rx) = std::sync::mpsc::channel::<usize>();
+        let (result_tx, result_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let client_socket_path = socket_path.clone();
+        let client_thread = std::thread::spawn(move || {
+            // `pthread_t` is an integer on Linux and an opaque pointer on
+            // macOS; `usize` is the one shape that carries both across the
+            // channel without a `cfg`.
+            let _ = thread_tx.send(unsafe { libc::pthread_self() } as usize);
+            let _ = result_tx.send(request_from_socket_at_detailed(
+                &client_socket_path,
+                r#"{"type":"get-seed"}"#,
+                Some(GET_SEED_REQUEST_TIMEOUT),
+            ));
+            // Outlive the signalling loop, not merely the read: `pthread_kill`
+            // against a thread that has already exited is undefined behaviour,
+            // so this thread may not return until the last signal has been
+            // sent.
+            let _ = release_rx.recv();
+        });
+
+        let client_thread_id = thread_rx
+            .recv_timeout(ASSERT_CEILING)
+            .expect("the client thread must report its thread id");
+
+        std::thread::sleep(SIGNAL_LEAD_IN);
+        for _ in 0..SIGNAL_ROUNDS {
+            unsafe { libc::pthread_kill(client_thread_id as libc::pthread_t, libc::SIGUSR1) };
+            std::thread::sleep(SIGNAL_INTERVAL);
+        }
+
+        let outcome = result_rx.recv_timeout(ASSERT_CEILING);
+        let _ = release_tx.send(());
+        let _ = client_thread.join();
+        let daemon_report = daemon_thread
+            .join()
+            .unwrap_or_else(|_| "the stub daemon thread panicked".to_string());
+        unsafe {
+            libc::sigaction(libc::SIGUSR1, &previous, std::ptr::null_mut());
+        }
+
+        let (reply, read_error) = outcome.expect(
+            "the client thread must return within the ceiling — the operation is bounded at \
+             GET_SEED_REQUEST_TIMEOUT, so a timeout here means an EINTR retry loop that does \
+             not consult the deadline",
+        );
+        assert!(
+            matches!(&reply, SocketReply::Line(line) if line == r#"{"seed":"abc123"}"#),
+            "a read interrupted by a signal must be retried, not mistaken for an absent \
+             daemon — got {reply:?} (read error: {read_error:?}); the stub daemon reports: \
+             {daemon_report}. `SocketReply::Unreachable` here would mean a signal landed \
+             during connect/write instead of during the read, which the {SIGNAL_LEAD_IN:?} \
+             lead-in is sized to prevent."
         );
     }
 

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -2185,6 +2185,13 @@ without depending on the config struct API.
 - **Does not assert:** the *partial*-line-then-EOF case (some bytes written, then closed before the newline) — that is deliberately left returning `Line(partial)`, unchanged by this fix; `SocketReply::Unreachable`; timing.
 - **Platform coverage:** mac+linux (Unix-domain socket).
 
+##### error/socket/007 — A `read(2)` interrupted by a signal (`EINTR`) is retried, not folded into "no daemon".
+- **Layer:** L1 (`src/hook.rs`'s `#[cfg(test)] mod tests`; same synthetic stub-daemon setup as `error/socket/003`/`004`/`005`/`006`).
+- **Agent:** none (a `std::thread` stub daemon that accepts one connection, reads the request line, sleeps 300ms, then writes one reply line — while the test `pthread_kill`s the *client* thread with `SIGUSR1` 25 times at 10ms intervals, under a handler installed without `SA_RESTART` so the interrupted read really does surface as `EINTR` rather than being restarted by the kernel).
+- **Asserts:** `request_from_socket_at` still returns `SocketReply::Line("{\"seed\":\"abc123\"}")`. Issue #564: `read_reply_line`'s `stream.read(&mut buf).ok()?` made *every* `io::Error` terminal, so a single signal on the reading thread ended an exchange that had ~4.7s of its 5s budget left and reported the daemon as absent. Verified to fail before the fix and pass after, with the same fast-fail signature (~0.31s of a 5s budget) as the two macOS CI occurrences.
+- **Does not assert:** the macOS failure itself (not reproducible off macOS — this pins the transient-read-error *class* the evidence points at, on any Unix); which errno macOS actually returned; the `WouldBlock`/`TimedOut` half of `is_transient_read_error`, which needs a deadline-vs-socket-clock divergence no portable stub can force; signal delivery during connect or write (the 50ms lead-in deliberately keeps signals out of that window).
+- **Platform coverage:** mac+linux (Unix-domain socket; `pthread_kill`/`sigaction`).
+
 #### error/config
 
 ##### error/config/001 — `.dot-agent-deck.toml` with an invalid regex makes the new-pane form refuse the mode and surface a status-line message.


### PR DESCRIPTION
Fixes #564.

## Where the defect is: the production timeout logic, not the test's timing assumption

The issue's leading hypothesis was that `socket_004` is a wall-clock race between two threads that a loaded macOS runner can lose. The durations refute that. Both occurrences failed **fast**:

| Occurrence | Head | nextest line | Budget |
|---|---|---|---|
| PR #558 | `3e179daf` | `FAIL [ 0.435s] ( 417/2628)` | `GET_SEED_REQUEST_TIMEOUT` = 5s |
| PR #464 | docs-only (`prds/*.md`) | `FAIL [ 0.401s] ( 405/2826)` | `GET_SEED_REQUEST_TIMEOUT` = 5s |

**This PR's own CI run then closed the argument.** The new artifact (below) records what a *healthy* macOS run of this test costs: `socket_004` **passed on `build-macos` in 0.420s** — sitting between the two failures at 0.401s and 0.435s. So the failing attempts were not slow at all; they took the same wall clock as a passing one and simply returned the wrong answer at the moment the reply was due. Whatever ended them was not the clock. (The honest cost is the test's own 300ms stub-daemon sleep plus platform overhead: 0.307s on Linux, ~0.42s on macOS.) Neither attempt spent a tenth of the budget. Starving this test into a false negative would take **5+ seconds** of scheduler denial — what actually happened returned in 0.4, about 100ms *after* the reply was due. The deadline was never in play, so the "wait on a readiness signal instead of a wall clock" direction would have papered over a real bug.

An abort there is reachable exactly one way. Every other terminal path in `read_reply_line` either needs the full ~5s (deadline expiry) or returns the reply — both EOF branches do, since a partial line is returned as `Some(partial)` and a completed one breaks out. So a `read` returned `Err`, and the loop did:

```rust
let n = stream.read(&mut buf).ok()?;
```

`.ok()?` makes **every** `io::Error` terminal. Two classes carry no information about whether the exchange is over:

- **`Interrupted` (`EINTR`)** — a signal landed on the waiting thread. It says nothing about the peer and nothing about the clock, and `std` does not retry it here the way `Write::write_all` does on the send side.
- **`WouldBlock`/`TimedOut`** — the socket's own per-read `SO_RCVTIMEO`, which is a *different clock* from the total-operation deadline this function advertises.

`read_reply_line` computed `deadline` only to re-arm the next read; it never consulted it when deciding a read failure was final. So the operation ended on the socket's word rather than the deadline's, inverting the contract its own doc comment states ("tracks wall-clock elapsed time against `deadline` … so the operation as a whole … cannot run past `deadline`"). The deadline bounded the operation from above but was not what *ended* it.

The user-visible cost is silent: `get-seed` treats "no reply" and "no daemon" alike and falls back to PTY injection, so a reply that was written and dropped is indistinguishable from an older daemon that never knew the verb. `delegate` shares the transport via `send_and_await_reply`.

## (a) The fix

A read failure is now reconciled with the deadline before it ends anything (`is_transient_read_error`): `Interrupted` always retries; `WouldBlock`/`TimedOut` retry while the operation's own budget has time left; everything else stays terminal. The loop head still returns once the budget is gone, so the operation stays bounded and **the 5s bound is unchanged** — `socket_003` and `socket_005` still return in 5.01s.

`read_reply_line` now returns a typed `ReplyReadError` (`DeadlineExpired` / `ClosedWithoutReply` / `Io` / `InvalidUtf8`) instead of a bare `Option`. **Every variant still folds into `SocketReply::NoReply` at the boundary**, so no caller sees a new outcome; the reason is logged and made available to the tests, because the ambiguity between those four is exactly what made this take two occurrences and a log excavation to place.

## Reproduced — the class, not the macOS failure

I have **no macOS box and did not reproduce the CI failure**, as the issue itself anticipated. What I did reproduce locally is the defect class, deterministically: **`error/socket/007`** drives the same slow stub daemon while `pthread_kill`ing the *client* thread with `SIGUSR1` 25 times at 10ms intervals, under a handler installed deliberately **without `SA_RESTART`** so the interrupted read really surfaces as `EINTR` rather than being restarted by the kernel.

Against the pre-fix logic it fails — and the signature matches CI:

```
FAIL [ 0.310s] socket_007_signal_interrupted_read_still_returns_the_reply
  got NoReply (read error: Some(Io(Os { code: 4, kind: Interrupted, message: "Interrupted system call" })));
  the stub daemon reports: writing the reply failed: Broken pipe (os error 32)
```

0.310s of a 5s budget, next to CI's 0.401s and 0.435s. It passes after the fix, and is stable over repeated runs including pinned to a single core (`taskset -c 0`, 4x, 0.312–0.314s).

To be explicit about what this does **not** establish: it does not prove which errno macOS returned. That is why the fix covers the whole transient class rather than one errno, and why the assertions now print the cause.

## Test hardening

`socket_004` no longer collapses the result into `Option<String>` before asserting — a bare `left: None` is a value that `NoReply` and `Unreachable` produce alike. It now reports the full `SocketReply`, the `ReplyReadError`, **elapsed vs. budget**, and the stub daemon's own outcome (did its write actually succeed?). Had that message existed, the diagnosis above would have come out of the failure instead of out of attempt-1 log archaeology.

The 300ms sleep is kept: the evidence says it was never the problem, and "slow daemon" is the scenario under test.

## (b) A job-level re-run no longer destroys the failing attempt

Two changes:

1. **All three nextest jobs upload their JUnit XML**, named `nextest-<os>-attempt-${{ github.run_attempt }}`. The attempt in the *name* is load-bearing twice over: artifacts are scoped to the run rather than the attempt, and upload-artifact v4+ refuses to overwrite an existing name, so a fixed name would make the re-run's upload fail outright. With it, attempt 1's results sit alongside attempt 2's and stay readable after the conclusion has been overwritten in place.

   The payload is the only structured record of a run — per-test wall clock plus the full failure message. Verified locally that a failing run's XML carries `time="0.325"` and the complete panic text. **The duration is not incidental; it is what diagnosed this issue**, and it currently appears nowhere but a nextest log line that ages out.

   Applied to `build`, `build-windows` and `build-macos`: the masking is a property of re-running any job, not of macOS.

   **Verified live on this PR's first run**, rather than assumed: it produced `nextest-linux-attempt-1`, `nextest-windows-attempt-1` and `nextest-macos-attempt-1` (37-55KB each, 90-day retention), and the macOS one is where the 0.420s figure above came from — a number that would previously have existed only in a log line. That is the mechanism doing exactly its job on its first outing.

2. **Fixed the JUnit path.** nextest resolves `[profile.default.junit] path` relative to the profile's store directory, so `"target/nextest/default/junit.xml"` was actually writing `target/nextest/default/target/nextest/default/junit.xml`. Nothing read the file, so the doubling went unnoticed — which is the point.

## Deliberately not done

- **No `slow-timeout`/retry override for `socket_004`** (the issue's second suggested direction). The evidence says the test is right and the code was wrong; a retry would have hidden a genuine production defect, and `retries = 0` stays the strict default.
- **`UnixStream::connect` still does not retry `EINTR`.** `connect(2)` on an already-bound local AF_UNIX socket completes without blocking, so this is theoretical; `socket_007`'s 50ms lead-in keeps signals out of that window on purpose, and the assertion message names `Unreachable` explicitly so that case would not be mysterious.
- **I did not sweep other `src/**` unit tests for wall-clock cross-thread waits** (the issue's third direction). Worth its own pass; the class here turned out to be a production bug rather than a test-timing one, so the sweep would be looking for something different than originally framed.

## Rule 12 — cross-version contract

**Did this change the TUI↔daemon contract? No.** No wire shape moved, no field changed meaning, no role-map value type shifted; `SocketReply`'s variants and their semantics are identical and the daemon side is untouched. The change is confined to the client's read loop deciding when to stop reading. So no `PROTOCOL_VERSION` bump and no `.breaking.md`.

Because nothing on the wire moved, I did **not** run the two-daemon cross-version sandbox — flagging that explicitly rather than silently, so it can be required if you read the boundary differently.

## Gates

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets --features e2e -- -D warnings` clean
- `cargo test-fast` — 2722 passed, 0 failed
- `cargo xtask linkage-check` — ok (534 catalog ids, 462 annotations)
- `cargo test-e2e` **not** run (rule 5 bounds it to pre-release; this change is fast-tier only)

Changelog fragment: `changelog.d/564.bugfix.md`.
