### PR TITLE
fix(e2e): run OpenCode coverage on the host's own agent auth, not metered OpenRouter

### DIFF
--- a/changelog.d/654.misc.md
+++ b/changelog.d/654.misc.md
@@ -1,0 +1,5 @@
+## Real-agent OpenCode tests run on whatever agent auth the machine already has
+
+The end-to-end suite used to pin its OpenCode coverage to a specific OpenRouter model, so those tests only ran on a machine holding OpenRouter credit — and quietly skipped everywhere else, reporting missing *credentials* even when credentials were present. They now name a provider rather than a billing route, so they resolve against whatever `opencode auth` holds, including a ChatGPT subscription, and a contributor no longer needs a second paid account to exercise them. `DOT_AGENT_DECK_OPENCODE_TEST_MODEL` overrides the choice where a different provider is wanted.
+
+The Codex equivalent is documented correctly for the first time. The guidance had it backwards — it said the `codex-*` models were reachable only with a ChatGPT subscription and that an API key needed the override, when a subscription is in fact what cannot reach them. A subscription host therefore failed the availability probe and skipped every real-agent Codex test silently, which reads as a pass. The skip now explains which authentication is in use and what to set instead.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2722,8 +2722,8 @@ pub fn check_opencode_available() -> Result<(), String> {
 }
 
 /// Compiled-in default cheap model for Codex availability probes and real-agent
-/// e2e coverage. Correct for a ChatGPT-subscription (oauth) `~/.codex/auth.json`,
-/// which is what most dev boxes here log in with.
+/// e2e coverage. Reachable by an **API-key** `~/.codex/auth.json`; a
+/// ChatGPT-subscription (oauth) host must override it — see [`codex_test_model`].
 const CODEX_TEST_MODEL_DEFAULT: &str = "gpt-5.1-codex-mini";
 
 /// Env var that overrides [`codex_test_model`] on a host whose Codex credentials
@@ -2734,16 +2734,39 @@ pub const CODEX_TEST_MODEL_ENV: &str = "DOT_AGENT_DECK_CODEX_TEST_MODEL";
 /// [`CODEX_TEST_MODEL_DEFAULT`] unless `DOT_AGENT_DECK_CODEX_TEST_MODEL` is set
 /// to a non-empty value, which wins.
 ///
-/// The override exists because the `codex-*` model family is served only to
-/// ChatGPT-subscription (oauth) credentials. With an **API-key**
+/// The override exists because no single model id is reachable by both Codex
+/// auth modes, so whichever one the default targets, the other needs an escape
+/// hatch.
+///
+/// The `codex-*` family is **API-key only**. On a ChatGPT-subscription (oauth)
 /// `~/.codex/auth.json`, `codex exec --model gpt-5.1-codex-mini` answers
-/// `404 Not Found: Model not found gpt-5.1-codex-mini` from
-/// `https://api.openai.com/v1/responses`, so [`check_codex_available`] fails its
-/// probe and every real-agent Codex test SKIPS — a silent no-coverage outcome
-/// that reads as a pass. Such a host exports e.g.
-/// `DOT_AGENT_DECK_CODEX_TEST_MODEL=gpt-5-nano` (an equally cheap model an API
-/// key *can* reach). The default is deliberately left alone so subscription-auth
-/// environments keep running codex-mini.
+/// `400 invalid_request_error: The 'gpt-5.1-codex-mini' model is not supported
+/// when using Codex with a ChatGPT account` (measured 2026-08-23), so
+/// [`check_codex_available`] fails its probe and every real-agent Codex test
+/// SKIPS — a silent no-coverage outcome that reads as a pass.
+///
+/// A subscription host therefore exports a plain `gpt-5.*` model it *can* reach,
+/// e.g. `DOT_AGENT_DECK_CODEX_TEST_MODEL=gpt-5.4-mini` (verified 2026-08-23).
+///
+/// **Setting it makes the tests run, not pass.** They then fail on an unrelated
+/// defect: Codex 0.149.0 does not execute the deck's trusted command hooks in
+/// **interactive TUI** mode, so no hook-sourced event ever reaches the deck and
+/// assertions wanting a `Thinking` carrying `user_prompt` time out. Measured
+/// 2026-08-23 against one `CODEX_HOME` with identical `hooks.json`, identical
+/// trust records and an identical socket: `codex exec` delivered `session_start`,
+/// `thinking` (with `user_prompt`) and `idle`; the same home driven interactively
+/// delivered nothing, while the turn itself ran (the deck still saw `ShellBusy`
+/// from the stdout classifier). `docs/develop/agent-adapters.md` records
+/// interactive hooks working on 0.145.0, so this is a regression in that range,
+/// and it is auth-mode independent — an API-key host on 0.149.0 fails the same
+/// way. The default is left on the API-key model so those tests SKIP rather than
+/// fail while that is outstanding.
+///
+/// (Before 2026-08-23 this comment asserted the reverse of the first paragraph —
+/// that `codex-*` was oauth-only and the override was for API-key hosts. That was
+/// wrong and cost a debugging session: the probe failed on a freshly
+/// authenticated subscription and the error text sent the reader looking for an
+/// API key that was not there.)
 ///
 /// Single source of truth: [`check_codex_available`] probes the model this
 /// returns, so the availability gate and the model the tests actually launch can
