### PR TITLE
fix(cli): bound --task-file and stdin reads, refuse non-regular files (#328)

### DIFF
--- a/changelog.d/328.bugfix.md
+++ b/changelog.d/328.bugfix.md
@@ -1,0 +1,9 @@
+## `--task-file` refuses an oversized or non-regular task file instead of hanging or reading it without limit
+
+`dot-agent-deck delegate`, `work-done`, and `dispatch` read the task text with `--task-file <path>`, or from stdin with `--task-file -`. Neither read had a size bound, and neither checked what the path actually pointed at. A path naming a FIFO with no writer blocked the command **forever** — the block happened inside `open`, before anything got a chance to look at it — and one naming an endless character device such as `/dev/zero`, or a file being appended to, was read into memory until the process ran out of it. Both reads are now capped at 1 MiB and refused, never truncated, past that; a path that is not a regular file is refused on its type before a single byte is read.
+
+The delegation protocol the deck writes into every orchestrator's context tells it to pass task text as a file rather than inline, precisely because `--task` lets the caller's shell mangle backticks, quotes and `$VAR` first. That makes `--task-file` the primary input for every delegation, so it is the one that needed the bound.
+
+1 MiB is far above anything a task can legitimately be: this project's largest PRD is ~117 KiB, and 1 MiB of prose is roughly 250k tokens — past the context window of the agent the text is being written for. Both refusals name what was wrong and what to do about it, rather than failing anonymously.
+
+**One behaviour changes for existing callers:** `--task-file <(some-command)` — bash process substitution — passes a `/dev/fd/N` pipe, not a regular file, so it is now refused. Pipe into stdin instead: `some-command | dot-agent-deck delegate --to coder --task-file -`, which is bounded but has no file-type requirement. Symlinks still work and are still followed; the type check applies to the resolved target, so a symlink pointing at a FIFO or a device is refused just the same.

--- a/src/bounded_read.rs
+++ b/src/bounded_read.rs
@@ -1,0 +1,320 @@
+//! Size-bounded reads for caller-supplied input.
+//!
+//! Issue #328. `std::fs::read_to_string` and `Read::read_to_string` are
+//! unbounded in both directions that matter: they allocate however much the
+//! source produces, and they wait however long it takes to produce it. That is
+//! fine for a file this process wrote; it is not fine for a path or a stream
+//! handed in on the command line, where the two pathological shapes are a file
+//! that is enormous (or growing) and a target that is not a file at all — a
+//! FIFO with no writer blocks forever, `/dev/zero` never ends.
+//!
+//! Two things live here, deliberately separated. [`read_capped`] is the
+//! general primitive — read anything, stop at a byte cap, refuse rather than
+//! truncate — and carries no policy of its own. [`read_task_input`] is the one
+//! policy built on it: the `--task-file` reader, which additionally opens a
+//! path once and refuses anything that is not a regular file, and whose error
+//! wording names that flag because it is the only thing that calls it.
+//!
+//! [`crate::config::load_features_file`] applies the same shape inline with
+//! different failure semantics (a bad `[features]` file keeps the previous
+//! value and warns rather than erroring), which is why it is not expressed in
+//! terms of these functions.
+
+use std::io::Read;
+
+/// Upper bound on the task/summary text accepted from `--task-file <path>` and
+/// `--task-file -`.
+///
+/// A task is prose destined for an agent's prompt, so the cap only has to sit
+/// far enough above "the longest brief anyone would actually write" that no
+/// legitimate input can reach it. 1 MiB clears that by a wide margin in both
+/// directions: this repository's largest PRD is ~117 KiB and a task file is a
+/// task *description*, not a whole PRD; and 1 MiB of prose is roughly 250k
+/// tokens, past the context window of the agents the text is being written
+/// for. Anything above it is pathological rather than long, and gets a clear
+/// refusal instead of an allocation.
+pub const MAX_TASK_BYTES: u64 = 1024 * 1024;
+
+/// Read `reader` to a `String`, refusing input larger than `max_bytes`.
+///
+/// `source` names the input in error messages ("task from stdin", "task file
+/// '…'") and is expected to read as a lowercase noun phrase.
+///
+/// The reader is capped at `max_bytes + 1` rather than `max_bytes` so the two
+/// outcomes stay distinguishable: input exactly at the limit is accepted, and
+/// input past it is *detected* without being read — the extra byte is the
+/// evidence, so an endless stream costs one megabyte and a refusal rather than
+/// the machine's memory. Nothing is ever silently truncated.
+pub fn read_capped(reader: impl Read, max_bytes: u64, source: &str) -> Result<String, String> {
+    let mut buf = String::new();
+    reader
+        .take(max_bytes.saturating_add(1))
+        .read_to_string(&mut buf)
+        .map_err(|e| format!("failed to read {source}: {e}"))?;
+    if buf.len() as u64 > max_bytes {
+        return Err(over_limit(source, max_bytes));
+    }
+    Ok(buf)
+}
+
+/// Read the task/summary text for `--task-file <path>`, or from `stdin` when
+/// `path` is `-`. Both are capped at [`MAX_TASK_BYTES`].
+///
+/// `-` deliberately keeps no file-type requirement — stdin is a pipe or a
+/// terminal by design, and the cap is the whole of its protection. A `path`,
+/// by contrast, must name a **regular file**, which is what the two shapes
+/// this guards against are not: a FIFO with no writer never produces a byte,
+/// and a character device such as `/dev/zero` never stops producing them.
+pub fn read_task_input(path: &str, stdin: impl Read) -> Result<String, String> {
+    if path == "-" {
+        read_capped(stdin, MAX_TASK_BYTES, "task from stdin")
+    } else {
+        read_task_file(path)
+    }
+}
+
+/// The path branch of [`read_task_input`], with two properties beyond
+/// [`read_capped`]:
+///
+/// * **Opened once, judged from the open handle.** The type check reads
+///   `File::metadata` (an `fstat` on the descriptor already held), not a second
+///   `std::fs::metadata` on the path, so there is no window in which the thing
+///   checked and the thing read can differ.
+/// * **The open cannot hang.** On Unix the handle is opened `O_NONBLOCK`,
+///   because a plain `open(2)` of a FIFO with no writer blocks *inside the
+///   open* — before any check could run, which would reproduce the hang this
+///   function exists to prevent. The flag is ignored for regular files, the
+///   only kind that survives the check below.
+///
+/// Symlinks are followed deliberately (no `O_NOFOLLOW`): a task file reached
+/// through a symlink is ordinary, and since the check is applied to the
+/// resolved target, a symlink pointing at `/dev/zero` or a FIFO is refused
+/// just the same. This matches [`crate::config::load_features_file`].
+fn read_task_file(path: &str) -> Result<String, String> {
+    let source = format!("task file '{path}'");
+    let io_err = |e: std::io::Error| format!("failed to read {source}: {e}");
+
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NONBLOCK);
+    }
+    let file = options.open(path).map_err(io_err)?;
+
+    let metadata = file.metadata().map_err(io_err)?;
+    if !metadata.is_file() {
+        return Err(format!(
+            "{source} is {}; --task-file needs a regular file (for a pipe, a process \
+             substitution, or a terminal, pipe the text in and pass `--task-file -` instead)",
+            describe_file_type(&metadata.file_type())
+        ));
+    }
+    // Cheap and exact: refuse an oversized file by its recorded length rather
+    // than by reading a megabyte of it first. `read_capped` still applies the
+    // cap afterwards, which is what catches a file that grows past the limit
+    // between this check and the read.
+    if metadata.len() > MAX_TASK_BYTES {
+        return Err(over_limit(&source, MAX_TASK_BYTES));
+    }
+
+    read_capped(file, MAX_TASK_BYTES, &source)
+}
+
+/// The over-limit refusal, shared so the file and stdin paths word it
+/// identically.
+fn over_limit(source: &str, max_bytes: u64) -> String {
+    format!(
+        "{source} exceeds the {max_bytes}-byte limit; a task is prose, so shorten it and point \
+         the agent at any bulk content by path instead of inlining it"
+    )
+}
+
+/// Name a rejected file type in a way that tells the caller what they actually
+/// pointed at. The generic fallback still completes the sentence in
+/// [`read_task_file`]'s message.
+fn describe_file_type(file_type: &std::fs::FileType) -> &'static str {
+    if file_type.is_dir() {
+        return "a directory";
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileTypeExt as _;
+        if file_type.is_fifo() {
+            return "a FIFO";
+        }
+        if file_type.is_socket() {
+            return "a socket";
+        }
+        if file_type.is_char_device() {
+            return "a character device";
+        }
+        if file_type.is_block_device() {
+            return "a block device";
+        }
+    }
+    "not a regular file"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Run `f` on a scratch thread and fail — rather than hang the tier — if it
+    /// has not returned within five seconds. Every refusal here is guarding
+    /// against an input that blocks forever, so "the call returned at all" is
+    /// half of what these tests assert.
+    fn within_timeout<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let _ = tx.send(f());
+        });
+        let got = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("the bounded read must return promptly, not block");
+        handle.join().expect("worker thread panicked");
+        got
+    }
+
+    #[test]
+    fn read_capped_accepts_input_exactly_at_the_limit() {
+        let input = "x".repeat(16);
+        let got = read_capped(input.as_bytes(), 16, "test input").expect("16 bytes under a 16 cap");
+        assert_eq!(
+            got, input,
+            "input exactly at the cap must be accepted whole"
+        );
+    }
+
+    #[test]
+    fn read_capped_refuses_input_one_byte_over_the_limit() {
+        let input = "x".repeat(17);
+        let err = read_capped(input.as_bytes(), 16, "test input")
+            .expect_err("17 bytes must not pass a 16-byte cap");
+        assert!(
+            err.contains("test input") && err.contains("exceeds the 16-byte limit"),
+            "over-limit error should name the source and the cap: {err}"
+        );
+    }
+
+    #[test]
+    fn read_capped_refuses_an_endless_reader_instead_of_consuming_it() {
+        // The `/dev/zero` shape at the reader level: a stream that never ends.
+        // Unbounded, this allocates until the process dies.
+        let err = within_timeout(|| {
+            read_capped(std::io::repeat(b'z'), 4096, "endless input")
+                .expect_err("an endless reader must be refused")
+        });
+        assert!(
+            err.contains("exceeds the 4096-byte limit"),
+            "endless input should be refused by the cap: {err}"
+        );
+    }
+
+    #[test]
+    fn regular_file_is_read_whole() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("task.md");
+        std::fs::write(&path, "line one\nline two\n").expect("write");
+        let got =
+            read_task_file(path.to_str().unwrap()).expect("a regular file under the cap must read");
+        assert_eq!(got, "line one\nline two\n");
+    }
+
+    #[test]
+    fn oversized_regular_file_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("huge.md");
+        std::fs::write(&path, "x".repeat(MAX_TASK_BYTES as usize + 1)).expect("write");
+        let err = read_task_file(path.to_str().unwrap())
+            .expect_err("a file over the cap must be refused");
+        assert!(
+            err.contains(&format!("exceeds the {MAX_TASK_BYTES}-byte limit"))
+                && err.contains("huge.md"),
+            "over-limit error should name the file and the cap: {err}"
+        );
+    }
+
+    #[test]
+    fn missing_file_error_names_the_path() {
+        let err = read_task_file("/no/such/task-file.md").expect_err("a missing file must error");
+        assert!(
+            err.contains("failed to read task file") && err.contains("/no/such/task-file.md"),
+            "missing-file error should name the path: {err}"
+        );
+    }
+
+    #[test]
+    fn directory_is_refused_as_not_a_regular_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err =
+            read_task_file(dir.path().to_str().unwrap()).expect_err("a directory must be refused");
+        assert!(
+            err.contains("is a directory") && err.contains("--task-file"),
+            "directory error should say what it is and what is required: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    fn mkfifo_at(path: &std::path::Path) {
+        let c_path = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()).expect("cstring");
+        // SAFETY: `c_path` is a valid NUL-terminated string that outlives the
+        // call, and `mkfifo` only reads through it.
+        let rc = unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) };
+        assert_eq!(rc, 0, "mkfifo failed: {}", std::io::Error::last_os_error());
+    }
+
+    /// The hang case. With no writer attached, a plain `open(2)` of this FIFO
+    /// never returns — so this test asserts both that the read is refused and
+    /// that it is refused *promptly*.
+    #[cfg(unix)]
+    #[test]
+    fn fifo_is_refused_without_blocking() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("task.fifo");
+        mkfifo_at(&path);
+        let arg = path.to_str().unwrap().to_string();
+        let err = within_timeout(move || read_task_file(&arg).expect_err("a FIFO must be refused"));
+        assert!(
+            err.contains("is a FIFO") && err.contains("--task-file -"),
+            "FIFO error should name the type and point at the stdin alternative: {err}"
+        );
+    }
+
+    /// A symlink to a FIFO is refused too: the type check reads the resolved
+    /// target, so no-follow semantics are not needed to close this.
+    #[cfg(unix)]
+    #[test]
+    fn symlink_to_fifo_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = dir.path().join("real.fifo");
+        mkfifo_at(&target);
+        let link = dir.path().join("task.md");
+        std::os::unix::fs::symlink(&target, &link).expect("symlink");
+        let arg = link.to_str().unwrap().to_string();
+        let err = within_timeout(move || {
+            read_task_file(&arg).expect_err("a symlink to a FIFO must be refused")
+        });
+        assert!(
+            err.contains("is a FIFO"),
+            "the check must judge the resolved target: {err}"
+        );
+    }
+
+    /// The endless-device case: `/dev/zero` is a character device, refused on
+    /// its type before a single byte is read.
+    #[cfg(unix)]
+    #[test]
+    fn character_device_is_refused() {
+        if !std::path::Path::new("/dev/zero").exists() {
+            return;
+        }
+        let err =
+            within_timeout(|| read_task_file("/dev/zero").expect_err("/dev/zero must be refused"));
+        assert!(
+            err.contains("is a character device"),
+            "device error should name the type: {err}"
+        );
+    }
+}

