### PR TITLE
fix(agent-pty): set pane_handed_over on the synthetic test agent — unbreak main

### DIFF
--- a/src/agent_pty.rs
+++ b/src/agent_pty.rs
@@ -6032,6 +6032,11 @@ impl AgentPtyRegistry {
                 pty_rows: 24,
                 pty_cols: 80,
                 exited: Arc::new(AtomicBool::new(false)),
+                // Issue #454: `false` is the birth value — the flag latches to
+                // `true` only when a *successor* takes this record's pane, and
+                // this synthetic agent holds no pane at all (`pane_id_env:
+                // None`), so nothing can ever hand one over.
+                pane_handed_over: false,
                 pending_seed: None,
                 seed_delivered_native: false,
             },


### PR DESCRIPTION
## `main` is RED — this unblocks a pending release. Please prioritise.

`main` at 776fab8 does not compile. Four of eight jobs in run [32249065340](https://github.com/vfarcic/dot-agent-deck/actions/runs/32249065340) fail — `build`, `build-macos`, `build-windows`, `windows-cross-check` — all on one hard compile error, not a flake:

```
error[E0063]: missing field `pane_handed_over` in initializer of `agent_pty::RunningAgent`
    --> src/agent_pty.rs:6011:13
```

It surfaces in the **lib-test** target, which is why it takes out all four: `cargo clippy --workspace --all-targets --features e2e` on Linux, `cargo nextest run --workspace` on macOS/Windows, and the Windows cross type-check.

## Root cause: a semantic merge conflict between two independently-green PRs

Neither PR touched a line the other touched, so neither CI run could have seen the break:

- **#607** (`715bc95`, issue #454) added `pub pane_handed_over: bool` to `RunningAgent` and updated **every construction site that existed at that time**.
- **#597** (`5c9d08b`, issue #581) added a **new** construction site — the `insert_test_agent` seam, the synthetic wedged-child test agent — which of course does not set a field that did not exist on its branch.

Both merged green; the combination is red. This is exactly the failure mode tracked in **#513** ("A PR can merge on CI that predates the gate which would have caught it"). Not fixing #513 here — this is the unbreak only.

## The fix

One field, at the one site that lacks it.

`false` is the *correct* value, not just the one that compiles. `pane_handed_over` is a **monotone latch**: it is set at PUBLISH (src/agent_pty.rs:4323-4330), only when a *successor* takes over a pane this record still holds, and it is never cleared — that permanence is the whole point, so a retired generation cannot get its pane back once both records die (read site: src/agent_pty.rs:5594-5605). The synthetic agent carries `pane_id_env: None`, so it holds no pane at all and nothing can ever hand one over. This matches the production site's own birth value and its comment at src/agent_pty.rs:4374-4378: *"a fresh generation has not been handed over yet."*

## Other sites, and the mirror-image hazard — both checked

`git grep -n "RunningAgent {"` gives five hits, and all five are accounted for:

| Site | Kind | Status |
|---|---|---|
| src/agent_pty.rs:1569 | struct declaration | n/a |
| src/agent_pty.rs:1730 | `impl` block | n/a |
| src/agent_pty.rs:4353 | production construction | already correct (`pane_handed_over: false`) |
| src/agent_pty.rs:5201 | **destructuring** | already correct — see below |
| src/agent_pty.rs:6011 | test construction | **fixed here** |

The mirror-image hazard is already covered: the respawn destructuring at :5201 binds `pane_handed_over: _` **explicitly** rather than eliding with `..`, so it is exhaustive and a future field addition still breaks loudly there rather than silently dropping a field. `RunningAgent` is constructed nowhere outside `src/agent_pty.rs` — every other `RunningAgent*` reference in the tree is `RunningAgentsSummary`, an unrelated type.

## Verification

Reproduced first on unpatched `main` (single E0063, as quoted above), then all gates run locally on the fix:

| Gate | Result |
|---|---|
| `cargo fmt --check` | clean |
| `cargo clippy --workspace --all-targets --features e2e -- -D warnings` | clean (exit 0) |
| `cargo test-fast` | **2887 passed, 0 failed, 0 skipped** |
| `scripts/windows-cross-check.sh` | clean (exit 0) |

The last one was run locally too, since `windows-cross-check` is one of the four red jobs. The four tests that actually drive `insert_test_agent` (src/agent_pty.rs:10472, :10528, :10611, :10663 — #581's wedged-reap shutdown coverage) are in that passing run.

## Changelog fragment: deliberately none

Both colliding commits post-date `v0.36.2`, and each already carries its own fragment (`changelog.d/454.bugfix.md`, `changelog.d/581.bugfix.md`). So the two features that collided will be described in the next release notes, while the collision itself never reached a released build — no user could have encountered it. A third fragment would describe a defect that only ever existed between two unreleased commits on `main`.

## Scope

Deliberately minimal and surgical — an urgent unbreak, not a refactor. No restructuring of the helper, no renames, no unrelated lint fixes. The diff is five added lines: one field and its rationale comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
