### PR TITLE
fix(ipc): bound the sync clients' connect step by the caller's deadline (#435)

### DIFF
--- a/changelog.d/435.bugfix.md
+++ b/changelog.d/435.bugfix.md
@@ -1,0 +1,9 @@
+## The deadlines on the deck's synchronous daemon requests now cover connecting, not just talking
+
+Two paths in the deck ask the daemon a question and wait for the answer on the spot: the TUI's own synchronous requests (the manager dialog's run-now, and the hint the `Ctrl+n` form asks for as it opens), and an agent's `delegate` / `get-seed` over the hook socket. Each states a deadline — five seconds, or a quarter of a second for the hint — and each applied it only *after* the connection was open. Connecting itself was unbounded.
+
+That is not a theoretical gap on Unix. A blocking `connect(2)` to a socket whose listener has a full accept queue does not fail: it parks, indefinitely, until something accepts. It does not report "connection refused", and it does not report "try again" either — that is what a non-blocking socket gets, which is exactly why only the blocking path was exposed. So a daemon whose runtime was starved long enough for connections to queue behind it could hang a keystroke in the TUI, or an agent's `delegate`, with no ceiling at all, while the code and its comments said the whole exchange was bounded.
+
+The connect step now honours the caller's budget on both platforms. On Unix the socket is created non-blocking and the connect retried until it succeeds, fails for a real reason, or the budget runs out — a full accept queue is a transient condition worth waiting out, just not forever. Failure kinds are unchanged, so a missing socket file and a stale one still read as "no daemon" exactly as before; blowing the budget is a timeout, which no caller could see previously. Windows could never hang here, but it can now honour a budget *shorter* than its own two-second retry ceiling, so the 250 ms hint path no longer spends two seconds on a busy pipe.
+
+Nothing on the wire moved: this is how the deck opens a connection, not what it says once it is open. A build carrying this fix and one without it interoperate exactly as before.

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -505,8 +505,8 @@ pub const DELEGATE_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::fro
 /// connect/write/read. An earlier draft of this function was exactly that, and
 /// it carried no deadline; sharing the one implementation gives `delegate` the
 /// total-operation bound, the half-close, the read-exactly-one-line behaviour
-/// PRD #163 M4 needed for Windows, and any future fix to the connect phase
-/// (issue #435) for free.
+/// PRD #163 M4 needed for Windows, and — since issue #435 — a connect step that
+/// is inside the deadline rather than beside it, for free.
 pub fn send_and_await_reply(json: &str) -> SocketReply {
     request_from_socket_inner(json, Some(DELEGATE_REPLY_TIMEOUT))
 }
@@ -567,7 +567,10 @@ const GET_SEED_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_
 /// `Some(String::new())`.
 ///
 /// [`GET_SEED_REQUEST_TIMEOUT`] bounds the **whole exchange**, not just a
-/// single idle read: [`request_from_socket_inner`]'s read loop measures
+/// single idle read — and since issue #435 that is literally rather than
+/// approximately true, because the connect step goes through
+/// [`crate::platform::ipc::IpcClient::connect_timeout`] instead of a blocking
+/// `connect(2)` that no deadline reached. The read loop measures
 /// elapsed wall-clock time against it and shrinks each individual blocking
 /// read's own timeout to whatever is left, so a peer that keeps dribbling a
 /// byte at a time without ever completing the reply line can no longer keep