--- a/src/bounded_read.rs
+++ b/src/bounded_read.rs
@@ -101,14 +101,32 @@ fn read_task_file(path: &str) -> Result<String, String> {
         use std::os::unix::fs::OpenOptionsExt as _;
         options.custom_flags(libc::O_NONBLOCK);
     }
-    let file = options.open(path).map_err(io_err)?;
+    let file = match options.open(path) {
+        Ok(file) => file,
+        // Windows refuses `open` on a directory outright (`Access is denied`,
+        // os error 5), so control never reaches the type check below and the
+        // caller would see a bare OS error instead of the refusal this
+        // function documents. Recover the documented message from the path so
+        // the refusal reads the same on every platform.
+        //
+        // Consulting the path here cannot reintroduce the TOCTOU the open
+        // handle exists to avoid: the open has already failed, so nothing is
+        // read on this branch either way, and the only thing a race can change
+        // is the wording of an error that is returned regardless.
+        Err(e) => {
+            return Err(if std::fs::metadata(path).is_ok_and(|m| m.is_dir()) {
+                not_a_regular_file(&source, "a directory")
+            } else {
+                io_err(e)
+            });
+        }
+    };
 
     let metadata = file.metadata().map_err(io_err)?;
     if !metadata.is_file() {
-        return Err(format!(
-            "{source} is {}; --task-file needs a regular file (for a pipe, a process \
-             substitution, or a terminal, pipe the text in and pass `--task-file -` instead)",
-            describe_file_type(&metadata.file_type())
+        return Err(not_a_regular_file(
+            &source,
+            describe_file_type(&metadata.file_type()),
         ));
     }
     // Cheap and exact: refuse an oversized file by its recorded length rather
@@ -120,6 +138,15 @@ fn read_task_file(path: &str) -> Result<String, String> {
     }
 
     read_capped(file, MAX_TASK_BYTES, &source)
+}
+
+/// The not-a-regular-file refusal, shared so the type check and the Windows
+/// open-failure recovery word it identically.
+fn not_a_regular_file(source: &str, kind: &str) -> String {
+    format!(
+        "{source} is {kind}; --task-file needs a regular file (for a pipe, a process \
+         substitution, or a terminal, pipe the text in and pass `--task-file -` instead)"
+    )
 }
 
 /// The over-limit refusal, shared so the file and stdin paths word it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 mod agent_hook_config;
 pub mod agent_pty;
 pub mod agent_registry;
+pub mod bounded_read;
 pub mod build_id;
 pub mod build_version_handshake;
 pub mod codex_hooks_manage;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use tokio::sync::RwLock;
 
 use dot_agent_deck::agent_pty::{DOT_AGENT_DECK_AGENT_ID, DOT_AGENT_DECK_PANE_ID};
+use dot_agent_deck::bounded_read::read_task_input;
 use dot_agent_deck::build_version_handshake;
 use dot_agent_deck::config::{DashboardConfig, attach_socket_path, socket_path};
 use dot_agent_deck::daemon::{Daemon, run_daemon_with};
@@ -101,7 +102,9 @@ enum Commands {
         /// Read the task text verbatim from a file (or `-` for stdin). The
         /// shell-safe way to pass a task containing backticks, quotes, `$VAR`,
         /// or newlines, which --task would otherwise let the caller's shell
-        /// mangle. Mutually exclusive with --task.
+        /// mangle. PATH must be a regular file, not a FIFO or a device; pass
+        /// `-` to read a pipe. At most 1 MiB, from a file or from stdin.
+        /// Mutually exclusive with --task.
         #[arg(long = "task-file", value_name = "PATH")]
         task_file: Option<String>,
         /// Role name(s) to delegate to (repeatable)
@@ -119,8 +122,10 @@ enum Commands {
         /// Mutually exclusive with --task-file.
         #[arg(long, conflicts_with = "task_file")]
         task: Option<String>,
-        /// Read the task text verbatim from a file (or `-` for stdin).
-        /// Mutually exclusive with --task.
+        /// Read the task text verbatim from a file (or `-` for stdin). PATH
+        /// must be a regular file, not a FIFO or a device; pass `-` to read a
+        /// pipe. At most 1 MiB, from a file or from stdin. Mutually exclusive
+        /// with --task.
         #[arg(long = "task-file", value_name = "PATH")]
         task_file: Option<String>,
         /// Start ONE agent, even where this repo defines `[[orchestrations]]`.
@@ -158,7 +163,9 @@ enum Commands {
         task: Option<String>,
         /// Read the summary text verbatim from a file (or `-` for stdin). The
         /// shell-safe way to pass a summary containing backticks, quotes,
-        /// `$VAR`, or newlines. Mutually exclusive with --task.
+        /// `$VAR`, or newlines. PATH must be a regular file, not a FIFO or a
+        /// device; pass `-` to read a pipe. At most 1 MiB, from a file or from
+        /// stdin. Mutually exclusive with --task.
         #[arg(long = "task-file", value_name = "PATH")]
         task_file: Option<String>,
         /// Signal that the entire orchestration is complete (orchestrator only)
@@ -526,6 +533,14 @@ enum ConfigAction {
 /// command-substitute the backticks before we ever run). `--task-file -` reads
 /// stdin instead. clap's `conflicts_with` already rejects passing *both*; this
 /// function rejects passing *neither* and surfaces file/stdin read errors.
+///
+/// Both reads are size-bounded at
+/// [`MAX_TASK_BYTES`](dot_agent_deck::bounded_read::MAX_TASK_BYTES) and
+/// refused — never
+/// truncated — past it, and the path branch additionally requires a **regular
+/// file** (issue #328): a FIFO with no writer would otherwise block the CLI
+/// forever inside `open`, and a character device such as `/dev/zero` never
+/// ends. See [`read_task_input`].
 fn resolve_task(
     task: Option<String>,
     task_file: Option<String>,
@@ -533,7 +548,7 @@ fn resolve_task(
 ) -> Result<String, String> {
     match (task, task_file) {
         (Some(t), None) => Ok(t),
-        (None, Some(path)) => read_task_file(&path, stdin),
+        (None, Some(path)) => read_task_input(&path, stdin),
         // clap `conflicts_with` normally prevents this; kept as a defensive
         // guard so the invariant holds even if the two are ever resolved
         // outside clap parsing.
@@ -544,18 +559,6 @@ fn resolve_task(
             "provide the task via --task <text> or --task-file <path> (use `-` for stdin)"
                 .to_string(),
         ),
-    }
-}
-
-/// Read task text verbatim from `path`, or from `stdin` when `path` is `-`.
-fn read_task_file(path: &str, mut stdin: impl std::io::Read) -> Result<String, String> {
-    if path == "-" {
-        let mut buf = String::new();
-        std::io::Read::read_to_string(&mut stdin, &mut buf)
-            .map_err(|e| format!("failed to read task from stdin: {e}"))?;
-        Ok(buf)
-    } else {
-        std::fs::read_to_string(path).map_err(|e| format!("failed to read task file '{path}': {e}"))
     }
 }
 
@@ -2166,6 +2169,7 @@ async fn run_schedule_cli(action: ScheduleAction) -> ExitCode {
 mod tests {
     use super::*;
     use clap::Parser;
+    use dot_agent_deck::bounded_read::MAX_TASK_BYTES;
 
     // --- PRD #220: the dispatch shape selector's parsing ---
 
@@ -2424,6 +2428,79 @@ mod tests {
         assert!(
             err.contains("failed to read task file") && err.contains("/no/such/task-file.txt"),
             "missing-file error should name the path: {err}"
+        );
+    }
+
+    // ---- Issue #328: both reads are bounded, and a non-regular path is
+    // refused rather than opened. The per-shape refusals (FIFO, symlink to a
+    // FIFO, character device, endless stream) are unit-tested against the
+    // helper in `dot_agent_deck::bounded_read`; what these pin is that
+    // `resolve_task` — the seam every `delegate` / `work-done` call goes
+    // through — actually routes into it.
+
+    #[test]
+    fn task_file_over_the_size_limit_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("huge-task.md");
+        std::fs::write(&path, "x".repeat(MAX_TASK_BYTES as usize + 1)).expect("write");
+
+        let err = resolve_task(
+            None,
+            Some(path.to_str().unwrap().to_string()),
+            std::io::empty(),
+        )
+        .expect_err("a task file over the cap must be refused");
+        assert!(
+            err.contains("exceeds the") && err.contains("limit"),
+            "over-limit error should state the cap: {err}"
+        );
+    }
+
+    #[test]
+    fn task_file_at_the_size_limit_is_still_accepted() {
+        // The cap refuses only what is genuinely past it — an input sitting
+        // exactly on the boundary is a legitimate task, not a pathological one.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("big-task.md");
+        let text = "x".repeat(MAX_TASK_BYTES as usize);
+        std::fs::write(&path, &text).expect("write");
+
+        let got = resolve_task(
+            None,
+            Some(path.to_str().unwrap().to_string()),
+            std::io::empty(),
+        )
+        .expect("a task file exactly at the cap must be accepted");
+        assert_eq!(got.len(), MAX_TASK_BYTES as usize);
+    }
+
+    #[test]
+    fn stdin_over_the_size_limit_is_refused() {
+        // `-` keeps working (see `task_file_dash_reads_task_verbatim_from_stdin`),
+        // but the same cap applies to it.
+        let oversized = "x".repeat(MAX_TASK_BYTES as usize + 1);
+        let err = resolve_task(None, Some("-".to_string()), oversized.as_bytes())
+            .expect_err("oversized stdin must be refused");
+        assert!(
+            err.contains("task from stdin") && err.contains("exceeds the"),
+            "over-limit stdin error should name stdin and the cap: {err}"
+        );
+    }
+
+    #[test]
+    fn task_file_pointing_at_a_non_regular_file_is_refused() {
+        // A directory is the portable stand-in for the whole class; the FIFO
+        // and character-device cases live in the `bounded_read` unit tests.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = resolve_task(
+            None,
+            Some(dir.path().to_str().unwrap().to_string()),
+            std::io::empty(),
+        )
+        .expect_err("a non-regular --task-file target must be refused");
+        assert!(
+            err.contains("--task-file needs a regular file") && err.contains("--task-file -"),
+            "refusal should say what is required and point at the stdin alternative: {err}"
         );
     }
 


### PR DESCRIPTION
Closes #328.

## The defects

`resolve_task` in `src/main.rs` read the task text with unbounded `read_to_string` on both branches and never checked what the path pointed at. Two distinct defects, both fixed here:

1. **No size bound**, on either input. A huge or endlessly-growing file was read into memory until the process died.
2. **No file-type check**, so a FIFO or a device node was opened and read. A FIFO with no writer blocked the command **forever** — and the block happened *inside `open`*, before anything got a chance to look at the target — while `/dev/zero` never stopped producing bytes.

This matters more than its size suggests: the delegation protocol the deck writes into every orchestrator's context (`src/orchestrator_context.rs`) tells it to prefer `--task-file` over `--task`, precisely because inline task text is at the mercy of the caller's shell. So this is the input path the dispatch and delegation flows are actively told to use, and it was the one without bounds. All three commands that take it — `delegate`, `work-done`, `dispatch` — go through `resolve_task`.

## The fix

A new `src/bounded_read.rs` holds a general primitive and the one policy built on it:

- **`read_capped(reader, max_bytes, source)`** — reads at `max_bytes + 1`, so input exactly at the limit is accepted while anything past it is *detected without being read*. Refused, never silently truncated.
- **`read_task_input(path, stdin)`** — the `--task-file` policy. `-` keeps no file-type requirement (stdin is a pipe or a terminal by design; the cap is the whole of its protection); a path must be a regular file.

Two properties of the path branch worth calling out:

- **Opened once, judged from the open handle.** The type check reads `File::metadata` — an `fstat` on the descriptor already held — not a second `std::fs::metadata` on the path, so the thing checked and the thing read cannot differ. This is what the issue asked for.
- **The open cannot hang.** On Unix the handle is opened `O_NONBLOCK`. Without it the FIFO hang happens *inside `open`* and no later check can help; the flag is ignored for regular files, the only kind that survives the check.

Symlinks are still followed (no `O_NOFOLLOW`) — reaching a task file through a symlink is ordinary, and since the check applies to the resolved target, a symlink pointing at a FIFO or `/dev/zero` is refused just the same. The issue listed no-follow as a "consider"; it would break a legitimate case to close one already covered.

### Why 1 MiB

Deliberately chosen so no legitimate task can reach it while pathological input still gets refused. A task is prose destined for an agent's prompt: this repository's largest PRD is ~117 KiB and a task file is a task *description*, not a whole PRD; and 1 MiB of prose is roughly 250k tokens, past the context window of the agent the text is being written for. Anything above that is pathological rather than long.

**Reuse checked first**, per the dispatch brief: `src/config.rs::load_features_file` already applies exactly this shape (regular-file check, size cap, `take()`-bounded read) for `.dot-agent-deck.toml`, but inline and with different failure semantics — a bad features file keeps the previous value and warns, it does not error. There was no reusable helper or shared constant to adopt, so this adds the first one rather than a second inline copy. `MAX_FEATURES_CONFIG_BYTES` (64 KiB) is a config-file policy and deliberately stays separate from `MAX_TASK_BYTES`.

## One deliberate behaviour change

`--task-file <(some-command)` — bash process substitution — passes a `/dev/fd/N` **pipe**, not a regular file, so it is now refused. The issue flagged this exact risk. The refusal names the working alternative, and stdin has no file-type requirement:

```
$ dot-agent-deck delegate --to coder --task-file <(generate-task)
Error: task file '/dev/fd/63' is a FIFO; --task-file needs a regular file (for a pipe, a
process substitution, or a terminal, pipe the text in and pass `--task-file -` instead)

$ generate-task | dot-agent-deck delegate --to coder --task-file -      # works
```

`-` and ordinary stdin keep working unchanged, and are covered by tests on both sides of the boundary.

## Rule 12 — cross-version contract: **the TUI↔daemon contract did not change**

Neither structurally nor semantically, so no `PROTOCOL_VERSION` bump and no `.breaking.md` fragment.

- **Structurally**: nothing under `src/daemon.rs`, `src/daemon_protocol.rs` or `src/event.rs` is touched. The diff is entirely upstream of serialization — `resolve_task` either produces the same `String` it produced before, or refuses before any message is constructed.
- **Semantically** (the same-wire/different-meaning case): no field's meaning shifts. The set of messages a new CLI can emit is a strict *subset* of what an old one could — same shapes, fewer accepted inputs.

Verified rather than asserted, in a sandbox with its own sockets, `HOME`, state dir **and `DOT_AGENT_DECK_LOG`** (rule 12's log-isolation point), against the real **v0.37.2** release binary:

1. **Wire bytes are identical.** Captured the `delegate` line from the v0.37.2 CLI and from this branch's CLI for the same `--task-file`, over a stub socket. Byte-identical modulo the timestamp:
   `{"message_type":"delegate","pane_id":"xver-pane","task":"Fix `compute()` in \"src/lib.rs\" for $USER\nsecond 'line' with $HOME & a \\ backslash\n","to":["coder"],"timestamp":…}`
2. **New CLI → v0.37.2 daemon.** Started a v0.37.2 daemon and ran this branch's `delegate --task-file <file>`, `delegate --task-file -`, and `work-done --task-file <file>` against it. The old daemon received, parsed and answered all three (`Received delegate signal pane_id=xver-pane targets=["coder"]`, `Received work-done signal`); the only rejection is its own expected `unknown pane` — there is no orchestration in the sandbox — not a parse or protocol failure. A CLI-side refusal (FIFO) never reaches the daemon at all.

**What I did not run**, stated rather than glossed: the full variant of rule 12's manual test — a TUI attached to the old daemon with a live agent under it, routing a delegate into a worker pane and receiving hooks back. What that adds over the above is the *routed* half, and the branch's own `cargo test-e2e` covers it (`e2e_dispatcher_mode`, `e2e_orchestration_route_isolation`, `idle_worker_detector`, `delegate_prompt_injection`). Given the wire is byte-identical, cross-version routing cannot differ from same-version routing here.

## Rule 4 — test tiers

**No TUI harness work needed.** The only new user-visible surface is a CLI error on stderr, printed by the `delegate` / `work-done` / `dispatch` arms before anything reaches the daemon — no pane, status, layout or hook behaviour changes, so neither an L1 snapshot nor an L2 PTY test applies. Coverage is unit tests in the fast tier, at both levels:

- `src/bounded_read.rs` — one per refusal path: at-the-limit accepted, one-byte-over refused, an endless reader refused, oversized file, missing file, directory, **FIFO**, **symlink to a FIFO**, and `/dev/zero`. The three that guard a *hang* run under a 5s watchdog thread, so a regression fails the tier instead of wedging it.
- `src/main.rs` — four at the `resolve_task` seam every command actually calls, proving it routes into the bounded reader: oversized file, exactly-at-the-cap accepted, oversized stdin, non-regular target.

**The tests were confirmed to fail against the old behaviour.** Reverting `read_task_file` to `std::fs::read_to_string` and rerunning: the FIFO and symlink-to-FIFO cases time out at 5s (the real hang), `/dev/zero` allocates until the watchdog fires, and the directory and oversized cases fail on the missing refusal — 5 of 10 red. Restored, all 10 pass.

## Rule 3 — naming

The new file is `src/bounded_read.rs`, named for what it contains. No issue or milestone number in the filename.

## Related: #319

#319 (hook ingestion has no line-length or connection bound) is the **daemon's** hook socket and stays untouched here — a different code path and a different unit, as the brief asked.

Since it comes up: it **cannot use `read_capped` directly**. That path is `tokio::io::BufReader::lines().next_line().await` over an accepted socket — async, line-oriented, and a socket is never a regular file, so neither `read_capped`'s `std::io::Read` signature nor `read_task_input`'s file-type check applies. What does transfer is the *policy*: cap, then refuse rather than truncate or buffer. Its async equivalent is an `AsyncBufReadExt::take`-bounded read per line (plus the connection cap #319 also asks for), which is a genuinely separate implementation.

## Gates

- `cargo fmt --check` — clean.
- `cargo clippy --workspace --all-targets --features e2e -- -D warnings` — clean.
- `cargo test-fast` — 3077/3077 pass.
- `cargo test-e2e` — green on this change; **reported honestly** rather than as a clean sweep. Two full runs: 8801/8802 and 8800/8802. Every failure was a **real-agent live test** (`devin_live_001_real_interactive_turn_drives_the_card_live`, `card_stats_005_real_agent_card_narrows_without_restructuring`), and each passes on an isolated rerun per rule 6 — 13.5s and 25.1s alone against 51s and 53s under a saturated box, i.e. timeout flakes in the tier rule 5 calls flaky-tolerant and keeps out of CI. Neither test contains a single reference to `--task-file` (grep: 0 matches in both files), and neither exercises `resolve_task`. Nothing else in the tier failed in either run.
- Changelog fragment: `changelog.d/328.bugfix.md`. Classified `bugfix` (patch bump), not `breaking` — per `pyproject.toml`, `breaking` is the cross-process compatibility axis specifically, and this project's definition excludes generic user-facing breakage; the process-substitution change above is the latter, and it is called out prominently in the fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8hfzaW7kQBhG22u6HSx67
