### PR TITLE
chore(orchestration): point the reviewer role at pi on Anthropic, not a dry OpenAI key

### DIFF
--- a/.dot-agent-deck.toml
+++ b/.dot-agent-deck.toml
@@ -165,7 +165,7 @@ prompt_template = "Implement the requested change. If the task references a PRD 
 
 [[orchestrations.roles]]
 name = "reviewer"
-command = "devbox run pi-sol"
+command = "devbox run pi-big"
 # command = "devbox run agent-reviewer"   # all-claude default
 description = "Reviews code changes for correctness, style, and edge cases"
 prompt_template = "Review the change. Report findings only — do not modify code. Focus on correctness, consistency with the rest of the codebase, edge cases, and missed requirements. If the task references a PRD path, verify the implementation matches it. If critical context is missing (e.g. the diff or PRD path), surface it in your work-done summary rather than guessing — the orchestrator will re-delegate with the missing context. Whenever you are blocked or missing critical context, report it back through `work-done` and stop there: never notify the user yourself and never wait on the user — the orchestrator is the only agent that does either, and it escalates for you."

--- a/changelog.d/655.misc.md
+++ b/changelog.d/655.misc.md
@@ -1,0 +1,3 @@
+## The project's own reviewer role points at an agent that can actually start
+
+The `reviewer` role in this repository's orchestration was configured to run pi against OpenAI, whose credit is exhausted, so the role failed to start at all. It now runs pi against Anthropic, keeping a second agent harness in the reviewer seat rather than reviewing Claude's work with Claude. This affects only the orchestration this repository ships for its own development; nothing in the deck's behaviour changes.


### PR DESCRIPTION
## Problem

The `reviewer` role is **dead on this machine**. It runs `devbox run pi-sol` → `pi --provider openai --model gpt-5.6-sol`, and the OpenAI API key answers:

```
429 insufficient_quota — "You have no credits remaining."
```

So the role cannot start.

## Change

One line: `pi-sol` → `pi-big` (`pi --model anthropic/claude-opus-4-8 --thinking high --approve`), an alias that already exists in `devbox.json`.

This keeps a **distinct harness** in the reviewer seat rather than collapsing to Claude-reviewing-Claude — pi is a different agent with a different prompt surface, which is the property the reviewer/auditor/tester split exists for.

Verified end to end (`PI_OK` returned). It only worked after clearing a **dead Anthropic OAuth entry** from `~/.pi/agent/auth.json`: pi preferred the stored, expired oauth credential over the working `ANTHROPIC_API_KEY` and never fell back, failing with `invalid_grant: Refresh token expired`. That is machine-local state, not repo state, so nothing here fixes it for anyone else — worth knowing if pi fails the same way on another box.

## Trade-off — please push back if this is wrong for you

This moves the reviewer's cost **from OpenAI onto metered `ANTHROPIC_API_KEY`**, and Opus at `--thinking high` is the most expensive per-token combination in the stack.

Critically, **an Anthropic Pro/Max subscription does not cover it.** Third-party tools were cut off from subscription quotas on 2026-04-04 — only official Claude Code, claude.ai and Desktop ride the subscription, so pi necessarily bills the API.

So:

- If you **have working OpenAI credit**, the previous `pi-sol` is better for you and this change costs you Anthropic credit instead.
- If you want **zero marginal cost**, `agent-reviewer` (Claude via subscription) is commented out one line below.

This is a judgment call about billing, not a correctness fix. It is one line and **separately revertible** — nothing else depends on it.

## Rule 12

Orchestration *configuration*, not the orchestration wire. **No `PROTOCOL_VERSION` bump, no `.breaking.md` fragment.**

## Related

Independent of #654 (e2e agent-auth portability) — no code dependency in either direction. Both came out of the same session making the agent stack run on available credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCjF32yf9vfMHjbnCLpTkf