@@ -644,7 +647,19 @@ fn request_from_socket_at(
     // `request_from_socket`'s docs describe. The timeout value itself is
     // unchanged — only when the clock starts.
     let deadline = timeout.map(|budget| std::time::Instant::now() + budget);
-    let mut stream = match crate::platform::ipc::IpcClient::connect(path) {
+    // Issue #435: connect through the deadline-aware entry point, not the bare
+    // one. `IpcClient::connect` blocks uninterruptibly on Unix when the
+    // daemon's accept queue is full, so starting the clock above bounded the
+    // *rest* of the exchange while connect itself could still run past the
+    // budget indefinitely — the whole-exchange bound this function's docs
+    // promise was approximate rather than literal. A connect that blows the
+    // budget lands in `Unreachable`, which is the honest classification: the
+    // request was never sent.
+    let connected = match timeout {
+        Some(budget) => crate::platform::ipc::IpcClient::connect_timeout(path, budget),
+        None => crate::platform::ipc::IpcClient::connect(path),
+    };
+    let mut stream = match connected {
         Ok(stream) => stream,
         Err(_) => return SocketReply::Unreachable,
     };

--- a/src/platform/ipc/mod.rs
+++ b/src/platform/ipc/mod.rs
@@ -28,6 +28,12 @@
 //!   stay compatible with both.
 //! - [`IpcClient`] — a blocking, single-shot connect handle (`std::io::Read +
 //!   Write`) for `hook::send_to_socket` and `ui::send_daemon_request_blocking`.
+//!   It has two connect entry points, and the distinction is load-bearing:
+//!   `connect` is unbounded, while `connect_timeout` honours a caller deadline
+//!   (issue #435). Any caller that advertises a budget must use the latter —
+//!   `connect` blocks uninterruptibly on Unix when the daemon's accept queue is
+//!   full, so a deadline applied only *after* connecting bounds every step of
+//!   the exchange except the one that can hang.
 //!
 //! Endpoint resolution lives in [`crate::platform::paths`] (a socket path on
 //! Unix, a `\\.\pipe\dot-agent-deck-{user}-{hook|attach}` name on Windows);
@@ -258,6 +264,59 @@ mod tests {
                 "round {round} did not round-trip"
             );
         }
+    }
+
+    /// The deadline-aware connect (issue #435) is a drop-in for the plain one
+    /// in the two cases every caller meets in practice: a live endpoint still
+    /// connects, and an absent one still fails with the same `NotFound` the
+    /// unbounded entry point produced — the kind `hook`/`ui` fold into "no
+    /// daemon". Neither of those is a timeout, which is exactly the point: the
+    /// budget must cost nothing when the daemon is healthy or plainly gone.
+    ///
+    /// Un-gated on purpose, so both backends' `connect_timeout` are asserted on
+    /// all three CI jobs. The *queue-full* case the deadline exists for is
+    /// necessarily platform-specific — it needs a listener with a saturated
+    /// `listen(2)` backlog — and lives beside the Unix backend in
+    /// `unix::tests`, which is where the defect was.
+    #[tokio::test]
+    async fn connect_timeout_is_a_drop_in_for_the_unbounded_connect() {
+        let endpoint = unique_endpoint("connect-timeout");
+        let listener = bind_for_test(&endpoint.path);
+
+        let path = endpoint.path.clone();
+        let client = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let mut client = IpcClient::connect_timeout(&path, Duration::from_secs(5))?;
+            client.write_all(b"bounded\n")?;
+            client.flush()
+        });
+        let mut stream = listener.accept().await.expect("accept the client");
+        let mut buf = vec![0u8; 32];
+        let read = stream
+            .read(&mut buf)
+            .await
+            .expect("read the client's frame");
+        client
+            .await
+            .expect("the client task must not panic")
+            .expect("a bounded connect to a live endpoint must succeed");
+        assert_eq!(&buf[..read], b"bounded\n");
+
+        let absent = unique_endpoint("connect-timeout-absent");
+        let started = Instant::now();
+        let err = IpcClient::connect_timeout(&absent.path, Duration::from_secs(5))
+            .err()
+            .map(|e| e.kind())
+            .expect("connecting to an endpoint nothing is serving must fail");
+        assert_eq!(
+            err,
+            std::io::ErrorKind::NotFound,
+            "an absent endpoint must keep reporting NotFound, got {err:?}"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "an absent endpoint must fail immediately, not burn the budget — took {:?}",
+            started.elapsed()
+        );
     }
 
     /// The stale-endpoint predicate keys off the *platform*, not the path shape:

