### PR TITLE
fix(ui): restore the basename when cycling away from an orchestration (#638)

### DIFF
--- a/changelog.d/638.bugfix.md
+++ b/changelog.d/638.bugfix.md
@@ -1,0 +1,7 @@
+## A plain pane is no longer named after an orchestration you only cycled past
+
+The new-pane form's Name field pre-fills with the picked directory's basename, and selecting an orchestration replaces that with the suggested `<folder>-orchestrator-N`. Cycling *away* from the orchestration left the suggestion behind, so a pane created with no mode at all — or with an ordinary workload mode, or as a `schedule` or `dispatcher` card — was named `<folder>-orchestrator-1` despite never being an orchestration.
+
+This was not a corner case, because the Mode cycler orders the project's orchestrations *between* "No mode" and the built-in `schedule` / `schedule: issues` / `dispatcher` options. Reaching any of those from the left means passing over an orchestration, and passing over one was enough: the suggestion applied on the way through and nothing ever put the basename back. The likeliest way to meet it was the plainest one — open the form, cycle through the options to see what is on offer, settle on "No mode", and submit something now claiming to be an orchestrator.
+
+The suggestion is now two-way: landing on an orchestration suggests `<folder>-orchestrator-N` as before, and landing on anything else restores the directory basename the form opened with. A name you typed yourself is still never overwritten in either direction.

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1074,13 +1074,25 @@ struct NewPaneFormState {
     /// opened — set by the two text-edit key arms in
     /// `handle_new_pane_form_key` (`FormField::Name` only), never by the
     /// basename pre-fill `transition_after_dir_pick` applies. While `false`,
-    /// [`Self::suggest_name_if_orchestration_selected`] is free to overwrite
+    /// [`Self::resuggest_name_for_selection`] is free to overwrite
     /// `name` with the generated suggestion; once `true`, that fn leaves the
     /// field alone — a generated default may replace a generated default,
     /// never a human edit. Guards re-clicking the selected chip, arrowing
     /// between orchestrations, and arrowing off and back onto one, all of
     /// which land on the same call.
     name_touched: bool,
+    /// The Name the form opened with — the directory basename
+    /// `transition_after_dir_pick` pre-fills. Kept so that cycling AWAY from an
+    /// orchestration can put it back: the `-orchestrator-N` suggestion belongs
+    /// to the orchestration selection, and a plain pane, a workload mode or the
+    /// built-in `schedule`/`dispatcher` options must not inherit it. Without
+    /// this, the suggestion was a one-way overwrite — and since the cycler
+    /// orders orchestrations BEFORE `schedule`/`dispatcher`, merely passing
+    /// over one on the way to them left every such pane named
+    /// `<folder>-orchestrator-N`. Only ever consulted while
+    /// [`Self::name_touched`] is `false`, so it can never overwrite a human
+    /// edit.
+    name_prefill: String,
 }
 
 impl NewPaneFormState {
@@ -1118,6 +1130,9 @@ impl NewPaneFormState {
             reactive_panes: 0,
         };
         let dispatcher_authoring = build_dispatcher_mode(&dir);
+        // Remembered so leaving an orchestration can restore it — see
+        // `name_prefill`.
+        let name_prefill = name.clone();
         Self {
             dir,
             name,
@@ -1156,6 +1171,7 @@ impl NewPaneFormState {
             // A freshly opened form has no human edit yet — the basename
             // pre-fill below is not one.
             name_touched: false,
+            name_prefill,
         }
     }
 
@@ -1210,22 +1226,38 @@ impl NewPaneFormState {
         }
     }
 
-    /// Overwrite the Name field with the next free suggested name whenever
-    /// the selection LANDS on an orchestration — called from every path that
-    /// can change `selection_index` (arrow keys, click). A no-op when the
-    /// current selection isn't an orchestration (a plain mode/card/authoring
-    /// option keeps whatever the user already typed), and a no-op once
-    /// [`Self::name_touched`] is set — a generated default may replace a
-    /// generated default, never a human edit. Without this guard, re-clicking
-    /// the already-selected chip, arrowing between two orchestrations, or
-    /// arrowing off one and back all silently clobber whatever the user typed.
-    fn suggest_name_if_orchestration_selected(&mut self) {
+    /// Re-derive the Name field for the CURRENT selection — called from every
+    /// path that can change `selection_index` (arrow keys, click).
+    ///
+    /// Landing on an orchestration suggests the next free
+    /// `<folder>-orchestrator-N`; landing on anything else (No mode, a
+    /// workload mode, the built-in `schedule` / `schedule: issues` /
+    /// `dispatcher` options) restores [`Self::name_prefill`], the directory
+    /// basename the form opened with.
+    ///
+    /// **Both directions matter.** This used to apply the suggestion and
+    /// return early otherwise, which made it a one-way overwrite: the name
+    /// survived the selection that generated it. Because the cycler orders the
+    /// orchestrations BEFORE the built-in `schedule`/`dispatcher` options,
+    /// reaching those from "No mode" means passing over an orchestration — so
+    /// a plain pane, a `dev`-mode pane and a scheduled task could all end up
+    /// named `<folder>-orchestrator-N` without the user ever selecting an
+    /// orchestration.
+    ///
+    /// Still a no-op once [`Self::name_touched`] is set — a generated default
+    /// may replace a generated default, never a human edit. Without that
+    /// guard, re-clicking the already-selected chip, arrowing between two
+    /// orchestrations, or arrowing off one and back all silently clobber
+    /// whatever the user typed.
+    fn resuggest_name_for_selection(&mut self) {
         if self.name_touched {
             return;
         }
-        if self.selected_orchestration().is_some() {
-            self.name = self.suggest_orchestration_name();
-        }
+        self.name = if self.selected_orchestration().is_some() {
+            self.suggest_orchestration_name()
+        } else {
+            self.name_prefill.clone()
+        };
     }
 
     /// The title this submission will ACTUALLY take: the typed Name when it
@@ -1334,6 +1366,9 @@ impl NewPaneFormState {
             // The Name field is hidden and fixed to `SCHEDULE_MODE_NAME` on
             // this form, so there is nothing to touch.
             name_touched: false,
+            // No cycler and no orchestration on this form, so nothing ever
+            // reverts to it.
+            name_prefill: SCHEDULE_MODE_NAME.to_string(),
         };
         // Lock the selection onto the built-in schedule option (index 1 with no
         // modes/orchestrations) so the existing schedule spawn branch fires.
@@ -1407,7 +1442,7 @@ impl NewPaneFormState {
             self.selection_index += 1;
             // Selecting an orchestration suggests the next free name in
             // place of whatever was in the field.
-            self.suggest_name_if_orchestration_selected();
+            self.resuggest_name_for_selection();
         }
     }
 
@@ -1415,7 +1450,7 @@ impl NewPaneFormState {
         self.selection_index = self.selection_index.saturating_sub(1);
         // Symmetric to `select_next_mode` — cycling backward onto an
         // orchestration suggests the next free name too.
-        self.suggest_name_if_orchestration_selected();
+        self.resuggest_name_for_selection();
     }
 
     fn selected_mode(&self) -> Option<&ModeConfig> {
@@ -9946,7 +9981,7 @@ fn dispatch_action(
                 // Clicking a chip lands on the selection the same way the
                 // arrow keys do — suggest a name if it landed on an
                 // orchestration.
-                form.suggest_name_if_orchestration_selected();
+                form.resuggest_name_for_selection();
             }
         }
         // [Submit] → spawn the pane from the form values (== Enter on the final
@@ -29633,6 +29668,92 @@ mod tests {
             ),
             other => panic!("expected SpawnPane, got {other:?}"),
         }
