### PR TITLE
docs(prd): add agent control-plane discovery portfolio

### DIFF
--- a/prds/221-agent-conformance-compatibility-evidence.md
+++ b/prds/221-agent-conformance-compatibility-evidence.md
@@ -1,0 +1,91 @@
+# PRD #221: Agent conformance and compatibility evidence
+
+**Status**: Candidate (Discovery)
+**Issue**: [#221](https://github.com/vfarcic/dot-agent-deck/issues/221)
+**Priority**: Medium
+**Created**: 2026-08-21
+**Builds on**: [#20](https://github.com/vfarcic/dot-agent-deck/issues/20) (multi-agent strategies), [#201](https://github.com/vfarcic/dot-agent-deck/issues/201) (Pi integration)
+**Interacts with**: [#234](https://github.com/vfarcic/dot-agent-deck/issues/234) (hookless screen-state observation), [#211](https://github.com/vfarcic/dot-agent-deck/issues/211) (Gemini), [#212](https://github.com/vfarcic/dot-agent-deck/issues/212) (Aider), [#502](https://github.com/vfarcic/dot-agent-deck/issues/502) (e2e reliability), [#164](https://github.com/vfarcic/dot-agent-deck/issues/164) (Windows release validation)
+
+## Opportunity
+
+dot-agent-deck supports several agents through native hooks, plugins, extensions, wrappers, and fallback observation, but support is currently understood through implementation details and scattered tests. Users cannot quickly determine which lifecycle states, prompt metadata, tool activity, delegation directions, restoration behavior, or platforms are genuinely validated for each agent.
+
+Issue #221 originally proposed a real-agent orchestrator-by-worker interoperability matrix. That matrix remains useful evidence, but a full N-by-N run is expensive, flaky, and mostly repeats agent-agnostic deck routing. The larger opportunity is a conformance model that defines support levels, tests the capabilities each integration claims, makes adapter regressions visible, and publishes only evidence that is repeatable enough to trust.
+
+## Target Users And Jobs
+
+- A user choosing an agent combination and needing to know which deck capabilities will work.
+- A contributor adding or updating an adapter and needing a mechanical contract and test target.
+- A maintainer detecting upstream CLI or hook changes before they silently degrade status or routing.
+- A future external adapter author evaluating whether extension can be supported safely.
+
+## Current Evidence
+
+- The compiled registry and strategy seam normalize materially different integrations behind `AgentEvent`.
+- Existing tests cover many worker directions and real-agent scenarios but do not produce one authoritative capability report.
+- The original #221 design correctly notes that a full real N-by-N matrix has poor cost and flake characteristics and that the orchestrator axis is largely deck-redundant.
+- Pi currently reports lifecycle without the same prompt and tool metadata as richer adapters, as tracked in #622.
+- Hookless agents and redrawing TUIs require the separate observation work in #234 before new adapters such as #211 and #212 can claim comparable status fidelity.
+- Emerging standards such as [ACP](https://agentclientprotocol.com/overview/introduction) may reduce integration cost but do not replace behavior-level conformance testing.
+
+## Hypotheses
+
+- Agent support should be expressed as tested capabilities, not a binary supported or unsupported label.
+- A small deterministic contract test suite plus reduced real-agent matrix can catch more regressions than a large flaky full matrix.
+- The registry should declare capabilities that tests verify, preventing documentation from drifting away from behavior.
+- Public compatibility evidence should be generated from repeatable results only after the e2e reliability work in #502 establishes a credible measurement process.
+- Runtime adapter extensibility should remain a separate decision from documenting and testing the existing compiled strategy seam.
+
+## Questions To Answer
+
+- What are the stable conformance dimensions: lifecycle, readiness, waiting, prompt metadata, tools, submission confirmation, delegation, restoration, remote operation, and platform support?
+- Which permission, filesystem, network, sandbox, credential, and tool-authority capabilities can each adapter and execution posture report or enforce?
+- Which dimensions can be tested with deterministic stand-ins and which require real agents?
+- What reduced interop matrix gives high routing coverage at acceptable cost and flake probability?
+- How are upstream version ranges, degraded modes, partial support, and temporary failures represented?
+- Should declared capabilities be compile-time registry data, generated metadata, or test-discovered output?
+- What evidence quality is required before publishing a compatibility matrix or reliability score?
+- Does ACP provide a useful adapter path for any current or planned agent without weakening lifecycle fidelity?
+- Is a community adapter boundary desirable after the conformance contract is stable, or should integrations remain compiled and curated?
+
+## Discovery Evidence Protocol
+
+- Define the claimed capability set for every shipped agent strategy, then require each claim to name a deterministic, PTY, or real-agent test that can disprove it.
+- Run the reduced interoperability set at least twenty times across available agents and record false failures, skips, runtime, and model cost separately from genuine compatibility failures.
+- Treat the default matrix as viable only if its false-failure rate is below 5 percent per combination and its cost remains acceptable for the documented pre-PR tier; otherwise revise the set or keep it opt-in.
+- Treat public compatibility reporting as `Go` only when every published cell is generated from a versioned claim and recent evidence, with unavailable and degraded states shown rather than omitted.
+- Choose `Stop` for public reporting if #502 cannot establish repeatability, while preserving any internal conformance contract that still improves adapter maintenance.
+
+## Discovery Milestones
+
+- [ ] Inventory every lifecycle and orchestration capability claimed or observed for each supported integration strategy and arbitrary commands.
+- [ ] Define capability levels and map each to deterministic, PTY, or real-agent evidence, including explicit degraded and unavailable states.
+- [ ] Design and trial the reduced default interop matrix from the original #221 proposal, with an opt-in full matrix and isolated retries.
+- [ ] Determine how registry declarations, generated compatibility output, docs, upstream versions, and #502's reliability constraints stay synchronized.
+- [ ] Record a `Go`, `Revise`, or `Stop` decision and create implementation PRDs for conformance metadata, harness changes, publishing, or adapter extensibility as justified.
+
+## Evidence And Decision Criteria
+
+A `Go` decision requires a capability taxonomy that distinguishes current agents meaningfully, tests whose cost and flake rate fit the repository's gates, and a generated report that cannot claim more support than the underlying evidence proves.
+
+## Non-Goals
+
+- Running the full real-agent N-by-N matrix on every CI or pre-PR invocation.
+- Ranking model intelligence or coding quality.
+- Claiming cross-platform support that #164 or equivalent platform evidence has not verified.
+- Introducing runtime plugins before the capability and trust contracts are understood.
+- Blocking all releases when an optional external agent service is unavailable.
+
+## Risks And Dependencies
+
+- Real-agent behavior and authentication can change without a deck code change.
+- A public matrix can become misleading if tests are flaky, stale, or run only manually.
+- Strategy-specific richness means a lowest-common-denominator contract could hide useful distinctions.
+- #234, #502, and #164 constrain which claims can become authoritative.
+
+## Candidate Outcomes
+
+- **Go**: Adopt the capability contract and create implementation PRDs for registry metadata, conformance tests, generated reporting, and optional adapter extension.
+- **Revise**: Keep the reduced interop matrix and internal compatibility report without publishing reliability claims.
+- **Stop**: Preserve per-agent tests and hand-maintained docs, recording why a shared contract would not improve reliability or contributor experience.

--- a/prds/626-reviewable-change-delivery.md
+++ b/prds/626-reviewable-change-delivery.md
@@ -1,0 +1,87 @@
+# PRD #626: Reviewable change delivery
+
+**Status**: Candidate (Discovery)
+**Issue**: [#626](https://github.com/vfarcic/dot-agent-deck/issues/626)
+**Priority**: Medium
+**Created**: 2026-08-21
+**Builds on**: [#220](https://github.com/vfarcic/dot-agent-deck/issues/220) (worktree dispatch)
+**Interacts with**: [#628](https://github.com/vfarcic/dot-agent-deck/issues/628) (durable work identity), [#236](https://github.com/vfarcic/dot-agent-deck/issues/236) (worktree removal and reclamation), [#425](https://github.com/vfarcic/dot-agent-deck/issues/425) (worktree ownership), [#468](https://github.com/vfarcic/dot-agent-deck/issues/468) (dispatch placement), [#174](https://github.com/vfarcic/dot-agent-deck/issues/174) (cross-project results)
+
+## Opportunity
+
+dot-agent-deck can spawn, coordinate, and monitor coding agents and isolate working-copy changes through worktrees, but it stops before the highest-friction part of parallel work: understanding what changed, verifying that it satisfies the request, reviewing risk, and safely turning branches into pull requests and merged changes. Users leave the deck and reconstruct this context through Git, editors, test logs, and issue trackers.
+
+Direct competitors such as [Conductor](https://www.conductor.build/), [dmux](https://github.com/standardagents/dmux), [Claude Squad](https://github.com/smtg-ai/claude-squad), [Cursor](https://cursor.com/blog/cursor-3), and [GitHub agents](https://github.com/features/copilot/agents) offer parts of the diff-to-PR loop. Rebuilding an IDE would enter a crowded market and dilute the deck's operational focus. The candidate opportunity is a narrower, evidence-first delivery workflow that makes agent work reviewable and integrable while handing rich editing to existing tools.
+
+## Target Users And Jobs
+
+- A maintainer reviewing several agent branches without losing the original requirement or verification context.
+- A developer deciding whether a completed worktree is ready to commit, push, open as a PR, retry, or discard.
+- An orchestrator collecting child results and determining a safe integration order.
+- A reviewer needing reproducible evidence rather than an agent's prose claim that tests passed.
+
+## Current Evidence
+
+- Dispatch and issue-dispatch already create worktrees and can instruct agents to open PRs, but the deck does not own review or delivery state.
+- Work-done reports and orchestration context carry summaries without a general artifact or evidence contract.
+- Existing PRDs anticipate returning PR links but do not define diff inspection, verification readiness, approval, or merge behavior.
+- Prior market research and practitioner reports identify review and branch integration as limiting resources after execution is parallelized; this claim remains a hypothesis to validate against actual deck workflows below.
+- The repository's own verification discipline demonstrates the value of explicit test commands, review findings, recordings, and merge gates.
+
+## Hypotheses
+
+- The deck should produce a review packet rather than a full editor.
+- A review packet should connect requirements, changed files, diff summary, commands run, test artifacts, risks, unresolved questions, interventions, and the resulting commit or PR.
+- `Ready for review` should be a distinct state with machine-checkable evidence, not an alias for process exit or agent self-report.
+- Initial Git operations should be local and explicit; automatic merge should remain out of scope until integration policy is proven.
+- Branch integration needs dependency, stale-base, and post-integration verification semantics rather than only a merge button.
+
+## Questions To Answer
+
+- What minimum evidence lets a reviewer decide without replaying the whole session?
+- Which evidence can the deck observe directly, which must an agent declare, and which must be independently rerun?
+- Should the TUI render a focused file/diff summary or hand off immediately to existing diff tools?
+- What Git actions are safe and valuable: commit, push, PR creation, rebase, merge queue, archive, or cleanup?
+- How are uncommitted changes, dirty worktrees, generated files, secrets, binary changes, and large diffs handled?
+- What does readiness mean across different languages, repositories, and verification commands?
+- How should branch dependencies and post-merge verification work when several agents target the same base?
+
+## Discovery Evidence Protocol
+
+- Sample at least eight completed agent branches across at least three repositories or task types, including clean success, verification failure, stale base, dependent branch, and abandoned work.
+- Measure the current time and tool switches required for a maintainer to reconstruct intent, inspect risk, verify claims, and choose the next Git action.
+- Test a review-packet and external-tool-handoff prototype with at least five maintainers using the same sampled branches.
+- Treat the concept as a `Go` candidate only if the prototype reduces median decision time by at least 30 percent and four of five reviewers reach the correct disposition without a critical evidence omission.
+- Choose `Revise` toward evidence export only if existing diff tools remain clearly superior, and choose `Stop` if current Git and editor workflows provide equivalent context with negligible reconstruction cost.
+
+## Discovery Milestones
+
+- [ ] Map the current path from dispatch completion to review, PR, merge, and cleanup, including where context or evidence is lost.
+- [ ] Define a provider-neutral evidence model and classify each field as observed, agent-asserted, or independently verified.
+- [ ] Prototype the smallest TUI review and external-tool handoff that can handle changed files, verification results, and risk without embedding an editor.
+- [ ] Compare safe Git and GitHub action boundaries, including failure recovery, stale bases, dependent branches, and worktree retention.
+- [ ] Record a `Go`, `Revise`, or `Stop` decision and split accepted work into evidence, review-surface, PR-delivery, and integration implementation PRDs as needed.
+
+## Evidence And Decision Criteria
+
+A `Go` decision requires a review packet that measurably reduces context reconstruction, a credible distinction between assertions and verified evidence, a bounded non-IDE interface, and Git operations whose failure and recovery semantics are explicit.
+
+## Non-Goals
+
+- Building a general-purpose code editor or replacing users' preferred diff tools.
+- Treating agent-written summaries as independent verification.
+- Automatically merging changes before dependency, conflict, approval, and rollback policy is understood.
+- Solving hosted CI, code review, or source control for every provider in the first implementation.
+
+## Risks And Dependencies
+
+- The feature can become an incomplete IDE if its boundary is not enforced.
+- Running verification can be expensive, destructive, environment-specific, or unsafe without repository policy.
+- Git actions against dirty or foreign worktrees depend on ownership and retention guarantees from #236 and #425.
+- Durable evidence and retries likely depend on the work identity explored in #628.
+
+## Candidate Outcomes
+
+- **Go**: Adopt an evidence-first delivery model and create smaller implementation PRDs for readiness, review, PR creation, and integration.
+- **Revise**: Limit the feature to review packets and external-tool handoff if native Git delivery adds too much risk.
+- **Stop**: Keep delivery outside the deck and document the integration conventions users should follow instead.

--- a/prds/627-product-category-target-users-positioning.md
+++ b/prds/627-product-category-target-users-positioning.md
@@ -1,0 +1,84 @@
+# PRD #627: Product category, target users, and positioning
+
+**Status**: Candidate (Discovery)
+**Issue**: [#627](https://github.com/vfarcic/dot-agent-deck/issues/627)
+**Priority**: High
+**Created**: 2026-08-21
+**Interacts with**: [#176](https://github.com/vfarcic/dot-agent-deck/issues/176) (desktop GUI), [#174](https://github.com/vfarcic/dot-agent-deck/issues/174) (cross-project orchestration), [#220](https://github.com/vfarcic/dot-agent-deck/issues/220) (worktree dispatch)
+
+## Opportunity
+
+dot-agent-deck has grown from a terminal dashboard into a control plane with detach-resilient daemon-owned PTYs, normalized agent events, orchestration, worktree dispatch, scheduling, and SSH operation. Its public category, primary target user, and product promise have not been reconsidered with that expanded capability in view.
+
+The market now contains a directly named [Agent Deck](https://github.com/asheshgoplani/agent-deck), terminal supervisors such as [Claude Squad](https://github.com/smtg-ai/claude-squad) and [dmux](https://github.com/standardagents/dmux), desktop workspaces such as [Conductor](https://www.conductor.build/) and [Superset](https://superset.sh/), and vendor control planes from [GitHub](https://github.com/features/copilot/agents), [Cursor](https://cursor.com/blog/cursor-3), [Anthropic](https://code.claude.com/docs/en/agent-teams), and [OpenAI](https://developers.openai.com/codex/cloud.md). Continuing without an explicit position risks incoherent roadmap choices and avoidable naming confusion.
+
+## Target Users And Jobs
+
+- Terminal-first developers supervising several coding agents on local machines or SSH hosts.
+- Maintainers coordinating specialist agents while remaining responsible for review and integration.
+- Platform and regulated teams that value local or self-hosted execution and provider independence.
+- Users who need agent sessions to survive terminal closure, network interruption, and frontend replacement.
+
+## Current Evidence
+
+- The product already supports Claude Code, OpenCode, Pi, Codex, and Devin through one event model.
+- Detach-resilient daemon-owned PTYs, scheduling, orchestration, and remote environments distinguish it from a simple session launcher.
+- Parallel agents, worktrees, and dashboards are documented capabilities across [Claude teams](https://code.claude.com/docs/en/agent-teams), [Cursor](https://cursor.com/blog/cursor-3), [GitHub agents](https://github.com/features/copilot/agents), and the direct competitors linked above.
+- Prior market research found practitioner reports that [reviewing parallel branches became the primary bottleneck](https://news.ycombinator.com/item?id=48897655) and that [parallel failures can consume substantial credits without useful output](https://news.ycombinator.com/item?id=49351539); these qualitative reports motivate, but do not substitute for, the evidence protocol below.
+- The `dot-agent-deck` name is close enough to the direct competitor `agent-deck` to create search, recall, and category confusion.
+
+## Hypotheses
+
+- The strongest position is a local-first, provider-neutral operations layer for durable and verifiable coding-agent work.
+- Terminal panes should be presented as an interface, not as the product's defining capability.
+- The initial ideal customer is an individual power user or maintainer operating local and SSH-hosted agents, not a broad enterprise software factory buyer.
+- A distinct public name may improve discovery and make the product promise easier to own.
+
+## Questions To Answer
+
+- Which user segment experiences the strongest recurring pain and retains after trying the product?
+- Which shipped capabilities cause users to choose dot-agent-deck over tmux, agent-specific teams, or desktop workspaces?
+- Should the category be described as an agent dashboard, supervisor, orchestrator, control plane, or operations layer?
+- Does the naming collision create measurable acquisition or trust problems?
+- Which future surfaces reinforce the chosen position, and which should be explicit non-goals?
+- Is verification-first orchestration understandable and valuable before the verification workflow is implemented?
+
+## Discovery Evidence Protocol
+
+- Recruit at least six participants across at least two plausible target segments, with at least three participants who currently supervise two or more coding agents.
+- Record each participant's current workflow, recurring pain, alternative tools, switching trigger, and response to unbranded positioning statements before showing product-specific language.
+- Treat a position as a `Go` candidate only if at least four participants correctly explain its promise and at least three current multi-agent users independently identify the addressed problem as recurring.
+- Treat a position as `Stop` or `Revise` if fewer than half of current multi-agent participants recognize the problem, if most interpret the promise as a generic terminal multiplexer, or if the proposed name remains confused with a direct competitor in unprompted recall.
+- Preserve anonymized interview notes and the tested statements in the issue so the decision can be challenged later.
+
+## Discovery Milestones
+
+- [ ] Interview or collect structured feedback from current and prospective multi-agent users about jobs, alternatives, and reasons to adopt or stop using the product.
+- [ ] Compare the current homepage and onboarding promise against actual shipped capabilities and the leading direct alternatives.
+- [ ] Test a small set of category statements, target-user definitions, and names against comprehension, differentiation, and searchability.
+- [ ] Define the product's durable principles and explicit non-goals, including its stance on local execution, provider neutrality, IDE functionality, and mandatory cloud services.
+- [ ] Record a `Go`, `Revise`, or `Stop` decision and create focused implementation PRDs only for accepted positioning or naming changes.
+
+## Evidence And Decision Criteria
+
+A `Go` decision requires a target user, primary job, category statement, product promise, and non-goals that are supported by user evidence and clearly distinguish the project from both terminal supervisors and vendor-specific agent products. A rename requires evidence that the expected discovery and clarity gains justify migration cost.
+
+## Non-Goals
+
+- Rewriting the website or renaming the project during discovery.
+- Selecting features solely because competitors advertise them.
+- Claiming enterprise readiness or autonomous software-factory reliability without product evidence.
+- Replacing separate implementation PRDs for accepted roadmap initiatives.
+
+## Risks And Dependencies
+
+- Current users may not represent the larger reachable market.
+- Competitor categories and capabilities are changing quickly.
+- Positioning ahead of delivered review and verification capabilities could overpromise.
+- A rename affects packaging, repositories, docs, configuration, and existing users and must not be treated as a copy change.
+
+## Candidate Outcomes
+
+- **Go**: Adopt a tested position and create implementation PRDs for the minimum product and communication changes needed to substantiate it.
+- **Revise**: Narrow the target user or run a second discovery round where evidence is inconclusive.
+- **Stop**: Preserve the current name and positioning, recording why change would not improve adoption or roadmap quality.

--- a/prds/628-durable-work-graph-execution-history.md
+++ b/prds/628-durable-work-graph-execution-history.md
@@ -1,0 +1,88 @@
+# PRD #628: Durable work graph and execution history
+
+**Status**: Candidate (Discovery)
+**Issue**: [#628](https://github.com/vfarcic/dot-agent-deck/issues/628)
+**Priority**: High
+**Created**: 2026-08-21
+**Builds on**: [#120](https://github.com/vfarcic/dot-agent-deck/issues/120) (scheduled issue dispatch), [#140](https://github.com/vfarcic/dot-agent-deck/issues/140) (orchestration instance identity), [#220](https://github.com/vfarcic/dot-agent-deck/issues/220) (worktree dispatch)
+**Interacts with**: [#174](https://github.com/vfarcic/dot-agent-deck/issues/174) (cross-project dispatch), [#468](https://github.com/vfarcic/dot-agent-deck/issues/468) (dispatch placement and spawning), [#236](https://github.com/vfarcic/dot-agent-deck/issues/236) (worktree lifecycle)
+
+## Opportunity
+
+The deck currently tracks panes, agent records, orchestration instances, delegation commissions, dispatch names, worktrees, branches, schedules, and issue claims through related but separate identities. A user can see live execution, but there is no durable parent record answering what work was requested, which executions attempted it, where its artifacts live, how it depends on other work, and what ultimately happened.
+
+A durable work graph could support recovery, review evidence, cost attribution, dependency-aware dispatch, integration queues, and team handoff. It could also become an expensive abstraction that duplicates GitHub issues, Git branches, or agent-native session history. This discovery exists to determine whether the abstraction earns its cost and where its authority should stop, while related vertical discoveries proceed against existing identities and report what they actually need.
+
+## Target Users And Jobs
+
+- A developer returning after detaching or restarting the daemon who needs to reconstruct active and completed work.
+- An orchestrator or dispatcher creating child work and waiting for durable outcomes.
+- A reviewer tracing a change back to its request, attempts, environment, and evidence.
+- A future remote or team client that cannot infer work identity from one TUI process's in-memory state.
+
+## Current Evidence
+
+- PRD #140 solved routing identity for concurrent orchestration instances, but routing identity is narrower than product work identity.
+- PRD #120 uses issue claims, worktrees, and PR presence as an operational ledger without defining a general work object.
+- PRD #220 and PRD #468 expose the distinction between placement, execution, and continuation.
+- Worktree ownership and reclamation remain separate from the execution record that caused a worktree to exist.
+- Products such as [Gas Town](https://github.com/gastownhall/gastown), GitHub agents, and hosted coding-agent systems make task identity and durable history central, but often with significantly more operational complexity.
+
+## Hypotheses
+
+- A work item should be the durable identity above sessions, panes, retries, and worktrees.
+- Work items should form a directed graph with explicit parent, child, and dependency relationships rather than relying on prompt prose.
+- Runtime state should survive daemon restart, while repository-portable workflow definitions may need a different storage boundary.
+- GitHub issues and PRs should be linked external records, not the only source of work identity.
+- A minimal append-only event history may be safer than persisting every mutable daemon structure.
+
+## Questions To Answer
+
+- What user-visible failures are caused by the absence of durable work identity today?
+- Which fields and transitions are universal across manual panes, orchestrations, dispatches, and schedules?
+- Is a work item authoritative, observational, or a projection over existing Git and issue-tracker objects?
+- What is the minimum viable relationship model: parent-child, dependency, attempt, continuation, and replacement?
+- Which state must survive daemon restart, machine restart, or movement to another host?
+- Should local runtime state live in SQLite, an event journal, Git metadata, repository files, or a combination?
+- How are deletion, retention, redaction, and backward compatibility handled?
+- Can the abstraction be introduced without changing the TUI-to-daemon contract incompatibly?
+
+## Discovery Evidence Protocol
+
+- Sample at least eight completed or interrupted runs covering manual panes, orchestration, interactive dispatch, and scheduled issue dispatch, with at least one daemon or client interruption.
+- Ask a maintainer to reconstruct request, attempts, current owner, workspace, result, and next action using current records; record missing or contradictory answers and time-to-reconstruction.
+- Treat a general work identity as a `Go` candidate only if at least three distinct launch paths share unresolved identity needs and one minimal model answers them without replacing Git or issue-tracker authority.
+- Prefer `Revise` to a narrower execution journal if history solves the observed failures without a graph, and choose `Stop` if existing Git, issue, and session records answer all sampled workflows reliably.
+- Require vertical discoveries such as #626 and #633 to state their actual identity needs rather than accepting #628 as a prerequisite by assumption.
+
+## Discovery Milestones
+
+- [ ] Inventory every existing identity, lifecycle map, persisted file, and external record involved in manual panes, orchestration, dispatch, scheduling, and worktree cleanup.
+- [ ] Document concrete recovery, attribution, and handoff scenarios that the current model cannot answer reliably.
+- [ ] Compare a minimal work-item model against alternatives that reuse Git branches, GitHub issues, or an append-only event log without a new top-level object.
+- [ ] Prototype the smallest persistence and migration approach needed to validate restart recovery and parent-child history without committing to a user interface.
+- [ ] Record a `Go`, `Revise`, or `Stop` decision, including the proposed authority boundary and follow-up implementation PRDs.
+
+## Evidence And Decision Criteria
+
+A `Go` decision requires demonstrated user workflows that cannot be solved cleanly by existing identities, a minimal state model shared by at least three launch paths, a credible persistence and migration approach, and a clear rule for how Git and issue trackers relate to the work record.
+
+## Non-Goals
+
+- Designing the final review, cost, team, or mobile user interfaces.
+- Replacing Git branches, worktrees, or issue trackers.
+- Persisting raw prompts, credentials, or complete terminal histories by default without an explicit privacy decision.
+- Implementing a general project-management system.
+
+## Risks And Dependencies
+
+- A broad work object can become a second source of truth that disagrees with GitHub or Git.
+- Persistence creates schema migration, retention, privacy, and cross-version obligations.
+- Incorrect parent or dependency identity can misroute automated actions rather than merely display stale information.
+- Existing correctness work in #236, #425, #545, and #555 must not be deferred behind a new abstraction.
+
+## Candidate Outcomes
+
+- **Go**: Define the minimal durable model and split storage, protocol, migration, and user-surface work into implementation PRDs.
+- **Revise**: Limit the effort to a durable execution journal or dispatch registry if a general work graph is not justified.
+- **Stop**: Keep existing identities and document why Git and issue-tracker records are sufficient.

--- a/prds/629-dependency-aware-execution-policy.md
+++ b/prds/629-dependency-aware-execution-policy.md
@@ -1,0 +1,89 @@
+# PRD #629: Dependency-aware execution policy
+
+**Status**: Candidate (Discovery)
+**Issue**: [#629](https://github.com/vfarcic/dot-agent-deck/issues/629)
+**Priority**: Medium
+**Created**: 2026-08-21
+**Builds on**: [#58](https://github.com/vfarcic/dot-agent-deck/issues/58) (multi-role orchestration)
+**Interacts with**: [#628](https://github.com/vfarcic/dot-agent-deck/issues/628) (durable work graph), [#174](https://github.com/vfarcic/dot-agent-deck/issues/174) (cross-project DAG), [#220](https://github.com/vfarcic/dot-agent-deck/issues/220) (dispatch), [#634](https://github.com/vfarcic/dot-agent-deck/issues/634) (agent authority and overrides), [#635](https://github.com/vfarcic/dot-agent-deck/issues/635) (execution budgets)
+
+## Opportunity
+
+dot-agent-deck makes parallel execution and orchestration possible, but the system does not decide when parallelism is safe or worthwhile. Dependencies, likely file conflicts, stale bases, landing order, and concurrency are currently encoded in prompts, individual commands, or not at all.
+
+Parallelism is not universally beneficial. [Anthropic's multi-agent research](https://www.anthropic.com/engineering/built-multi-agent-research-system) reports substantial coordination and token overhead and notes that coding tasks with shared context and dependencies are less naturally parallel than breadth-first research. A deterministic execution policy could recommend serialization and make integration safer, but an overambitious scheduler could duplicate agent reasoning and create opaque behavior.
+
+## Target Users And Jobs
+
+- A developer deciding whether several tasks can run concurrently without creating avoidable review or merge debt.
+- An orchestrator dispatching dependent work in a predictable order.
+- A maintainer integrating several branches that may share files, APIs, generated artifacts, or a moving base.
+- A cross-project workflow that needs cycle, readiness, and dependency semantics beyond prompt prose.
+
+## Current Evidence
+
+- PRD #58 enables role fan-out but leaves planning decisions primarily to the orchestrator prompt.
+- PRD #174 explicitly models cross-project work as a DAG and defers deeper cycle and nesting policy.
+- PRD #220 deliberately avoids making the dispatcher a general planner.
+- Worktree isolation prevents direct working-copy collisions but does not prevent conflicting branches, duplicated work, stale assumptions, or an unsafe landing order.
+- Review and integration remain serial human bottlenecks after execution is parallelized, a hypothesis this discovery will test on actual deck workflows.
+
+## Hypotheses
+
+- The deck should enforce declared dependency invariants deterministically while agents propose plans and decomposition.
+- The system should sometimes recommend or require serial execution when dependencies or overlap make parallelism wasteful.
+- Initial conflict signals can combine explicit dependencies, repository paths, changed-file overlap, and stale-base state without claiming semantic certainty.
+- Scheduling and integration should expose the reason for every defer, serialization, or readiness decision.
+- The discovery can proceed against current dispatch and orchestration identities while informing whether #628 needs a general work graph.
+
+## Questions To Answer
+
+- Which decisions belong to deterministic deck policy and which should remain agent or human judgment?
+- How are dependencies declared, discovered, changed, and validated?
+- Which cycles and nested-dispatch patterns can be prevented mechanically?
+- Can file overlap, changed interfaces, and stale-base signals predict enough integration risk to influence scheduling?
+- When should a dependency block spawn, block delivery, or only block integration?
+- How are ready, blocked, superseded, and invalidated dependency states explained to users and agents?
+- What override and approval model keeps policy useful without becoming obstructive?
+- Which identity does a dependency edge connect before #628 is decided?
+
+## Discovery Evidence Protocol
+
+- Sample at least twelve real or reconstructed task sets containing independent work, direct dependencies, shared-file conflicts, stale bases, nested dispatch, and intentionally serial work.
+- Record the current execution order, conflicts, rework, review delay, and whether a maintainer could have identified the risk before spawn or only before integration.
+- Compare a minimal explicit-DAG policy and a signal-assisted recommendation model against the actual outcomes without using future information unavailable at decision time.
+- Treat the candidate as `Go` only if deterministic policy prevents or identifies at least three observed conflict or rework cases without incorrectly blocking more than one clearly independent task set.
+- Choose `Revise` toward advisory warnings if hard blocking has unacceptable false positives, and choose `Stop` if prompt-level planning and Git already expose the relevant decisions reliably.
+
+## Discovery Milestones
+
+- [ ] Collect representative task graphs and failure cases involving unnecessary parallelism, dependency waits, stale assumptions, duplicated work, and integration conflicts.
+- [ ] Define the smallest dependency vocabulary that can operate across current orchestration, dispatch, and cross-project concepts without assuming #628's outcome.
+- [ ] Separate enforceable invariants, configurable policy, advisory signals, and agent judgment, with an explanation contract for each decision.
+- [ ] Simulate or prototype policy against the sampled serial, parallel, nested, stale-base, and conflicting task sets.
+- [ ] Record a `Go`, `Revise`, or `Stop` decision and split accepted dependency, scheduling, conflict, and integration behavior into implementation PRDs.
+
+## Evidence And Decision Criteria
+
+A `Go` decision requires observed cases where dependency policy prevents measurable conflict or rework, understandable explanations, acceptable false-positive behavior, and an identity model that works before or independently of a universal work graph.
+
+## Non-Goals
+
+- Maximizing concurrent agent count.
+- Replacing agent reasoning with a universal task planner.
+- Enforcing token, monetary, attempt, or elapsed-time budgets, which belong to #635.
+- Building a cluster scheduler or enterprise quota system.
+- Automatically merging branches as part of execution scheduling.
+
+## Risks And Dependencies
+
+- Incorrect dependency state can block useful work or create false confidence about safe parallelism.
+- File overlap is only a proxy and can miss semantic conflicts across different files.
+- Cross-project cycles and nested dispatch require stable identity across current and future work models.
+- Integration behavior must preserve dirty worktrees and existing lifecycle safety guarantees.
+
+## Candidate Outcomes
+
+- **Go**: Define an explainable dependency-policy core and create incremental implementation PRDs for declaration, scheduling, conflict signals, and integration ordering.
+- **Revise**: Ship advisory dependency and conflict visibility before enforcing execution order.
+- **Stop**: Keep planning in orchestrator prompts and rely on Git plus human integration judgment.

--- a/prds/630-human-attention-inbox.md
+++ b/prds/630-human-attention-inbox.md
@@ -1,0 +1,87 @@
+# PRD #630: Human-attention inbox
+
+**Status**: Candidate (Discovery)
+**Issue**: [#630](https://github.com/vfarcic/dot-agent-deck/issues/630)
+**Priority**: High
+**Created**: 2026-08-21
+**Builds on**: [#126](https://github.com/vfarcic/dot-agent-deck/issues/126) (agent-driven notifications and idle-worker detection), [#333](https://github.com/vfarcic/dot-agent-deck/issues/333) (orchestration tab status)
+**Interacts with**: [#447](https://github.com/vfarcic/dot-agent-deck/issues/447) (waiting worker escalation), [#628](https://github.com/vfarcic/dot-agent-deck/issues/628) (durable work identity), [PRD #78](78-tab-level-status-indicators.md) (older tab-indicator concept), [PRD #18](done/18-permission-prompt-control.md) and [PRD #92](done/92-process-boundary-invariant-audit.md) (existing approval controls)
+
+## Opportunity
+
+The dashboard shows agent state and the notification work can signal selected events, but a user supervising several sessions still has to scan panes, tabs, terminal bells, and external messages to determine what needs action. Every visible session competes for equal attention even when one blocks an entire dependency chain and another can wait.
+
+An attention inbox could present actionable events as a ranked queue, preserve enough context to make a decision, and jump directly to the relevant pane or work item. The discovery must determine whether a separate inbox is better than improving existing cards and tabs, and which prioritization can be deterministic rather than model-generated.
+
+## Target Users And Jobs
+
+- A developer supervising enough agents that scanning every pane is no longer practical.
+- A user away from the terminal who returns to several accumulated requests and outcomes.
+- An orchestrator operator deciding which blocked worker, approval, failure, or completed change to handle next.
+- A future remote client that needs a concise actionable surface rather than a full terminal layout.
+
+## Current Evidence
+
+- PRD #126 introduced idle-worker detection and notification recipes but intentionally did not create a deck-owned notification center.
+- PRD #333 and the dashboard cards expose status at the tab and pane level.
+- PRDs #18 and #92 provide an existing `y`/`n` approval path by sending generic PTY input; they are an interaction baseline, not yet a strongly target-bound approval primitive.
+- Issue #447 shows that a waiting worker can require action that is not routed to the person or orchestrator best able to resolve it.
+- [Cursor](https://cursor.com/blog/cursor-3), [Superset](https://superset.sh/), and [Orca](https://onorca.dev/) emphasize notifications and direct navigation to sessions requiring input.
+- Prior market research suggests attention routing and review queues are a greater bottleneck than launching additional agents; this claim remains a hypothesis to validate with the evidence protocol below.
+
+## Hypotheses
+
+- The primary unit should be an actionable attention event, not an agent notification log.
+- Deterministic factors such as dependency impact, time waiting, explicit approval state, failure severity, and active cost burn can rank events without an LLM.
+- Events need acknowledgement, snooze, resolution, and stale-event invalidation so the inbox does not become another noisy status view.
+- The TUI can provide the authoritative first surface, with notification and remote clients consuming the same event model later.
+
+## Questions To Answer
+
+- Which events are truly actionable and which should remain ambient status?
+- Should attention attach to panes, agents, orchestration roles, work items, or all of them through one identity?
+- What ranking rules are understandable and predictable enough for users to trust?
+- How should duplicate events from hooks, timers, process exits, and orchestrator reports collapse?
+- What happens when the underlying condition resolves before the user opens the event?
+- Which actions belong in the inbox: focus, answer, approve, retry, cancel, review, dismiss, or snooze?
+- How should terminal, OS, chat, and future mobile notifications relate to the canonical inbox?
+
+## Discovery Evidence Protocol
+
+- Observe at least six runs with three or more concurrent sessions, including waiting, failure, completion, and stale-event cases, and record missed actions, duplicate signals, time-to-action, and notification count.
+- Compare the current dashboard against inbox and sorted-dashboard prototypes using the same scripted event sets with at least five multi-agent users.
+- Treat an inbox as a `Go` candidate only if at least three observed runs contain a missed or materially delayed action and the prototype reduces median time-to-correct-action by at least 30 percent without increasing total alerts.
+- Choose `Revise` toward cards or tab indicators if they achieve comparable results, and choose `Stop` if users reliably identify the next action under the current surface.
+- Include at least one stale target and pane-replacement scenario so fast navigation or approval cannot pass by acting on the wrong generation.
+
+## Discovery Milestones
+
+- [ ] Catalogue existing state transitions, bells, notifications, idle prompts, failures, and completion signals and classify them as actionable or informational.
+- [ ] Observe or simulate multi-agent runs to identify attention failures, duplicate signals, and the information needed to act without first opening every pane.
+- [ ] Compare an inbox, a sorted dashboard mode, and enhanced tab/card indicators through low-cost TUI prototypes or mockups.
+- [ ] Define deterministic ranking, deduplication, acknowledgement, and stale-event semantics, including interactions with #126 and #447.
+- [ ] Record a `Go`, `Revise`, or `Stop` decision and create implementation PRDs for the event model and chosen surfaces only if justified.
+
+## Evidence And Decision Criteria
+
+A `Go` decision requires evidence that users miss or delay important actions under the current dashboard, a bounded event taxonomy, deterministic lifecycle rules, and a surface that reduces time-to-action without increasing notification volume.
+
+## Non-Goals
+
+- Sending more notifications for every agent transition.
+- Using an LLM to decide basic priority when deterministic state is available.
+- Building team assignment, RBAC, or escalation policy in the first personal inbox.
+- Replacing the detailed terminal pane where context or interaction requires it.
+
+## Risks And Dependencies
+
+- A noisy or stale inbox is worse than status cards because users learn to ignore it.
+- Hook coverage differs by agent, so apparent priority can be biased toward better-instrumented adapters.
+- Durable acknowledgement across restart may depend on the work identity explored in #628.
+- Security-sensitive actions such as approval or prompt submission require stronger identity binding than read-only navigation.
+
+## Candidate Outcomes
+
+- **Go**: Define the canonical attention-event lifecycle and create implementation PRDs for the TUI surface and notification integration.
+- **Revise**: Improve existing cards and tabs if a separate inbox does not reduce interaction cost.
+- **Stop**: Retain current status and notification behavior, recording the usage evidence that did not justify another surface.

--- a/prds/631-authenticated-remote-companion.md
+++ b/prds/631-authenticated-remote-companion.md
@@ -1,0 +1,90 @@
+# PRD #631: Authenticated remote companion for steering and approvals
+
+**Status**: Candidate (Discovery)
+**Issue**: [#631](https://github.com/vfarcic/dot-agent-deck/issues/631)
+**Priority**: Low
+**Created**: 2026-08-21
+**Builds on**: [#76](https://github.com/vfarcic/dot-agent-deck/issues/76) (remote agent environments), [#93](https://github.com/vfarcic/dot-agent-deck/issues/93) (always-external daemon), [#345](https://github.com/vfarcic/dot-agent-deck/issues/345) (remote doctor)
+**Depends on discovery in**: [#634](https://github.com/vfarcic/dot-agent-deck/issues/634) (execution isolation and agent authority)
+**Interacts with**: [#176](https://github.com/vfarcic/dot-agent-deck/issues/176) (desktop GUI), [#630](https://github.com/vfarcic/dot-agent-deck/issues/630) (attention inbox), [#318](https://github.com/vfarcic/dot-agent-deck/issues/318), [#401](https://github.com/vfarcic/dot-agent-deck/issues/401), [#543](https://github.com/vfarcic/dot-agent-deck/issues/543) (event provenance and authority)
+
+## Opportunity
+
+Remote environments let the TUI reach a daemon through SSH, and daemon-owned agents survive local disconnection. Users still need a terminal and full TUI session to inspect status, answer a prompt, approve a gate, retry work, or cancel a run. A lightweight authenticated companion could make long-running local or remote work steerable from a browser or phone without turning execution into a mandatory hosted service.
+
+[Cursor](https://cursor.com/blog/cursor-3), [Orca](https://onorca.dev/), [Codexia](https://github.com/milisp/codexia), [GitHub agents](https://github.com/features/copilot/agents), and hosted coding agents increasingly provide asynchronous mobile or web interaction. The deck's client-independent daemon boundary makes another client plausible, but its current same-user local trust model is not a network authorization model. This discovery must treat identity, transport, revocation, and action safety as prerequisites rather than frontend details.
+
+## Target Users And Jobs
+
+- A developer who receives an attention signal while away from the terminal and wants to inspect and answer it safely.
+- A user supervising agents on an SSH devbox whose laptop sleeps or changes networks.
+- A maintainer who needs concise status and approval controls rather than terminal fidelity on a phone.
+- A future desktop or team client that needs an authenticated client-neutral control contract.
+
+## Current Evidence
+
+- PRD #76 deliberately relies on SSH authentication and excludes additional multi-user authorization.
+- The attach protocol already supports several non-TUI clients but is designed for trusted same-user IPC.
+- PRD #176 explicitly excludes browser and mobile delivery while identifying the daemon as a client-neutral source of truth.
+- Open issues #318, #401, and #543 show that event provenance and authority are not yet strong enough to expose blindly over a network.
+- PRD #126 proves that out-of-band notification is valuable but intentionally leaves interaction in the primary agent or terminal channel.
+
+## Hypotheses
+
+- The highest-value companion surface is an attention queue plus narrow actions, not terminal streaming or a mobile IDE.
+- Remote access should be optional, local-first, and deployable without a vendor-operated execution cloud.
+- Read-only status, prompt submission, approval, retry, and cancellation need separate authorization and confirmation policies.
+- A secure relay may be a later convenience layer, but direct self-hosted access and SSH-based options should remain viable.
+- The remote API should be client-neutral so web, mobile, desktop, and automation clients do not create separate business logic.
+
+## Questions To Answer
+
+- Which remote actions deliver enough value to justify the new attack surface?
+- Can SSH forwarding and short-lived local credentials satisfy the initial use case without a public listener?
+- What identity, pairing, token storage, expiration, revocation, replay protection, and audit semantics are required?
+- How does a remote client prove that a prompt, pane, work item, or approval target is still the same generation it displayed?
+- Which actions require reauthentication or confirmation because they can execute code, spend money, or destroy work?
+- Is terminal streaming necessary, or can the companion rely on structured status, snapshots, evidence, and targeted responses?
+- How do notifications deep-link into a self-hosted companion without leaking repository or task data?
+- Where is the boundary between this candidate and the desktop GUI in #176?
+
+## Discovery Evidence Protocol
+
+- Interview at least six users who run agents on SSH hosts or leave them unattended, including at least three who encounter an away-from-terminal decision weekly.
+- Record the exact remote action, urgency, current workaround, frequency, and consequence of waiting before showing a proposed companion.
+- Threat-model and prototype read-only status plus one reversible action; no mutating action can graduate with an unresolved high-severity identity, replay, stale-target, or credential-storage finding.
+- Treat the companion as a `Go` candidate only if at least three participants need a supported action weekly and five of six can complete the prototype flow without terminal access or target confusion.
+- Choose `Revise` toward SSH reconnect or notification deep links if remote mutation does not justify its risk, and choose `Stop` if observed users can wait or use SSH without meaningful cost.
+
+## Discovery Milestones
+
+- [ ] Define the smallest away-from-terminal journeys and rank read-only and mutating actions by value and risk.
+- [ ] Threat-model direct network access, SSH-forwarded access, device pairing, optional relay, stolen credentials, replay, and stale-target actions.
+- [ ] Audit the existing protocol and provenance issues to identify which boundaries can be reused and which require a separate authenticated service.
+- [ ] Prototype a read-only status and one reversible action through the safest plausible transport, measuring operational burden and usability.
+- [ ] Record a `Go`, `Revise`, or `Stop` decision and create separate implementation PRDs for authentication, API, notification deep links, and companion UI if accepted.
+
+## Evidence And Decision Criteria
+
+A `Go` decision requires a common away-from-terminal job that users cannot solve adequately through SSH and notifications, a credible threat model, generation-safe action semantics, and a deployment path that preserves optional local and self-hosted operation.
+
+## Non-Goals
+
+- Exposing the existing trusted local socket directly to a network.
+- Building a mobile code editor or reproducing full terminal fidelity in the first companion.
+- Making hosted relay or cloud execution mandatory.
+- Adding multi-user team sharing, RBAC, or organization policy in this personal remote-access candidate.
+- Deferring current provenance vulnerabilities because a stronger future protocol is planned.
+
+## Risks And Dependencies
+
+- Prompt submission and approval can trigger arbitrary agent actions with repository and credential access.
+- A stale mobile view can target a replaced pane or different agent generation unless identity is end-to-end.
+- Public exposure changes the security and compatibility obligations of the daemon substantially.
+- Attention and evidence surfaces may depend on #630 and #626 to be useful without terminal streaming.
+
+## Candidate Outcomes
+
+- **Go**: Select a narrow authenticated boundary and create implementation PRDs for security foundations, API, and the minimum companion surface.
+- **Revise**: Improve SSH reconnect and notification deep links if a separate remote API does not justify its risk.
+- **Stop**: Keep remote steering terminal-only and document the security and maintenance reasons.

--- a/prds/632-self-hosted-multi-user-team-control-plane.md
+++ b/prds/632-self-hosted-multi-user-team-control-plane.md
@@ -1,0 +1,90 @@
+# PRD #632: Self-hosted multi-user team control plane
+
+**Status**: Candidate (Discovery)
+**Issue**: [#632](https://github.com/vfarcic/dot-agent-deck/issues/632)
+**Priority**: Low
+**Created**: 2026-08-21
+**Builds on**: [#76](https://github.com/vfarcic/dot-agent-deck/issues/76) (per-user remote environments), [#93](https://github.com/vfarcic/dot-agent-deck/issues/93) (daemon source of truth)
+**Depends on discovery in**: [#627](https://github.com/vfarcic/dot-agent-deck/issues/627) (target user and positioning), [#631](https://github.com/vfarcic/dot-agent-deck/issues/631) (authenticated remote boundary), [#634](https://github.com/vfarcic/dot-agent-deck/issues/634) (execution isolation and agent authority)
+**Interacts with**: [#628](https://github.com/vfarcic/dot-agent-deck/issues/628) (durable work identity), [#633](https://github.com/vfarcic/dot-agent-deck/issues/633) (telemetry and accounting)
+
+## Opportunity
+
+The current daemon is intentionally a per-user trusted process. That simplicity is a strength for local terminal users, but it cannot safely provide shared work visibility, ownership, handoffs, execution pools, policy, budgets, or audit history for a team. Commercial systems from GitHub, Cursor, Devin, Factory, and Warp increasingly bundle those capabilities with hosted execution or enterprise plans.
+
+An open self-hosted team layer could serve consultancies, platform teams, remote-devbox users, and regulated organizations that need provider-neutral agent operations without sending code or execution to a vendor cloud. It could also burden the project with identity, tenancy, policy, support, and distributed-systems responsibilities before personal workflows are proven. This discovery cannot advance unless #627 validates or deliberately revises the initial individual-user position, and it must choose a boundary that does not compromise the local product.
+
+## Target Users And Jobs
+
+- A development team sharing visibility into agent work without sharing Unix accounts or terminal sessions.
+- A maintainer handing work and review responsibility to another person with an auditable history.
+- A platform team enforcing allowed agents, models, networks, secrets, concurrency, and spending policy.
+- A regulated organization operating workers and state inside its own infrastructure.
+
+## Current Evidence
+
+- PRD #76 and the local protocol explicitly assume same-user trust and exclude multi-user authorization.
+- The daemon owns powerful PTYs and can execute commands with the user's environment and credentials.
+- Current orchestration models several agent roles but not multiple human owners, approvers, or administrative roles.
+- [GitHub](https://github.com/features/copilot/agents), [Devin](https://devin.ai/enterprise), [Factory](https://www.factory.ai/pricing), and [Warp](https://www.warp.dev/factories) monetize team visibility, policy, audit, managed or self-hosted workers, and access controls rather than only local agent panes.
+- Authenticated remote actions and explicit execution authority are prerequisites for mutating team features; durable work history and trustworthy telemetry become prerequisites only for features that claim shared history, audit, accounting, or budgets.
+
+## Hypotheses
+
+- Team functionality should be a separate control-plane layer over per-user or isolated workers, not a mode that weakens the local daemon's trust assumptions.
+- The first valuable collaboration capabilities are shared visibility, ownership, handoff, and review responsibility rather than centralized autonomous execution.
+- Self-hosted deployment and provider neutrality can differentiate the project from mandatory vendor clouds.
+- Local single-user operation should remain fully functional and open without the team service.
+- Governance and managed connectivity may support sustainable commercial offerings without reselling model inference.
+
+## Questions To Answer
+
+- Which teams have a problem severe enough to deploy and operate a shared control plane?
+- What is the tenancy boundary: organization, repository, project, worker, Unix user, or work item?
+- Which identities act: humans, agents, workers, service accounts, and external issue or source-control systems?
+- What RBAC, approval, audit, secrets, network, retention, and data-residency requirements are minimum rather than enterprise extras?
+- Should workers initiate outbound connections to a control plane, or should the service connect inward?
+- How are local subscriptions and credentials kept isolated when work is assigned by another user?
+- Which state belongs centrally and which remains on the worker or in the repository?
+- Can the layer be self-hosted simply enough for the target users, and what managed service would add value later?
+
+## Discovery Evidence Protocol
+
+- Interview at least six teams across at least two candidate segments, with respondents who own both the workflow problem and the authority to adopt or pilot a self-hosted tool.
+- Record current collaboration failures, security requirements, deployment constraints, willingness to operate the service, and whether shared visibility alone would create value.
+- Treat the candidate as `Go` only if #627 permits the team segment, at least three teams report the problem monthly or more often, and at least two commit to a bounded read-only pilot.
+- Require the architecture review to resolve all high-severity tenant-isolation, worker-authority, and credential-boundary findings before any mutating shared action is planned.
+- Choose `Revise` toward repository-mediated handoff or managed remote connectivity if teams reject operating a control plane, and choose `Stop` if no target team will pilot the minimum shared view.
+
+## Discovery Milestones
+
+- [ ] Interview target teams about current multi-agent collaboration, compliance constraints, willingness to self-host, and purchasing or adoption authority.
+- [ ] Define human and machine actors, trust boundaries, tenancy, ownership, and audit requirements without reusing the per-user daemon assumptions.
+- [ ] Compare architectures based on isolated workers, shared daemon state, repository-mediated coordination, and an outbound-connected control service.
+- [ ] Prototype the smallest shared read-only work view using current identities after #627 permits the team segment; treat ownership handoff as a separate mutating step gated by #631 and #634.
+- [ ] Record a `Go`, `Revise`, or `Stop` decision with an explicit local-product boundary and any follow-up product, security, deployment, or commercial PRDs.
+
+## Evidence And Decision Criteria
+
+A `Go` decision requires repeated team demand, a defensible tenant and worker isolation model, a self-hosted deployment that target users can operate, and proof that the shared layer does not make local single-user execution dependent on a service.
+
+## Non-Goals
+
+- Adding multiple trusted users to the current local socket protocol.
+- Building enterprise administration before positioning, remote authorization, and execution authority are sound.
+- Hosting customer source code or execution as the default design.
+- Requiring a project-owned model gateway or reselling tokens.
+- Assuming agent roles and human RBAC roles are interchangeable.
+
+## Risks And Dependencies
+
+- Multi-tenancy around code-executing agents has a much larger security and support burden than the current same-user model.
+- Enterprise feature pressure can distract from individual workflow quality and open-source adoption.
+- Central history and telemetry create privacy, retention, residency, and incident-response obligations.
+- Interviews and a bounded read-only prototype may proceed after #627 permits the segment; mutating actions depend on #631 and #634, durable shared history depends on #628, and telemetry-dependent audit or budget features depend on #633.
+
+## Candidate Outcomes
+
+- **Go**: Define a separate self-hosted team architecture and create staged implementation PRDs beginning with shared visibility and handoff.
+- **Revise**: Offer repository-mediated collaboration or managed remote connectivity without a full multi-user control plane.
+- **Stop**: Keep the product explicitly personal and local-first, recording why team governance does not fit the project's strategy.

--- a/prds/633-execution-telemetry-outcomes-cost-accounting.md
+++ b/prds/633-execution-telemetry-outcomes-cost-accounting.md
@@ -1,0 +1,89 @@
+# PRD #633: Execution telemetry, outcomes, and cost accounting
+
+**Status**: Candidate (Discovery)
+**Issue**: [#633](https://github.com/vfarcic/dot-agent-deck/issues/633)
+**Priority**: Medium
+**Created**: 2026-08-21
+**Builds on**: [#20](https://github.com/vfarcic/dot-agent-deck/issues/20) (multi-agent event model)
+**Interacts with**: [#628](https://github.com/vfarcic/dot-agent-deck/issues/628) (durable work identity), [#176](https://github.com/vfarcic/dot-agent-deck/issues/176) (future rich usage views), [#221](https://github.com/vfarcic/dot-agent-deck/issues/221) (agent conformance), [#635](https://github.com/vfarcic/dot-agent-deck/issues/635) (budget enforcement)
+
+## Opportunity
+
+The deck observes lifecycle events, process state, delegation, elapsed time, and some agent-specific activity, but it does not provide a durable provider-neutral account of what a run consumed or achieved. Users cannot consistently attribute model spend, tokens, retries, elapsed time, resource use, intervention count, changed lines, verification results, or final outcome to one piece of work.
+
+Cost data is especially uneven because agents expose different APIs and users may run subscriptions, API keys, local models, or opaque hosted plans. A credible telemetry system must distinguish directly measured values from estimates and unavailable data. This discovery will determine which metrics are useful and trustworthy, whether OpenTelemetry is an appropriate export seam, and how outcome data can improve decisions without becoming surveillance.
+
+## Target Users And Jobs
+
+- A developer identifying expensive, stuck, or repeatedly retried work before it wastes more time or credits.
+- A maintainer comparing agent and workflow reliability on the repository's real tasks.
+- An operator diagnosing why a work item failed despite substantial execution time.
+- A future team administrator enforcing transparent budgets without mandating a model gateway.
+
+## Current Evidence
+
+- The unified event model already normalizes lifecycle semantics across several integration strategies.
+- Agent-specific token and cost visibility varies and unknown commands provide much weaker telemetry.
+- [Anthropic's multi-agent research](https://www.anthropic.com/engineering/built-multi-agent-research-system) reports large token amplification for multi-agent systems and warns that coding work is not always independently parallelizable.
+- Direct competitor [Agent Deck](https://github.com/asheshgoplani/agent-deck) and commercial platforms such as [Factory](https://www.factory.ai/pricing) expose cost or usage views, making basic attribution an emerging expectation.
+- [OpenTelemetry agent observability](https://opentelemetry.io/blog/2025/ai-agent-observability/) provides an emerging vocabulary and export ecosystem, but adopting it does not define the product's own outcome semantics.
+
+## Hypotheses
+
+- Every metric should carry provenance such as measured, provider-reported, estimated, agent-asserted, or unavailable.
+- Work-item outcome, intervention count, verification state, and elapsed time are more actionable than token totals alone.
+- The internal event and metric model should remain provider-neutral, with OpenTelemetry as an optional export rather than the source of truth.
+- Local telemetry should default to private and bounded retention, with no mandatory hosted collection.
+- Reliable telemetry can later support budgets, agent conformance reporting, and repository-specific workflow evaluation.
+
+## Questions To Answer
+
+- Which metrics can each existing adapter report accurately, and at what lifecycle points?
+- How should subscription-based agents be represented when monetary cost is unknowable?
+- What is the stable outcome taxonomy: completed, verified, rejected, abandoned, failed, timed out, superseded, or merged?
+- How are retries, child agents, orchestrations, and cross-project dispatch aggregated without double counting?
+- What local storage, retention, redaction, and export controls are appropriate?
+- Which OpenTelemetry semantic conventions are stable enough to adopt, and where is a deck-specific schema necessary?
+- Can telemetry be collected without intercepting prompts, source code, or secrets?
+- Which metrics are useful for users rather than vanity dashboards?
+
+## Discovery Evidence Protocol
+
+- Capture at least twelve runs across at least three agent strategies, including success, failure, retry, interruption, orchestration, and a provider for which monetary cost is unavailable.
+- For every candidate field, compare deck-observed, provider-reported, estimated, and user-visible values and record disagreement, overhead, and missing-data rates.
+- Treat a telemetry field as viable only when its provenance is explicit and it is present or honestly unavailable in at least 90 percent of sampled runs without inspecting source or prompt content.
+- Treat the candidate as `Go` only if at least three metrics change a real user decision in the sample, such as stopping, retrying, switching workflow, or investigating failure.
+- Choose `Revise` toward a smaller outcome and intervention record if token or cost accounting remains unreliable, and choose `Stop` if the data is primarily diagnostic noise or creates unacceptable privacy exposure.
+
+## Discovery Milestones
+
+- [ ] Inventory observable lifecycle, usage, process, Git, verification, and intervention signals for every supported agent strategy and arbitrary commands.
+- [ ] Define provenance, aggregation, privacy, retention, and missing-data semantics for a minimal provider-neutral execution record.
+- [ ] Validate an outcome taxonomy against real successful, failed, retried, interrupted, and manually reviewed runs.
+- [ ] Prototype local capture and optional OpenTelemetry export for a narrow metric set, measuring overhead and data leakage risk.
+- [ ] Record a `Go`, `Revise`, or `Stop` decision and create implementation PRDs for storage, adapter instrumentation, user surfaces, or export only where evidence supports them.
+
+## Evidence And Decision Criteria
+
+A `Go` decision requires metrics that users can act on, explicit provenance and missing-data behavior, bounded overhead, privacy-safe defaults, and evidence that the model works across materially different agent integrations without a mandatory proxy or gateway.
+
+## Non-Goals
+
+- Reselling inference or routing all model traffic through the deck.
+- Pretending estimates are exact provider billing data.
+- Uploading prompts, code, or telemetry to a hosted service by default.
+- Ranking models publicly from a small or biased task sample.
+- Building budget enforcement before accounting semantics are trustworthy.
+
+## Risks And Dependencies
+
+- Adapter and provider data can change without notice or disagree with final billing.
+- Metrics can incentivize cheap but low-quality outcomes if verification is not represented.
+- Detailed traces can expose prompts, paths, repository names, or secrets.
+- Durable attribution may depend on the work identity explored in #628.
+
+## Candidate Outcomes
+
+- **Go**: Adopt the minimal telemetry and outcome schema and split local storage, adapter capture, UI, and export into implementation PRDs.
+- **Revise**: Limit the system to elapsed time, interventions, verification, and outcomes if token or monetary accounting is not reliable.
+- **Stop**: Retain diagnostic logs only and document why product telemetry would be misleading or too sensitive.

--- a/prds/634-execution-isolation-agent-authority.md
+++ b/prds/634-execution-isolation-agent-authority.md
@@ -1,0 +1,91 @@
+# PRD #634: Execution isolation and agent authority
+
+**Status**: Candidate (Discovery)
+**Issue**: [#634](https://github.com/vfarcic/dot-agent-deck/issues/634)
+**Priority**: High
+**Created**: 2026-08-21
+**Builds on**: [#20](https://github.com/vfarcic/dot-agent-deck/issues/20) (agent strategies), [#76](https://github.com/vfarcic/dot-agent-deck/issues/76) (remote environments), [#220](https://github.com/vfarcic/dot-agent-deck/issues/220) (worktree dispatch)
+**Interacts with**: [#221](https://github.com/vfarcic/dot-agent-deck/issues/221) (agent conformance), [#318](https://github.com/vfarcic/dot-agent-deck/issues/318), [#401](https://github.com/vfarcic/dot-agent-deck/issues/401), [#543](https://github.com/vfarcic/dot-agent-deck/issues/543) (event provenance), [#631](https://github.com/vfarcic/dot-agent-deck/issues/631) (remote companion), [#632](https://github.com/vfarcic/dot-agent-deck/issues/632) (team control plane)
+
+## Opportunity
+
+Git worktrees isolate branches and working-copy changes, but they do not isolate processes, filesystems outside the worktree, networks, credentials, environment variables, project configuration, MCP servers, caches, services, ports, or build artifacts. The current model runs agents as the daemon user and treats project configuration as trusted code-executing input, which is coherent for a deliberate same-user local tool but becomes a limiting and dangerous ambiguity as automation, remote control, and shared operation expand.
+
+Remote documentation already warns that agents sharing a host share its credentials and filesystem. Existing provenance issues show that authority-bearing events also need stronger identity. This discovery will determine whether the deck should define explicit execution postures, what it can enforce across heterogeneous agents and hosts, and which risks must remain visible user responsibility.
+
+## Target Users And Jobs
+
+- A developer running agents in repositories with different trust levels or credential requirements.
+- A user dispatching unattended work that should not access unrelated files, networks, or secrets.
+- A remote-host operator deciding whether projects can safely share a machine.
+- A future companion or team-control-plane user authorizing actions without inheriting unlimited daemon-user authority.
+- An adapter maintainer documenting what an agent sandbox actually constrains.
+
+## Current Evidence
+
+- `docs/remote-requirements.md` states that remote v1 isolation is at host level and that agents sharing a host share credentials and filesystem access.
+- `.dot-agent-deck.toml` role commands execute through a shell and therefore belong to the same trust class as repository build scripts.
+- MCP servers and agent processes can inherit broad environment credentials unless launch configuration narrows them.
+- Agent-native sandboxes differ in filesystem, network, confirmation, and tool behavior and are not represented by one deck-level capability contract.
+- Worktree safety PRDs protect Git data lifecycle but do not create a process or credential security boundary.
+- Issues #318, #401, and #543 show that event provenance and authority must be bound before stronger remote actions rely on them.
+
+## Hypotheses
+
+- The product needs named execution postures with explicit capabilities and limitations rather than a binary sandboxed label.
+- Isolation may be composed from agent-native controls, environment filtering, OS processes, containers, remote hosts, or future Kubernetes placement, with no one mechanism required everywhere.
+- Project trust, agent authority, and human authorization are separate decisions and should not be collapsed into one prompt permission mode.
+- Safe defaults can reduce credential and network exposure without preventing users from opting into trusted full-access workflows.
+- Conformance reporting in #221 should include the authority each adapter can request, expose, and enforce.
+
+## Questions To Answer
+
+- What threats are in scope for local trusted repositories, cloned untrusted repositories, unattended dispatch, remote hosts, and future team operation?
+- Which resources require explicit authority: repository writes, parent Git metadata, arbitrary filesystem paths, network, subprocesses, environment variables, MCP tools, services, and credentials?
+- What can the deck enforce independently of an agent, and what can it only declare or test?
+- How should trusted project configuration be surfaced before its shell commands or MCP setup execute?
+- Can environment and credential scoping be made useful without breaking existing agent authentication and tools?
+- Which isolation boundary should be recommended for projects that run services, use fixed ports, or share expensive build caches?
+- How do worktree, container, host, SSH, and Kubernetes placement compose without implying stronger isolation than they provide?
+- What evidence must a remote or team feature require before it can expose a mutating action?
+
+## Discovery Evidence Protocol
+
+- Audit at least five representative launch configurations across local panes, worktree dispatch, orchestration, SSH remote, and one containerized or host-isolated workflow.
+- For each configuration, test and record access to repository parent metadata, unrelated files, inherited credentials, outbound network, subprocesses, MCP tools, and sibling agent state.
+- Define at least three concrete threat scenarios, including an untrusted repository, a compromised or mistaken agent, and a stale or forged authority event, and verify whether proposed postures contain them.
+- Treat an execution-posture model as `Go` only if every named posture has testable capabilities, no unresolved high-severity mismatch between label and enforcement, and a migration path that does not silently broaden current access.
+- Choose `Revise` toward documentation and host-level recommendations where enforcement is not portable, and choose `Stop` for any posture whose security promise cannot be tested reliably.
+
+## Discovery Milestones
+
+- [ ] Document the current trust and authority model from configuration load through process spawn, hooks, tools, credentials, worktrees, remotes, and cleanup.
+- [ ] Build a threat model and capability matrix for current agents, operating systems, and placement options, feeding the adapter dimensions in #221.
+- [ ] Compare minimal environment filtering, agent-native sandbox controls, containers, per-project hosts, and policy declarations through targeted prototypes.
+- [ ] Define user-visible posture names, escalation and override semantics, and the evidence required before remote or shared mutation can depend on them.
+- [ ] Record a `Go`, `Revise`, or `Stop` decision and create separate implementation PRDs for authority metadata, launch enforcement, trust prompts, credential scoping, or isolated placement as justified.
+
+## Evidence And Decision Criteria
+
+A `Go` decision requires a threat model grounded in current launch paths, accurately named and testable execution postures, explicit residual risks, and evidence that the proposed controls reduce authority without breaking the supported agent workflows they claim to protect.
+
+## Non-Goals
+
+- Claiming a worktree is a security sandbox.
+- Treating all project configuration as untrusted while continuing to execute its shell commands.
+- Building a mandatory cloud or container runtime.
+- Guaranteeing containment through agent prompt instructions alone.
+- Solving multi-user RBAC, which belongs to #632 after execution authority is understood.
+
+## Risks And Dependencies
+
+- Security labels that overstate enforcement can make users less safe than explicit full access.
+- Agent-native sandboxes and permission flags change across upstream versions.
+- Credential filtering can break legitimate authentication and tools in difficult-to-diagnose ways.
+- Container or host isolation affects performance, caches, services, networking, and installation complexity.
+
+## Candidate Outcomes
+
+- **Go**: Adopt an explicit authority and execution-posture contract and create incremental implementation PRDs for the controls that prove portable and valuable.
+- **Revise**: Standardize capability disclosure and safer host guidance while leaving enforcement to selected agents or environments.
+- **Stop**: Preserve the trusted-user model and explicitly prevent remote or team features from implying a stronger boundary.

--- a/prds/635-execution-budgets-stop-conditions.md
+++ b/prds/635-execution-budgets-stop-conditions.md
@@ -1,0 +1,89 @@
+# PRD #635: Execution budgets and stop conditions
+
+**Status**: Candidate (Discovery)
+**Issue**: [#635](https://github.com/vfarcic/dot-agent-deck/issues/635)
+**Priority**: Medium
+**Created**: 2026-08-21
+**Builds on**: [#126](https://github.com/vfarcic/dot-agent-deck/issues/126) (idle-worker detection)
+**Interacts with**: [#628](https://github.com/vfarcic/dot-agent-deck/issues/628) (durable work identity), [#629](https://github.com/vfarcic/dot-agent-deck/issues/629) (dependency-aware policy), [#633](https://github.com/vfarcic/dot-agent-deck/issues/633) (telemetry and cost accounting), [#634](https://github.com/vfarcic/dot-agent-deck/issues/634) (agent authority and external overrides), [#236](https://github.com/vfarcic/dot-agent-deck/issues/236) (dirty worktree safety)
+
+## Opportunity
+
+Long-running, repeatedly retried, nested, or unexpectedly expensive agent work has no consistent parent budget across heterogeneous agents and launch paths. Existing controls such as scheduled issue caps and idle-worker timeouts address specific cases but do not define elapsed-time, attempt, concurrency, token, monetary, resource, or change-size limits, nor what safely happens when a limit is reached.
+
+Budgets can make unattended automation more predictable, but only if measurement provenance is honest and stopping preserves useful work. Token and monetary limits depend on credible telemetry, while elapsed time, attempts, and concurrency may be enforceable sooner. This discovery separates budget semantics from dependency scheduling so each can advance at the pace its evidence allows.
+
+## Target Users And Jobs
+
+- A developer preventing a mistaken or stuck run from consuming an entire subscription allowance or workday.
+- An orchestrator bounding the aggregate work of children, retries, and nested dispatches.
+- A user choosing pause, notify, preserve, retry, or cancel behavior when a limit is reached.
+- A future team operator allocating scarce agent slots or remote workers without silently discarding work.
+
+## Current Evidence
+
+- Scheduled issue dispatch has a per-run cap, with semantic follow-ups tracked in #194.
+- PRD #126 detects elapsed silence after delegation but does not stop work or enforce a total deadline.
+- The daemon can stop panes, but safe termination, dirty worktree preservation, and child cleanup have known edge cases.
+- Cross-agent token and monetary data is incomplete and must inherit provenance rules from #633 rather than assuming exact billing.
+- [Anthropic's multi-agent research](https://www.anthropic.com/engineering/built-multi-agent-research-system) demonstrates that multi-agent execution can multiply token use substantially.
+
+## Hypotheses
+
+- Budgets should aggregate attempts and child executions under the work that authorized them, while remaining usable with current identities during discovery.
+- Elapsed-time, attempt, and concurrency budgets can be explored independently of token and monetary accounting.
+- Reaching a budget should normally pause and surface a decision before destructive cancellation.
+- Every enforced limit needs explicit preservation, notification, override, and restart semantics.
+- Unknown or estimated cost must never trigger a destructive hard stop as if it were exact.
+
+## Questions To Answer
+
+- Which limits solve observed problems: elapsed time, attempts, concurrency, tokens, money, CPU, memory, changed lines, or output volume?
+- At what level does each budget attach before #628 is decided: pane, orchestration, dispatch, schedule, issue, or another current identity?
+- How are child agents, retries, nested dispatches, and resumed sessions charged without double counting?
+- What is the difference between notify, pause, graceful stop, force stop, and refuse-to-start?
+- How is uncommitted work preserved and reported when a process stops?
+- Which limits can be enforced with current measurements and which remain advisory until #633 advances?
+- How do users override or extend a budget without agents granting themselves more authority?
+- What happens after daemon restart or temporary loss of telemetry?
+
+## Discovery Evidence Protocol
+
+- Sample at least twelve runs containing normal completion, timeout, retry, nested work, high concurrency, interrupted work, and unavailable cost data.
+- Record which proposed limits could have prevented real waste, which would have stopped productive work, and whether the required measurement was known at decision time.
+- Prototype elapsed-time, attempt, and concurrency decisions first; test token or monetary limits only with #633 provenance attached.
+- Treat a budget type as a `Go` candidate only if it would prevent at least two sampled waste cases, produces no destructive action from estimated or missing data, and preserves all dirty work in stop simulations.
+- Choose `Revise` toward advisory notification where hard enforcement is unreliable, and choose `Stop` for limits that create more false stops than prevented waste in the sample.
+
+## Discovery Milestones
+
+- [ ] Catalogue current caps, timeouts, retries, stop paths, child lifecycles, and preservation behavior across manual, orchestration, dispatch, and schedule flows.
+- [ ] Define candidate budget scopes, aggregation rules, measurement provenance, and the distinction between advisory and enforceable limits.
+- [ ] Prototype non-destructive pause and graceful-stop behavior for elapsed time, attempts, and concurrency before cost-based enforcement.
+- [ ] Simulate nested, restarted, missing-data, dirty-worktree, and override scenarios and record whether useful work remains recoverable.
+- [ ] Record a `Go`, `Revise`, or `Stop` decision and create implementation PRDs per accepted budget type and stop behavior.
+
+## Evidence And Decision Criteria
+
+A `Go` decision requires an enforceable measurement, a clear scope and aggregation rule, user-visible explanation, safe preservation, override semantics, and sampled evidence that the limit prevents more waste than productive work.
+
+## Non-Goals
+
+- Dependency ordering or conflict prediction, which belongs to #629.
+- Exact monetary enforcement when a provider exposes no exact usage data.
+- Allowing an agent to raise its own budget without external authorization.
+- Force-killing work as the default response to every exceeded limit.
+- Building organization billing or enterprise quotas in the first implementation.
+
+## Risks And Dependencies
+
+- A stop path can lose work, orphan children, or leave external operations running.
+- Missing or delayed telemetry can make cost limits inaccurate.
+- Parent aggregation may remain awkward until #628 decides whether a durable work identity is justified.
+- Budget pressure can encourage agents to optimize visible metrics rather than verified outcomes.
+
+## Candidate Outcomes
+
+- **Go**: Create staged implementation PRDs beginning with reliable non-monetary limits and non-destructive stop behavior.
+- **Revise**: Provide visibility and notifications while deferring hard enforcement or exact cost budgets.
+- **Stop**: Retain existing targeted caps and timeouts, documenting why broader budgets are unsafe or unhelpful.

--- a/src/agent_pty.rs
+++ b/src/agent_pty.rs
@@ -6034,6 +6034,7 @@ impl AgentPtyRegistry {
                 exited: Arc::new(AtomicBool::new(false)),
                 pending_seed: None,
                 seed_delivered_native: false,
+                pane_handed_over: false,
             },
         );
         id


### PR DESCRIPTION
## Summary

- add eleven candidate PRDs covering positioning, durable work identity, attention routing, reviewable delivery, dependency policy, execution budgets, telemetry, agent conformance, execution authority, remote steering, and a self-hosted team layer
- define each candidate as discovery rather than implementation commitment, with hypotheses, non-goals, dependencies, falsifiable evidence protocols, and explicit Go/Revise/Stop outcomes
- expand existing issue #221 instead of duplicating its agent interoperability work, and link related active PRDs rather than recreating dispatch, worktree, GUI, Kubernetes, or hookless-agent plans
- fix a pre-existing test-only `RunningAgent` initializer omission exposed by the mandatory all-targets clippy gate

## Candidate issues

#221 #626 #627 #628 #629 #630 #631 #632 #633 #634 #635

Each issue links to its PRD on both this branch and the eventual `main` location. These issues stay open as candidate opportunities; this PR does not mark any initiative approved for implementation.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --features e2e -- -D warnings`
- `cargo test-fast` (`2886/2886` passed)

The first fast-tier attempt hit the known timing-sensitive `delegate_010_observed_session_start_waits_for_readiness_buffer` path while the command reached its tool timeout. The isolated rerun passed, followed by the full green tier above.