--- a/src/platform/ipc/unix.rs
+++ b/src/platform/ipc/unix.rs
@@ -441,7 +441,7 @@ mod tests {
     struct SaturatedListener {
         _dir: tempfile::TempDir,
         path: std::path::PathBuf,
-        _listener: UnixListener,
+        listener: UnixListener,
         /// Connections already sitting in the accept queue. Held so they are
         /// not closed, and so the queue stays full for the whole test.
         _queued: Vec<UnixStream>,
@@ -497,7 +497,7 @@ mod tests {
                 return Self {
                     _dir: dir,
                     path,
-                    _listener: listener,
+                    listener,
                     _queued: queued,
                     behaviour,
                 };
@@ -552,6 +552,61 @@ mod tests {
         assert!(
             elapsed < CONNECT_BUDGET * 8,
             "connect must return within its budget, took {elapsed:?}"
+        );
+    }
+
+    /// The retry loop must be able to *succeed*, not merely to give up on time.
+    /// Once the listener drains its queue, a connect that was refused a
+    /// millisecond earlier has to complete inside the budget — otherwise a
+    /// `connect_timeout` that could never connect at all would still satisfy the
+    /// saturated-listener test above, and the deck would simply stop talking to
+    /// a busy daemon instead of hanging on one.
+    #[test]
+    fn connect_retries_until_the_listener_drains_its_queue() {
+        let listener = SaturatedListener::new();
+        // Non-blocking so the drain loop below can poll for a queued connection
+        // without parking once the queue is empty.
+        listener
+            .listener
+            .set_nonblocking(true)
+            .expect("make the listener non-blocking");
+
+        let path = listener.path.clone();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let started = Instant::now();
+            let result = IpcClient::connect_timeout(&path, Duration::from_secs(5));
+            let _ = tx.send((started.elapsed(), result));
+        });
+
+        // Drain one connection at a time until the client gets in. Accepting
+        // once is not enough: the filling connect that `SaturatedListener`
+        // left parked is queued as well and may take the first freed slot.
+        let mut drained = Vec::new();
+        let mut outcome = None;
+        for _ in 0..64 {
+            match rx.recv_timeout(Duration::from_millis(50)) {
+                Ok(v) => {
+                    outcome = Some(v);
+                    break;
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    if let Ok((stream, _)) = listener.listener.accept() {
+                        drained.push(stream);
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+
+        let (elapsed, result) =
+            outcome.expect("the connect never returned while the queue drained");
+        if let Err(err) = result {
+            panic!("a connect must succeed once the queue drains, got {err:?} after {elapsed:?}");
+        }
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "the successful connect must land inside the budget, took {elapsed:?}"
         );
     }
 

--- a/src/platform/ipc/unix.rs
+++ b/src/platform/ipc/unix.rs
@@ -11,6 +11,7 @@
 //! so every bound endpoint ends up owner-only exactly as before.
 
 use std::io;
+use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -155,9 +156,100 @@ impl IpcListener {
 pub struct IpcClient(std::os::unix::net::UnixStream);
 
 impl IpcClient {
-    /// Connect synchronously. Lift of `std::os::unix::net::UnixStream::connect`.
+    /// Connect synchronously, with **no** bound on how long the connect itself
+    /// may take. Lift of `std::os::unix::net::UnixStream::connect`.
+    ///
+    /// `connect(2)` on a blocking `AF_UNIX` socket parks indefinitely when the
+    /// listener's accept queue is full — it does *not* report `ECONNREFUSED`,
+    /// and it does not report `EAGAIN` either (that is what a *non-blocking*
+    /// socket gets, which is why only this path is exposed). Any caller that
+    /// advertises a deadline must therefore use [`connect_timeout`] instead;
+    /// this entry point is for the fire-and-forget senders that advertise none
+    /// (`hook::send_to_socket`), where dropping an event on a momentarily-full
+    /// queue would be a worse trade than waiting for a slot.
+    ///
+    /// [`connect_timeout`]: Self::connect_timeout
     pub fn connect(endpoint: &Path) -> io::Result<Self> {
         Ok(Self(std::os::unix::net::UnixStream::connect(endpoint)?))
+    }
+
+    /// Connect synchronously, bounded by `timeout` (issue #435).
+    ///
+    /// `std::os::unix::net::UnixStream` has no `connect_timeout` (unlike
+    /// `TcpStream`), so this is the manual form: create the socket
+    /// non-blocking, then retry `connect(2)` until it succeeds, fails for a
+    /// real reason, or the budget runs out — restoring blocking mode before the
+    /// client is handed back, so the result is indistinguishable from a
+    /// [`connect`](Self::connect) one (blocking reads and writes, bounded by
+    /// [`set_timeouts`](Self::set_timeouts)).
+    ///
+    /// **Retry, not `poll`.** The obvious shape — connect once, `poll(2)` for
+    /// writability, read the outcome out of `SO_ERROR` — is the `TcpStream`
+    /// recipe and it is silently wrong here. `connect(2)` documents
+    /// `EINPROGRESS` as the pollable "started, not finished" state and says in
+    /// as many words that "UNIX domain sockets failed with `EAGAIN` instead":
+    /// on `AF_UNIX` a queue-full connect starts nothing, so there is no pending
+    /// operation for writability to report the completion of. Worse, an
+    /// *unconnected* Unix socket already polls writable (the kernel's
+    /// `unix_writable` only excludes a listening socket and a full send
+    /// buffer), so the `poll` returns instantly, `SO_ERROR` is 0 — nothing
+    /// failed, nothing was attempted — and the caller is handed a client that
+    /// is not connected to anything. Measured, not reasoned: that version
+    /// returned `Ok` against a saturated listener in single-digit milliseconds.
+    /// `EINPROGRESS`/`EALREADY` are still folded into the retry so this stays
+    /// correct if the endpoint type ever changes.
+    ///
+    /// Retrying is also the right *behaviour* for the condition, not merely the
+    /// available one: a full accept queue is transient, and the Windows backend
+    /// already retries its exact analogue (`ERROR_PIPE_BUSY`) against a budget.
+    ///
+    /// Error kinds are preserved, because everything except "try again" is
+    /// reported by `connect(2)` itself and propagated verbatim: `NotFound` for
+    /// a missing socket file, `ConnectionRefused` for a stale inode (and, on
+    /// the BSDs, for the queue-full case Linux makes you wait through),
+    /// `PermissionDenied` for a socket we may not talk to. Blowing the budget
+    /// is [`io::ErrorKind::TimedOut`], which no caller had a way to see before.
+    pub fn connect_timeout(endpoint: &Path, timeout: std::time::Duration) -> io::Result<Self> {
+        let (addr, addr_len) = sockaddr_un(endpoint)?;
+        let stream = cloexec_stream_socket()?;
+        let fd = stream.as_raw_fd();
+        stream.set_nonblocking(true)?;
+
+        let started = std::time::Instant::now();
+        let mut backoff = CONNECT_RETRY_INITIAL;
+        loop {
+            // SAFETY: `addr` is a well-formed `sockaddr_un` living on this stack
+            // frame for the whole loop and `addr_len` is its exact length; `fd`
+            // is the socket `stream` owns, so it stays open throughout.
+            let rc = unsafe { libc::connect(fd, std::ptr::addr_of!(addr).cast(), addr_len) };
+            if rc == 0 {
+                break;
+            }
+            let err = io::Error::last_os_error();
+            let remaining = timeout.saturating_sub(started.elapsed());
+            match err.raw_os_error() {
+                // An attempt from an earlier iteration completed underneath us.
+                Some(libc::EISCONN) => break,
+                // Retry at once rather than sleeping, but still against the
+                // deadline: a signal storm must not turn this into the
+                // unbounded loop the whole change exists to remove.
+                Some(libc::EINTR) if !remaining.is_zero() => continue,
+                Some(libc::EAGAIN) | Some(libc::EINPROGRESS) | Some(libc::EALREADY)
+                    if !remaining.is_zero() =>
+                {
+                    std::thread::sleep(backoff.min(remaining));
+                    backoff = (backoff * 2).min(CONNECT_RETRY_MAX);
+                }
+                Some(libc::EINTR)
+                | Some(libc::EAGAIN)
+                | Some(libc::EINPROGRESS)
+                | Some(libc::EALREADY) => return Err(connect_timed_out(endpoint, timeout)),
+                _ => return Err(err),
+            }
+        }
+
+        stream.set_nonblocking(false)?;
+        Ok(Self(stream))
     }
 
     /// Apply a read+write timeout (used by the ui request/response path so a
@@ -195,5 +287,291 @@ impl std::io::Write for IpcClient {
 
     fn flush(&mut self) -> io::Result<()> {
         self.0.flush()
+    }
+}
+
+/// A fresh, unconnected `AF_UNIX` stream socket with close-on-exec set.
+///
+/// Close-on-exec matters because the deck `exec`s agents constantly (every PTY
+/// pane); an fd that survives into an agent's process is a leaked handle on the
+/// daemon socket. [`std::os::unix::net::UnixStream::connect`] sets it, so
+/// [`IpcClient::connect_timeout`] — which has to build the socket itself in
+/// order to connect non-blocking — must too. Linux gets it atomically via
+/// `SOCK_CLOEXEC`; elsewhere a follow-up `fcntl` leaves a window only a
+/// concurrent `fork`+`exec` between the two calls could exploit, which is what
+/// the stdlib does on those platforms as well.
+fn cloexec_stream_socket() -> io::Result<std::os::unix::net::UnixStream> {
+    #[cfg(target_os = "linux")]
+    let socket_type = libc::SOCK_STREAM | libc::SOCK_CLOEXEC;
+    #[cfg(not(target_os = "linux"))]
+    let socket_type = libc::SOCK_STREAM;
+
+    // SAFETY: `socket(2)` takes no pointers; the arguments are the constant
+    // AF_UNIX/SOCK_STREAM pair. The returned fd is owned by us.
+    let fd = unsafe { libc::socket(libc::AF_UNIX, socket_type, 0) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: `fd` is a fresh, valid, exclusively-owned socket fd, and the raw
+    // handle is not used to close it anywhere — `stream` owns it from here and
+    // closes it exactly once, including on the error path below.
+    let stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(fd) };
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        // SAFETY: `fd` is the socket `stream` owns; `F_SETFD` takes an int
+        // argument, no pointers. `FD_CLOEXEC` is the only descriptor flag, so
+        // setting it outright cannot clear another.
+        if unsafe { libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+
+    Ok(stream)
+}
+
+/// Gap before the FIRST `connect(2)` retry in [`IpcClient::connect_timeout`].
+/// Short enough that a listener draining its queue costs the caller nothing
+/// measurable.
+const CONNECT_RETRY_INITIAL: std::time::Duration = std::time::Duration::from_millis(1);
+/// Ceiling the gap doubles up to. Keeps a full 5s budget down to a few hundred
+/// cheap syscalls rather than a spin, while staying far below any budget a
+/// caller states (the shortest is the 250ms hint path in `ui`).
+const CONNECT_RETRY_MAX: std::time::Duration = std::time::Duration::from_millis(20);
+
+fn connect_timed_out(endpoint: &Path, timeout: std::time::Duration) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::TimedOut,
+        format!(
+            "connecting to {} timed out after {timeout:?}",
+            endpoint.display()
+        ),
+    )
+}
+
+/// Encode `endpoint` as a filesystem `AF_UNIX` address, returning the address
+/// and the exact `socklen_t` to pass to `connect(2)`/`bind(2)`.
+///
+/// Mirrors what `std::os::unix::net::UnixStream::connect` does internally (the
+/// stdlib keeps its version private): reject an over-long path or one carrying
+/// an interior NUL up front with `InvalidInput`, then copy the bytes into a
+/// zeroed `sockaddr_un` and size the address to `offsetof(sun_path) + len + 1`
+/// rather than `size_of::<sockaddr_un>()`, so the trailing NUL is included and
+/// nothing beyond it is.
+fn sockaddr_un(endpoint: &Path) -> io::Result<(libc::sockaddr_un, libc::socklen_t)> {
+    use std::os::unix::ffi::OsStrExt;
+
+    // SAFETY: `sockaddr_un` is a plain C struct of scalars and a byte array,
+    // for which all-zero is a valid (and the conventional) initial state.
+    let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+    addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
+
+    let bytes = endpoint.as_os_str().as_bytes();
+    if bytes.contains(&0) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "socket path contains an interior NUL byte",
+        ));
+    }
+    // `<` and not `<=`: `sun_path` must still hold the terminating NUL.
+    if bytes.len() >= addr.sun_path.len() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "socket path is longer than the platform's sun_path limit",
+        ));
+    }
+    // SAFETY: `bytes.len()` is strictly less than `sun_path`'s length (checked
+    // above), the two regions cannot overlap (`addr` is a fresh stack local),
+    // and `sun_path` is a byte array whose element type is `c_char` — written
+    // through a `u8` pointer to avoid a same-width cast that flips signedness
+    // between targets.
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            bytes.as_ptr(),
+            addr.sun_path.as_mut_ptr().cast::<u8>(),
+            bytes.len(),
+        );
+    }
+
+    let len = std::mem::offset_of!(libc::sockaddr_un, sun_path) + bytes.len() + 1;
+    Ok((addr, len as libc::socklen_t))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::net::{UnixListener, UnixStream};
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    use super::*;
+
+    /// How long the reproduction waits for a connect to come back before
+    /// declaring it hung. Comfortably above [`CONNECT_BUDGET`] so a slow CI box
+    /// cannot make a *bounded* connect look like a hung one.
+    const WATCHDOG: Duration = Duration::from_secs(5);
+    /// The deadline the connect under test advertises.
+    const CONNECT_BUDGET: Duration = Duration::from_millis(250);
+
+    /// How a platform answers a `connect(2)` to a listener whose accept queue
+    /// is full — the one place the two Unixes genuinely differ, so the test
+    /// asserts against what the platform actually did rather than guessing.
+    #[derive(Debug, PartialEq, Eq)]
+    enum QueueFull {
+        /// Linux: a *blocking* `connect(2)` parks indefinitely. This is the
+        /// hang issue #435 is about.
+        Parks,
+        /// The BSDs (macOS included): `sonewconn` refuses over-limit
+        /// connections outright, so connect fails fast with `ECONNREFUSED` and
+        /// was never able to hang. The client still has to come back inside its
+        /// budget, which is what the test asserts either way.
+        Refuses,
+    }
+
+    /// A listener whose accept queue is full and that never calls `accept(2)`.
+    ///
+    /// This is the shape issue #435 is about: on Linux a *blocking* `connect(2)`
+    /// to such an endpoint parks indefinitely — it does not get
+    /// `ECONNREFUSED`, and it does not get `EAGAIN` either (that is what a
+    /// *non-blocking* socket gets, which is precisely why only the blocking
+    /// path is affected).
+    ///
+    /// The backlog is set to 1 via a raw `listen(2)` because
+    /// `UnixListener::bind` hardcodes 128, and queuing 129 connections to reach
+    /// the same state is slower and no more faithful.
+    struct SaturatedListener {
+        _dir: tempfile::TempDir,
+        path: std::path::PathBuf,
+        _listener: UnixListener,
+        /// Connections already sitting in the accept queue. Held so they are
+        /// not closed, and so the queue stays full for the whole test.
+        _queued: Vec<UnixStream>,
+        behaviour: QueueFull,
+    }
+
+    impl SaturatedListener {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("saturated.sock");
+
+            // SAFETY: a plain `socket(2)` with the constant AF_UNIX/SOCK_STREAM
+            // pair; the returned fd is handed to `UnixListener::from_raw_fd`
+            // below, which takes sole ownership and closes it exactly once.
+            let fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
+            assert!(fd >= 0, "socket: {}", io::Error::last_os_error());
+            // SAFETY: `fd` is a fresh, valid, exclusively-owned socket fd that
+            // is not used through the raw handle again after this point.
+            let listener = unsafe { UnixListener::from_raw_fd(fd) };
+
+            let (addr, len) = sockaddr_un(&path).expect("encode the socket path");
+            // SAFETY: `addr`/`len` describe a well-formed `sockaddr_un` that
+            // outlives the call, and `fd` is our own listening socket.
+            let rc = unsafe { libc::bind(fd, std::ptr::addr_of!(addr).cast(), len) };
+            assert_eq!(rc, 0, "bind: {}", io::Error::last_os_error());
+            // SAFETY: `fd` is our own bound socket; `listen(2)` has no
+            // pointer arguments.
+            let rc = unsafe { libc::listen(fd, 1) };
+            assert_eq!(rc, 0, "listen: {}", io::Error::last_os_error());
+
+            // Fill the queue. Exactly how many connections fit is a kernel
+            // detail (Linux admits backlog + 1), so keep connecting until the
+            // queue stops taking them rather than assuming a count — and let
+            // the platform tell us *how* it stops. Each filling connect runs on
+            // its own thread because on Linux the one that finds the queue full
+            // parks: that parked connect is the bug under test, and it stays
+            // parked until the process exits, which is harmless.
+            let mut queued = Vec::new();
+            for _ in 0..64 {
+                let probe = path.clone();
+                let (tx, rx) = mpsc::channel();
+                std::thread::spawn(move || {
+                    let _ = tx.send(UnixStream::connect(&probe));
+                });
+                let behaviour = match rx.recv_timeout(Duration::from_millis(500)) {
+                    Ok(Ok(stream)) => {
+                        queued.push(stream);
+                        continue;
+                    }
+                    Ok(Err(_)) => QueueFull::Refuses,
+                    Err(_) => QueueFull::Parks,
+                };
+                return Self {
+                    _dir: dir,
+                    path,
+                    _listener: listener,
+                    _queued: queued,
+                    behaviour,
+                };
+            }
+            panic!("could not saturate the listener's accept queue");
+        }
+    }
+
+    /// Run [`IpcClient::connect_timeout`] on its own thread and report how long
+    /// it took, or `None` if it never came back within [`WATCHDOG`].
+    ///
+    /// The connect runs on a thread of its own precisely because the defect
+    /// under test is an *uninterruptible* block: calling it inline would hang
+    /// the test process instead of failing it, which is not a reproduction.
+    fn timed_connect(path: &std::path::Path) -> Option<(Duration, io::Result<IpcClient>)> {
+        let path = path.to_path_buf();
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let started = Instant::now();
+            let result = IpcClient::connect_timeout(&path, CONNECT_BUDGET);
+            let _ = tx.send((started.elapsed(), result));
+        });
+        rx.recv_timeout(WATCHDOG).ok()
+    }
+
+    /// Issue #435: the synchronous client's connect must honour the caller's
+    /// deadline. Against a listener whose backlog is full and that never
+    /// accepts, a blocking `connect(2)` parks forever, so the deadline the two
+    /// sync IPC callers advertise never covers the connect step at all.
+    #[test]
+    fn connect_against_a_saturated_listener_returns_within_the_deadline() {
+        let listener = SaturatedListener::new();
+
+        let (elapsed, result) = timed_connect(&listener.path)
+            .expect("connect never returned — it is still parked in connect(2)");
+
+        let Err(err) = result else {
+            panic!("a saturated listener must not hand back a connected client");
+        };
+        let expected = match listener.behaviour {
+            QueueFull::Parks => io::ErrorKind::TimedOut,
+            QueueFull::Refuses => io::ErrorKind::ConnectionRefused,
+        };
+        assert_eq!(
+            err.kind(),
+            expected,
+            "a {:?} platform must report {expected:?}, got {err:?}",
+            listener.behaviour
+        );
+        // Generous multiple of the budget: the assertion is "bounded, not
+        // parked", and a loaded CI box may schedule the thread late.
+        assert!(
+            elapsed < CONNECT_BUDGET * 8,
+            "connect must return within its budget, took {elapsed:?}"
+        );
+    }
+
+    /// The control for the test above: the same client, the same code path, a
+    /// listener that is merely *not* accepting yet rather than saturated. This
+    /// must still connect, and promptly — otherwise the failure above would
+    /// only show that the deck cannot talk to an un-accepted socket at all.
+    #[test]
+    fn connect_against_a_listener_with_room_still_succeeds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("roomy.sock");
+        let _listener = UnixListener::bind(&path).expect("bind");
+
+        let (elapsed, result) = timed_connect(&path).expect("connect never returned");
+        if let Err(err) = result {
+            panic!("connecting to a listener with a free backlog slot must succeed: {err}");
+        }
+        assert!(
+            elapsed < CONNECT_BUDGET,
+            "a healthy connect must be fast, took {elapsed:?}"
+        );
     }
 }