+    }
+
+    /// Scenario: Open the new-pane form the way `Ctrl+n` does — Name
+    /// pre-filled with the bare directory basename `myproj` — then cycle the
+    /// Mode field RIGHT onto the orchestration (which suggests
+    /// `myproj-orchestrator-1`) and back LEFT to "No mode". The Name field
+    /// must read `myproj` again, and submitting must spawn a plain pane
+    /// called `myproj`: a pane with no mode is not an orchestrator, and a
+    /// generated suggestion must not outlive the selection that generated it.
+    /// Same for cycling FORWARD off the orchestration onto the built-in
+    /// `schedule` option — which is how the user reaches `schedule` /
+    /// `dispatcher` at all, since the cycler puts the orchestrations in
+    /// between.
+    #[spec("orchestration/identity/006")]
+    #[test]
+    fn identity_006_leaving_the_orchestration_restores_the_basename() {
+        let left = KeyEvent::new(KeyCode::Left, KeyModifiers::NONE);
+        let right = KeyEvent::new(KeyCode::Right, KeyModifiers::NONE);
+        let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+
+        // --- back to "No mode" (index 0) ---
+        let mut ui = default_ui();
+        ui.mode = UiMode::NewPaneForm;
+        ui.new_pane_form = Some(NewPaneFormState::new(
+            PathBuf::from("/tmp/myproj"),
+            "myproj".to_string(),
+            String::new(),
+            vec![],
+            vec![make_orchestration("review")],
+        ));
+
+        handle_new_pane_form_key(right, &mut ui); // land on the orchestration
+        assert_eq!(
+            ui.new_pane_form.as_ref().unwrap().name,
+            "myproj-orchestrator-1",
+            "control: landing on the orchestration still suggests N=1"
+        );
+
+        handle_new_pane_form_key(left, &mut ui); // back to "No mode"
+        assert_eq!(
+            ui.new_pane_form.as_ref().unwrap().selection_index,
+            0,
+            "precondition: Left from the orchestration lands on \"No mode\""
+        );
+        assert_eq!(
+            ui.new_pane_form.as_ref().unwrap().name,
+            "myproj",
+            "leaving the orchestration must restore the basename pre-fill — a \
+             plain pane must not be named `-orchestrator-N`"
+        );
+
+        handle_new_pane_form_key(enter, &mut ui); // Mode -> Name
+        handle_new_pane_form_key(enter, &mut ui); // Name -> Command
+        let result = handle_new_pane_form_key(enter, &mut ui);
+        match result {
+            Action::SpawnPane(req) => assert_eq!(
+                req.name, "myproj",
+                "the plain pane must submit under the basename, not the stale \
+                 orchestrator suggestion"
+            ),
+            other => panic!("expected SpawnPane, got {other:?}"),
+        }
+
+        // --- forward off the orchestration onto `schedule` ---
+        let mut ui = default_ui();
+        ui.mode = UiMode::NewPaneForm;
+        ui.new_pane_form = Some(NewPaneFormState::new(
+            PathBuf::from("/tmp/myproj"),
+            "myproj".to_string(),
+            String::new(),
+            vec![],
+            vec![make_orchestration("review")],
+        ));
+
+        handle_new_pane_form_key(right, &mut ui); // orchestration
+        handle_new_pane_form_key(right, &mut ui); // `schedule`
+        let form = ui.new_pane_form.as_ref().unwrap();
+        assert!(
+            form.is_schedule_selected(),
+            "precondition: two Rights land on the built-in `schedule` option"
+        );
+        assert_eq!(
+            form.name, "myproj",
+            "cycling PAST the orchestration to reach `schedule` must not leave \
+             the orchestrator suggestion behind"
+        );
     }
 
     /// Scenario: With `myproj-orchestrator-1` already live (a name a running

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -2458,6 +2458,13 @@ without depending on the config struct API.
 - **Does not assert:** the daemon-side authoritative check deferred to a follow-up issue (form-time uniqueness stays advisory); a real-binary/PTY-attached end-to-end pass.
 - **Platform coverage:** mac+linux+windows.
 