@@ -2756,6 +2779,46 @@ pub fn codex_test_model() -> &'static str {
             .map(|raw| raw.trim().to_string())
             .filter(|model| !model.is_empty())
             .unwrap_or_else(|| CODEX_TEST_MODEL_DEFAULT.to_string())
+    })
+}
+
+/// Compiled-in default cheap model for real-agent OpenCode e2e coverage.
+///
+/// OpenCode model ids are provider-qualified (`provider/model`); a bare
+/// `gpt-4o-mini` is rejected as "Invalid model format". This default is on the
+/// `openai` provider so it resolves against whatever `opencode auth` holds for
+/// OpenAI — including a **ChatGPT-subscription (oauth)** credential, which is
+/// how the dev boxes here are logged in and which costs nothing per call.
+///
+/// This deliberately does *not* route through OpenRouter. It used to: both call
+/// sites hardcoded `openrouter/openai/gpt-4o-mini`, which billed metered
+/// OpenRouter credit for coverage the subscription already pays for, and made
+/// two OpenCode tests skip whenever that balance ran dry — with a skip reason
+/// naming missing *credentials*, which were present the whole time.
+const OPENCODE_TEST_MODEL_DEFAULT: &str = "openai/gpt-5.4-mini";
+
+/// Env var that overrides [`opencode_test_model`] on a host whose OpenCode
+/// credentials cannot reach the default — e.g. one authenticated to OpenRouter
+/// but not OpenAI, which exports
+/// `DOT_AGENT_DECK_OPENCODE_TEST_MODEL=openrouter/openai/gpt-4o-mini`.
+pub const OPENCODE_TEST_MODEL_ENV: &str = "DOT_AGENT_DECK_OPENCODE_TEST_MODEL";
+
+/// Cheap provider-qualified model used by real-agent OpenCode e2e coverage —
+/// [`OPENCODE_TEST_MODEL_DEFAULT`] unless `DOT_AGENT_DECK_OPENCODE_TEST_MODEL`
+/// is set to a non-empty value, which wins.
+///
+/// Mirrors [`codex_test_model`]. Note the gates are not symmetric:
+/// [`check_opencode_available`] only checks that an `auth.json` exists and does
+/// **not** probe the model, so an unreachable model id here surfaces as a test
+/// failure rather than a skip.
+pub fn opencode_test_model() -> &'static str {
+    static MODEL: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    MODEL.get_or_init(|| {
+        std::env::var(OPENCODE_TEST_MODEL_ENV)
+            .ok()
+            .map(|raw| raw.trim().to_string())
+            .filter(|model| !model.is_empty())
+            .unwrap_or_else(|| OPENCODE_TEST_MODEL_DEFAULT.to_string())
     })
 }
 