--- a/src/platform/ipc/unix.rs
+++ b/src/platform/ipc/unix.rs
@@ -564,6 +564,23 @@ mod tests {
     #[test]
     fn connect_retries_until_the_listener_drains_its_queue() {
         let listener = SaturatedListener::new();
+        if listener.behaviour == QueueFull::Refuses {
+            // There is no retry to observe on the BSDs: the kernel answers a
+            // full queue with `ECONNREFUSED`, which is a FINAL answer that
+            // `connect_timeout` must propagate rather than retry — a stale
+            // socket inode reports the same errno, and the daemon's
+            // stale-endpoint probe depends on seeing it immediately. What
+            // replaces this test there is asserted directly by
+            // `connect_against_a_saturated_listener_returns_within_the_deadline`
+            // (queue-full is `ConnectionRefused`) and by
+            // `connect_does_not_retry_a_stale_socket_inode` (that errno is not
+            // retried anywhere).
+            eprintln!(
+                "skipped: this platform refuses a full accept queue rather than parking on it, \
+                 so connect_timeout's retry loop is unreachable here"
+            );
+            return;
+        }
         // Non-blocking so the drain loop below can poll for a queued connection
         // without parking once the queue is empty.
         listener
@@ -607,6 +624,40 @@ mod tests {
         assert!(
             elapsed < Duration::from_secs(5),
             "the successful connect must land inside the budget, took {elapsed:?}"
+        );
+    }
+
+    /// The retry loop must not swallow a FINAL answer. A socket inode with no
+    /// listener behind it — what a crashed daemon leaves — reports
+    /// `ECONNREFUSED`, the same errno the BSDs use for a full accept queue, and
+    /// `daemon.rs`'s stale-endpoint dance keys off seeing it *promptly*: it is
+    /// the probe that decides whether to unlink the leftover and rebind. Adding
+    /// `ECONNREFUSED` to the retryable set — the obvious way to "fix" a BSD
+    /// running the test above — would leave that classification intact while
+    /// making every stale-socket probe cost the caller's whole budget, so this
+    /// pins the timing as well as the kind.
+    #[test]
+    fn connect_does_not_retry_a_stale_socket_inode() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("stale.sock");
+        // Bind and drop: the stdlib does not unlink on drop, so the inode
+        // outlives the listener exactly as a crashed daemon's does.
+        drop(UnixListener::bind(&path).expect("bind"));
+        assert!(path.exists(), "the stale inode must survive the listener");
+
+        let started = Instant::now();
+        let Err(err) = IpcClient::connect_timeout(&path, Duration::from_secs(5)) else {
+            panic!("a socket with no listener must not connect");
+        };
+        assert_eq!(
+            err.kind(),
+            io::ErrorKind::ConnectionRefused,
+            "the stale-inode classification the daemon probes for must survive, got {err:?}"
+        );
+        assert!(
+            started.elapsed() < CONNECT_BUDGET,
+            "a final answer must be returned at once, not retried to the deadline — took {:?}",
+            started.elapsed()
         );
     }
 

--- a/src/platform/ipc/windows.rs
+++ b/src/platform/ipc/windows.rs
@@ -370,6 +370,27 @@ impl IpcClient {
     /// check — stated explicitly on the async side too
     /// ([`IpcStream::connect`]) rather than inherited from a `tokio` default.
     pub fn connect(endpoint: &Path) -> io::Result<Self> {
+        Self::connect_within(endpoint, CONNECT_RETRY_BUDGET)
+    }
+
+    /// Connect bounded by `timeout` — the Windows half of issue #435's
+    /// `connect_timeout` seam, so the two synchronous callers can state one
+    /// deadline that actually covers the connect step on both platforms.
+    ///
+    /// Windows was never able to hang here: a named-pipe connect either
+    /// succeeds, fails outright, or reports `ERROR_PIPE_BUSY` (all instances
+    /// taken, the next not yet created — the analogue of a momentarily-full
+    /// Unix accept queue), and that last case has always been bounded by
+    /// [`CONNECT_RETRY_BUDGET`]. What it could not do is honour a budget
+    /// *shorter* than that: the 250 ms hint path in
+    /// `ui::send_daemon_request_blocking_with_timeout` would still spend two
+    /// seconds retrying. Taking the smaller of the two therefore tightens this
+    /// path and can never loosen it.
+    pub fn connect_timeout(endpoint: &Path, timeout: Duration) -> io::Result<Self> {
+        Self::connect_within(endpoint, timeout.min(CONNECT_RETRY_BUDGET))
+    }
+
+    fn connect_within(endpoint: &Path, retry_budget: Duration) -> io::Result<Self> {
         let wide = wide_nul(endpoint.as_os_str());
         let mut waited = Duration::ZERO;
         let raw = loop {
@@ -392,8 +413,8 @@ impl IpcClient {
                 break handle;
             }
             let err = io::Error::last_os_error();
-            if err.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) && waited < CONNECT_RETRY_BUDGET {
-                std::thread::sleep(CONNECT_RETRY_INTERVAL);
+            if err.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) && waited < retry_budget {
+                std::thread::sleep(CONNECT_RETRY_INTERVAL.min(retry_budget - waited));
                 waited += CONNECT_RETRY_INTERVAL;
                 continue;
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -745,7 +745,13 @@ fn send_daemon_request_blocking_with_timeout(
     use std::io::Write;
 
     let path = config::attach_socket_path();
-    let mut stream = crate::platform::ipc::IpcClient::connect(&path)?;
+    // Issue #435: `timeout` is a per-operation deadline, and connect is one of
+    // the operations. Connecting through the bare `IpcClient::connect` left it
+    // outside the budget entirely — on Unix that call blocks uninterruptibly
+    // when the daemon's accept queue is full, so a wedged daemon could hang
+    // this synchronous TUI key path forever despite the deadline two lines
+    // below.
+    let mut stream = crate::platform::ipc::IpcClient::connect_timeout(&path, timeout)?;
     stream.set_timeouts(timeout)?;
 
     let payload = serde_json::to_vec(req).map_err(std::io::Error::other)?;


### PR DESCRIPTION
Fixes #435.

## The defect

Both synchronous IPC paths opened the connection with a blocking, uninterruptible call and applied their deadline only afterwards:

- `src/hook.rs` — `request_from_socket_at` (the `get-seed` and `delegate` verbs), whose doc comment claims to bound the **whole exchange**;
- `src/ui.rs` — `send_daemon_request_blocking_with_timeout` (the manager dialog's run-now and the 250 ms `Ctrl+n` hint), on the synchronous TUI key path.

On Unix `IpcClient::connect` was a straight lift of `std::os::unix::net::UnixStream::connect`, which honours no timeout — so the connect step sat outside every budget those callers advertise.

## Reproduced first

`connect(2)` to a Unix socket whose listener has a full accept queue and never calls `accept()` **parks indefinitely**. It does not report `ECONNREFUSED`, and it does not report `EAGAIN` either — that is what a *non-blocking* socket gets, which is precisely why only the blocking path was exposed.

The new `platform::ipc::unix::tests::connect_against_a_saturated_listener_returns_within_the_deadline` builds exactly that shape (a raw `listen(2)` with backlog 1, filled until the queue stops taking connections, never accepted). Against the code as it stood it **sat parked past a 5 s watchdog**; with the fix it returns `TimedOut` in ~250 ms. Reverting `connect_timeout` to delegate to `connect` turns it red again, so the fix is load-bearing rather than incidental.

Its control — the same client, the same code path, a listener with a free backlog slot — connects in 6 ms both before and after, so the red above is attributable to saturation and not to "the deck can no longer talk to an un-accepted socket".

## The fix

`IpcClient::connect_timeout(endpoint, timeout)` on both backends; both sync callers now use it.

**Unix** creates the socket non-blocking and retries `connect(2)` against the budget with a 1 ms → 20 ms backoff. The obvious shape — connect once, `poll(2)` for writability, read `SO_ERROR` — is the `TcpStream` recipe and is silently wrong here, which I found by measurement rather than by reasoning: `connect(2)` documents `EINPROGRESS` as the pollable "started, not finished" state and states that "UNIX domain sockets failed with `EAGAIN` instead", and an *unconnected* Unix socket already polls writable, so that version returned `Ok` — with a client connected to nothing — against a saturated listener in single-digit milliseconds. Retrying is also the right behaviour for the condition: a full accept queue is transient, and the Windows backend already retries its exact analogue (`ERROR_PIPE_BUSY`) against a budget.

Error kinds are preserved: everything except "try again" comes straight from `connect(2)`, so a missing socket file is still `NotFound` and a stale inode still `ConnectionRefused`. Blowing the budget is `TimedOut`, which no caller had a way to see before. The socket is created `SOCK_CLOEXEC` (with an `fcntl` fallback off Linux) to match what the stdlib's connect does — the deck `exec`s an agent per pane, so a leaked daemon-socket fd would be a real handle escape.

**Windows** could never hang here, but it could not honour a budget *shorter* than its own 2 s retry ceiling either; `connect_timeout` takes the smaller of the two, so the 250 ms hint path no longer spends two seconds on a busy pipe. This only tightens the path.

**`hook::send_to_socket` deliberately keeps the unbounded `connect`.** It advertises no deadline, and dropping an agent event on a momentarily-full queue is a worse trade than waiting for a slot. That is now stated on `connect`'s own doc comment, so the choice between the two entry points is documented at the seam rather than left to be rediscovered.

## Cross-version contract (CLAUDE.md rule 12)

**Did this change the TUI↔daemon contract? No.** No request or response variant, field, or framing moved, and no field changed meaning — this is how a connection is *opened*, not what is said over it. `PROTOCOL_VERSION` stays at **7** (both `v0.36.2` and this branch report `server_version: 7` from `daemon hello`), and no `changelog.d/*.breaking.md` fragment applies. Bump class: **bugfix → patch**.

Verified rather than asserted. A `v0.36.2` daemon was started in a fully isolated sandbox (sockets, lock dir, state dir, config, `HOME`, **and `DOT_AGENT_DECK_LOG`**), and this branch's binary was driven against it:

| Path | Result |
|---|---|
| Attach socket — TUI attach + `daemon status` | both panes listed |
| `Ctrl+n` form (`send_daemon_request_blocking_with_timeout`, 250 ms) | form opened, orchestration offered and created |
| `delegate` (`send_and_await_reply` → `connect_timeout`) | routed; task file written with the exact task text; worker pane received it |
| `agent-event --type running` | arrived; the worker card flipped to Thinking |
| `work-done --done` | arrived; the daemon retired the delegation and cancelled its idle watch |
| `get-seed` (`request_from_socket` → `connect_timeout`) | answered (`has_seed=false`) |

One wrinkle worth recording, because it makes the naive form of this test vacuous: the **first** attempt did not test cross-version at all. The branch build's `DAD_BUILD_ID` differs from the release's, so the PRD #103 handshake did what it is supposed to do — the branch TUI `SIGTERM`'d the older daemon on attach and lazy-spawned its own, and everything after that was same-version. The run above therefore builds the branch with `DAD_VERSION=0.36.2 DAD_BUILD_ID=0.36.2-g4bb47a5` so the handshake sees a current daemon and attaches to it; the `v0.36.2` daemon PID was confirmed still serving after every step. Anyone repeating this check on a daemon-adjacent PR should mask the build id the same way, or they will silently test a new binary against itself.

## Tests

- `platform::ipc::unix::tests::connect_against_a_saturated_listener_returns_within_the_deadline` — the reproduction. Asserts against what the platform actually did, because Linux and the BSDs genuinely differ here: Linux parks a blocking connect (`TimedOut` after the budget), while `sonewconn` on the BSDs refuses an over-limit connection outright (`ConnectionRefused`, fast). Either way the client must come back inside its budget, which is the property under test.
- `platform::ipc::unix::tests::connect_against_a_listener_with_room_still_succeeds` — the control.
- `platform::ipc::unix::tests::connect_retries_until_the_listener_drains_its_queue` — the failure direction alone is not enough: a `connect_timeout` that could never connect *at all* would satisfy the reproduction above, and returning `TimedOut` on the first `EAGAIN` does exactly that while leaving it green. This test saturates the same listener, starts a connect with a 5 s budget, then drains the queue until the client gets in — and was confirmed to fail under that stubbed-out implementation while the reproduction stayed green.
- `platform::ipc::tests::connect_timeout_is_a_drop_in_for_the_unbounded_connect` — un-gated, so both backends are asserted on all three CI jobs: a live endpoint still round-trips, and an absent one still fails with `NotFound` immediately rather than burning the budget.

No TUI test is added under rule 4: nothing user-visible changes except in the pathological wedged-daemon case, which has no rendered surface.

## Gates

`cargo fmt --check`, `cargo clippy --workspace --all-targets --features e2e -- -D warnings`, `cargo test-fast` (2724/2724), and `cargo xtask linkage-check` all clean.