+##### orchestration/identity/006 — Cycling AWAY from the orchestration restores the directory-basename pre-fill, so a plain pane, a workload-mode pane or a `schedule`/`dispatcher` card is never left holding the `<folder>-orchestrator-N` suggestion (issue #638).
+- **Layer:** L1 (`src/ui.rs`'s own `#[cfg(test)] mod tests` — the real `handle_new_pane_form_key` arrow-key path against a `NewPaneFormState` built with the bare-basename pre-fill `transition_after_dir_pick` produces; no daemon, no PTY).
+- **Agent:** none.
+- **Asserts:** a form built with Name `"myproj"` and one orchestration, after Right selects the orchestration (control: `form.name == "myproj-orchestrator-1"`, so the failure below is attributable to the leave path and not to the whole suggestion), Left back to "No mode" restores `form.name == "myproj"` and submitting yields `Action::SpawnPane` with `req.name == "myproj"`; separately, two Rights landing on the built-in `schedule` option — the cycler orders orchestrations BEFORE it, so reaching it means passing over one — also leaves `form.name == "myproj"`.
+- **Does not assert:** that a name the user TYPED survives the same cycling (that is `orchestration/identity/004`, whose `name_touched` guard this shares and does not change); the render of the Name field's literal text; the daemon round-trip that learns live orchestration names.
+- **Platform coverage:** mac+linux+windows.
+
 #### orchestration/guard
 
 ##### orchestration/guard/001 — Opening an orchestration in a cwd that already hosts a live orchestration shows a non-blocking shared-resource warning pointing at worktrees (PRD #140).


### PR DESCRIPTION
Fixes #638.

## What was wrong

The new-pane form's Name field pre-fills with the picked directory's basename, and #538/#539 made selecting an orchestration replace that with the suggested `<folder>-orchestrator-N`. That replacement was **one-way** — `suggest_name_if_orchestration_selected` applied the suggestion on an orchestration and `return`ed early on everything else, so nothing ever restored the pre-fill:

```rust
if self.selected_orchestration().is_some() {
    self.name = self.suggest_orchestration_name();
}
// ← no else: the generated name outlives the selection that generated it
```

So a pane created with **no mode at all** — or with an ordinary workload mode, or as a `schedule` / `dispatcher` card — ended up named `<folder>-orchestrator-1` despite never having been an orchestration.

## Why it was easy to hit

`mode_option_name` orders the cycler `No mode → …modes… → …orchestrations… → schedule → schedule: issues → dispatcher`. The orchestrations sit **between** "No mode" and the built-in options, so reaching any of those from the left necessarily passes over an orchestration — and passing over one was enough. The plainest path to it was opening the form, cycling through to see what is on offer, settling back on "No mode", and submitting.

## The fix

Rename to `resuggest_name_for_selection` and make it two-way: an orchestration suggests `<folder>-orchestrator-N` as before, anything else restores `name_prefill` — the basename the form opened with, captured in the constructor.

The `name_touched` guard is deliberately untouched, so a name the user typed is still never overwritten in either direction. `orchestration/identity/004` continues to pin that and passes unchanged.

## Reproduce-first

Test written and confirmed failing **before** the fix, against `v0.36.2` — the released build this was reported on:

```
assertion `left == right` failed: leaving the orchestration must restore the
basename pre-fill — a plain pane must not be named `-orchestrator-N`
  left: "myproj-orchestrator-1"
 right: "myproj"
```

`orchestration/identity/006` carries a **control** assertion — landing on the orchestration still suggests `-1` — which passes first, so the failure is attributable to the leave path specifically and not to the suggestion feature as a whole. The fix was then confirmed load-bearing by reverting only the `else` branch and watching the same test go red again.

## Gates

- `cargo test-fast` — **2944 passed, 0 failed** (includes `orchestration/identity/002`–`005` unchanged)
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --features e2e -- -D warnings` — clean

## Contract check (CLAUDE.md rule 12)

Presentation only — the new-pane form's Name field. No daemon, TUI↔daemon protocol, orchestration-runtime or hook change, so no `PROTOCOL_VERSION` bump and no `.breaking.md`. Cross-version run not applicable.

## Deliberately not in scope

Whether the suffix should appear on the **first** orchestration at all, and whether `N` should count per-directory rather than globally, came up alongside this and were decided to stay as-is — that is what #538 specified, and the global counter is what stops `-orchestrator-1` being offered in two directories at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0181zWG1w5h7SebEmLBuSpEQ