@@ -2834,9 +2897,10 @@ pub fn check_codex_available() -> Result<(), String> {
         .any(|marker| lower.contains(marker))
     {
         return Err(format!(
-            "Codex could not reach model {} with the current authentication — if this host's \
-             ~/.codex/auth.json is an API key rather than a ChatGPT subscription, set {} to a \
-             model the key can reach (e.g. gpt-5-nano)",
+            "Codex could not reach model {} with the current authentication — the two auth \
+             modes reach different model families, so set {} to one these credentials can \
+             reach (API key: e.g. gpt-5-nano or gpt-5.1-codex-mini; ChatGPT subscription: \
+             e.g. gpt-5.4-mini). Run `codex login status` to see which mode is in use",
             codex_test_model(),
             CODEX_TEST_MODEL_ENV,
         ));

--- a/tests/e2e_delegate_respawn_readiness.rs
+++ b/tests/e2e_delegate_respawn_readiness.rs
@@ -33,7 +33,6 @@ const CLAUDE_MODEL: &str = "claude-haiku-4-5-20251001";
 const CLAUDE_SENTINEL: &str = "prd249-claude-respawn-4d37c1.txt";
 const CLAUDE_SENTINEL_CONTENT: &str = "PRD249_CLAUDE_RESPAWN_OK";
 
-const OPENCODE_MODEL: &str = "openrouter/openai/gpt-4o-mini";
 const OPENCODE_SENTINEL: &str = "prd249-opencode-respawn-8a62f4.txt";
 const OPENCODE_SENTINEL_CONTENT: &str = "PRD249_OPENCODE_RESPAWN_OK";
 
@@ -258,7 +257,7 @@ fn delegate_014_real_claude_worker_acts_on_clear_true_delegate() {
 fn delegate_015_real_opencode_worker_acts_on_clear_true_delegate() {
     skip_unless!(common::check_opencode_available());
 
-    let worker_command = format!("opencode --model {OPENCODE_MODEL} --auto");
+    let worker_command = format!("opencode --model {} --auto", common::opencode_test_model());
     let builder = TuiDeck::builder()
         .with_pty_size(180, 45)
         .with_env("PATH", path_with_binary_dir())

--- a/tests/e2e_delegate_work_done_chain.rs
+++ b/tests/e2e_delegate_work_done_chain.rs
@@ -306,12 +306,15 @@ async fn opencode_auto_submits_daemon_injected_prompt() {
     // sibling Claude arm pins its own socket for the same reason, and a test
     // that spawns a real agent should never depend on ambient environment.
     let dead_hook_socket = cwd.path().join("no-listener.sock");
+    // OpenCode model ids are provider-qualified (`provider/model`); a bare
+    // `gpt-4o-mini` is rejected as "Invalid model format". A small model is
+    // plenty for a one-line arithmetic reply. Shared with the other real-agent
+    // OpenCode test through `common::opencode_test_model` so both move together
+    // and both honour `DOT_AGENT_DECK_OPENCODE_TEST_MODEL`.
+    let worker_command = format!("opencode --model {}", common::opencode_test_model());
     let worker_agent_id = registry
         .spawn_agent(SpawnOptions {
-            // OpenCode model ids are provider-qualified (`provider/model`); a
-            // bare `gpt-4o-mini` is rejected as "Invalid model format". A small
-            // model is plenty for a one-line arithmetic reply.
-            command: Some("opencode --model openrouter/openai/gpt-4o-mini"),
+            command: Some(worker_command.as_str()),
             cwd: Some(cwd_str.as_str()),
             rows: 40,
             cols: 120,


### PR DESCRIPTION
## Problem

The real-agent e2e tier baked **host-specific auth assumptions into test constants**, so it only ran properly on a machine configured like the one that wrote it.

Two OpenCode tests hardcoded `openrouter/openai/gpt-4o-mini` — in one case not even via the shared constant, just an inline string in a second file. That billed metered OpenRouter credit for coverage a maintainer's existing subscription already pays for, and skipped both tests whenever that balance ran dry. The skip reason named missing *credentials*, which were present the whole time.

Separately, `codex_test_model`'s documentation asserted the **exact reverse of reality**, which cost a long debugging session.

## Changes

**1. OpenCode coverage runs on the host's own auth.** `openai/gpt-5.4-mini` names a *provider*, not an auth mode, so it resolves against whatever `opencode auth` holds — a ChatGPT-subscription (oauth) credential or an API key. Verified end to end on a subscription host: both tests run and pass, no OpenRouter involved.

**2. `opencode_test_model()` + `DOT_AGENT_DECK_OPENCODE_TEST_MODEL`**, mirroring the existing Codex accessor. A host that can only reach OpenRouter overrides it instead of editing two files. Also collapses the duplicate — one call site previously ignored the shared constant entirely.

**3. Corrected the Codex model documentation.** It claimed the `codex-*` family was served *only* to ChatGPT-subscription credentials, and that an **API key** needed the override. Measured 2026-08-23, it is the other way round:

```
$ codex exec --model gpt-5.1-codex-mini        # ChatGPT-subscription auth
400 invalid_request_error: The 'gpt-5.1-codex-mini' model is not supported
when using Codex with a ChatGPT account
```

So a subscription host fails the availability probe and **all four real-agent Codex tests SKIP** — silently, reading as a pass. The failure message sent readers hunting for an API key that was not the problem; it now names both auth modes and points at `codex login status`.

## What is deliberately *not* changed

`CODEX_TEST_MODEL_DEFAULT` stays `gpt-5.1-codex-mini`.

Overriding it (`DOT_AGENT_DECK_CODEX_TEST_MODEL=gpt-5.4-mini`, verified reachable) makes those four tests **run but not pass** — they then fail on a separate defect unrelated to auth or model choice. Converting four silent skips into four red tests is not an improvement while that is outstanding, and `cargo test-e2e` is the pre-PR gate.

**Flipping that default is a one-line follow-up** once the separate defect lands. Everything else here stands on its own.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --features e2e -- -D warnings` — clean
- `cargo test-fast` — 3049/3049
- `cargo test-e2e` — the two OpenCode tests pass on subscription auth with no OpenRouter credit

One unrelated e2e failure exists on this branch, `e2e_dispatcher_mode::orchestration_dispatch_002_every_real_agent_role_comes_alive`. **It fails identically on clean `main`** (verified by stashing this branch's changes and rerunning: same 313s, same assertion), so it is pre-existing and not introduced here.

## Rule 12

Touches no daemon, protocol, orchestration or hook code — `tests/` only. **No `PROTOCOL_VERSION` bump, no `.breaking.md` fragment.**

## Notes for the reviewer

- **Verification hazard worth knowing about.** Running the e2e tier leaks orphaned `dot-agent-deck wrap --agent codex` processes; 35 had accumulated on the dev box, the oldest 8½ days, pinning 385 temp roots / 14.2 GB that `cargo xtask clean-e2e-tmp` will never reap while their PIDs live. The stale state they leave behind produced several wrong conclusions while investigating this. Tracked separately.
- **`DOT_AGENT_DECK_REQUIRE_REAL_E2E=1`** turns every runtime skip into a loud failure with its reason. Worth using to confirm a run genuinely exercised your auth rather than skipping past it — without it, `SKIP:` goes to stderr and is invisible in a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCjF32yf9vfMHjbnCLpTkf
