### PR TITLE
fix(demo-reel-adapter): name the real reason a reel was skipped

### DIFF
--- a/.claude/skills/demo-reel-adapter/SKILL.md
+++ b/.claude/skills/demo-reel-adapter/SKILL.md
@@ -23,10 +23,10 @@ Everything dot-agent-deck-specific (which tests, where their title/description l
 
 | Command | What it does |
 | --- | --- |
-| `build.sh [reel] [--out OUT.mp4] [--publish] [--manifest PATH] [--title TITLE]` | Full pipeline: **select** → **assemble** → invoke the engine, forwarding `--out`/`--publish` plus a composed `--title`. Clean-skips (no manifest, no engine, exit 0) when no e2e tests changed. `--manifest` sets where `manifest.json` is written (default `manifest.json` in CWD). `--title` overrides the composed title verbatim (see **Title composition**). |
+| `build.sh [reel] [--out OUT.mp4] [--publish] [--manifest PATH] [--title TITLE]` | Full pipeline: **select** → **assemble** → invoke the engine, forwarding `--out`/`--publish` plus a composed `--title`. Clean-skips (no manifest, no engine, exit 0) when no e2e tests changed — and just as cleanly, but with a **different message naming the tests**, when e2e tests *did* change and none is `[reel]`-marked (see **Which clean skip you got**). `--manifest` sets where `manifest.json` is written (default `manifest.json` in CWD). `--title` overrides the composed title verbatim (see **Title composition**). |
 | `build.sh title [--title TITLE]` | Print the title the `reel` pipeline would pass to the engine on the current branch — the composed title, or `--title` verbatim. Dry-run: no selection, no manifest, no engine, no upload. |
 | `build.sh select` | Print the in-scope recording-dir IDs, one per line (the git-diff half — concern **a**). |
-| `build.sh assemble [ID...] [--manifest PATH]` | Build `manifest.json` from an explicit list of recording-dir IDs (the pure half — concern **b**; no git, no network). Excludes cast-less IDs **and** IDs whose catalog entry lacks the ` [reel]` marker, orders by catalog id, clean-skips an empty/all-ineligible list. |
+| `build.sh assemble [ID...] [--manifest PATH]` | Build `manifest.json` from an explicit list of recording-dir IDs (the pure half — concern **b**; no git, no network). Excludes cast-less IDs **and** IDs whose catalog entry lacks the ` [reel]` marker, orders by catalog id, clean-skips an empty/all-ineligible list — naming any ID it dropped for a missing marker. |
 
 Run the full `reel` pipeline from the repo root so the default relative paths (`.dot-agent-deck/recordings`, `tests/CATALOG.md`) resolve. The engine resolves `clip` paths relative to its own CWD, so it is invoked from the same directory.
 
@@ -64,7 +64,12 @@ Composition degrades gracefully — a missing repo/PRD/PR drops only its own seg
    [Reel-eligibility marker](#reel-eligibility-marker-real-user-facing-usage-only)
    below). Eligibility is **opt-in**: a cast alone means the test is PTY-attached,
    not that it belongs in the reel, so an unmarked test is excluded even with a
-   cast and a changed source.
+   cast and a changed source. This gate is evaluated **last** even though it is
+   listed second: the three conditions are ANDed, so order cannot change *which*
+   dirs are selected, but checking the marker last means its `excluding '<id>' …
+   has no [reel] marker` diagnostic fires only for a dir that would otherwise
+   have been selected — a genuine near-miss — rather than for every unmarked
+   recording on disk.
 3. **Its source file changed on this branch vs `origin/main`.** Each `test.md`
    carries a `**Source:** `<dir>/<file>::<fn>`` line. The file is matched **by
    basename** against `git diff --name-only origin/main` restricted to `*.rs`.
@@ -139,11 +144,20 @@ Pick the grid for what the scenario needs to show, then keep the ratio near 4:1.
   smuggle an unmarked test in).
 - Entries are **ordered by catalog id's line position in `CATALOG.md`** (the
   authoritative order); an id absent from the catalog sorts last.
-- **Clean skip:** if no ID resolves to a reel-eligible e2e clip, it prints
-  `skipped: no e2e tests changed on this branch`, writes **no** manifest, and
-  exits 0.
+- **Clean skip:** if no ID resolves to a reel-eligible e2e clip it writes **no** manifest and exits 0, printing either the plain `skipped: no e2e tests changed on this branch` or, when an ID was dropped for a missing marker, the eligibility message that names it (see **Which clean skip you got**).
 
-Splitting selection (a) from assembly (b) is deliberate: (b) is fully deterministic and fixture-testable without git or the network, which is what the acceptance test below exercises.
+Splitting selection (a) from assembly (b) is deliberate: (b) is fully deterministic and fixture-testable without git or the network, which is what most of the acceptance test below exercises.
+
+## Which clean skip you got
+
+Both skips are identical in behaviour — no manifest, no engine, **exit 0** — and that is deliberate: a reel is not owed on every branch, so the pre-merge reel step must not fail an ordinary PR. Only the **wording** differs, and it has to, because the two causes call for opposite responses (issue #735):
+
+| Printed | Cause | What to do |
+| --- | --- | --- |
+| `skipped: no e2e tests changed on this branch` | Nothing was in scope at all — no changed e2e test with a cast. | Nothing. A reel was never possible on this branch. (If you expected one, check that the e2e suite ran with `DOT_AGENT_DECK_RECORD=1` so the casts exist.) |
+| `skipped: N e2e test(s) …, but none is reel-eligible — no [reel] marker in tests/CATALOG.md for: <ids>` | e2e tests **did** change and have casts; they were dropped by the opt-in marker gate alone. | Read the named ids. Usually **nothing** — an unmarked test is unmarked on purpose. Add the marker only if that test genuinely spins up a **real agent** and shows the feature as a user runs it; a stand-in stays unmarked. |
+
+The second message names the ids because that is what makes it actionable, and because the older generic wording pointed at the wrong gate: a reader who saw "no e2e tests changed" on a branch that *had* changed e2e tests would go debugging the git-diff selection, which was working correctly. The inverse hazard is worth naming too — a message claiming nothing changed invites someone to reach for a ` [reel]` marker to make a reel appear, when the absent marker was the deliberate, correct answer.
 
 ## Environment overrides
 
@@ -164,8 +178,17 @@ A **re-runnable, pure-shell** test (no `agg`/`ffmpeg`, no git, no network — so
    titles/descriptions/clip paths **in catalog order** (`beta`=001 before
    `alpha`=002), **excludes** the cast-less L1 `gamma`, and **excludes** the
    cast-bearing but unmarked `delta`;
-2. given an empty list, it **clean-skips** — no manifest, exit 0, skip message —
-   and likewise for an L1-only list and for an unmarked-cast-only list.
+2. given an empty list — and likewise an L1-only list — it **clean-skips** with
+   the `no e2e tests changed` message, while an **unmarked-cast-only** list
+   clean-skips with the **eligibility** message naming `delta`, so the two
+   wordings cannot drift back into one;
+3. on the **`reel`** path, a branch that changed only the *unmarked* test's
+   source skips with that eligibility message (never `no e2e tests changed` —
+   the issue #735 defect) and still writes no manifest and invokes no engine,
+   while a branch that changed a **marked** test's source selects, assembles and
+   invokes the engine (a stub) with no near-miss reported.
+
+Sections 1–2 are pure shell. Section 3 exercises the selection half, which exists to run `git diff`, so it shells out to **git** — building every repository inside its own `mktemp -d` with the ambient git configuration switched off, so it can neither read nor write the checkout it runs in, and with no network and no sleep (the same discipline CLAUDE.md rule 5 sets for the `xtask` real-git tests). It **skips**, without failing, where `git` is unavailable.
 
 ```sh
 task reel-adapter-test

--- a/.claude/skills/demo-reel-adapter/SKILL.md
+++ b/.claude/skills/demo-reel-adapter/SKILL.md
@@ -64,12 +64,8 @@ Composition degrades gracefully — a missing repo/PRD/PR drops only its own seg
    [Reel-eligibility marker](#reel-eligibility-marker-real-user-facing-usage-only)
    below). Eligibility is **opt-in**: a cast alone means the test is PTY-attached,
    not that it belongs in the reel, so an unmarked test is excluded even with a
-   cast and a changed source. This gate is evaluated **last** even though it is
-   listed second: the three conditions are ANDed, so order cannot change *which*
-   dirs are selected, but checking the marker last means its `excluding '<id>' …
-   has no [reel] marker` diagnostic fires only for a dir that would otherwise
-   have been selected — a genuine near-miss — rather than for every unmarked
-   recording on disk.
+   cast and a changed source.
+   This gate is evaluated **last** even though it is listed second: the three conditions are ANDed, so order cannot change *which* dirs are selected, but checking the marker last means its `excluding '<id>' … has no [reel] marker` diagnostic fires only for a dir that would otherwise have been selected — a genuine near-miss — rather than for every unmarked recording on disk.
 3. **Its source file changed on this branch vs `origin/main`.** Each `test.md`
    carries a `**Source:** `<dir>/<file>::<fn>`` line. The file is matched **by
    basename** against `git diff --name-only origin/main` restricted to `*.rs`.
@@ -157,6 +153,8 @@ Both skips are identical in behaviour — no manifest, no engine, **exit 0** —
 | `skipped: no e2e tests changed on this branch` | Nothing was in scope at all — no changed e2e test with a cast. | Nothing. A reel was never possible on this branch. (If you expected one, check that the e2e suite ran with `DOT_AGENT_DECK_RECORD=1` so the casts exist.) |
 | `skipped: N e2e test(s) …, but none is reel-eligible — no [reel] marker in tests/CATALOG.md for: <ids>` | e2e tests **did** change and have casts; they were dropped by the opt-in marker gate alone. | Read the named ids. Usually **nothing** — an unmarked test is unmarked on purpose. Add the marker only if that test genuinely spins up a **real agent** and shows the feature as a user runs it; a stand-in stays unmarked. |
 
+A hand-written id list can trip **both** gates at once — one id with no cast, another with a cast but no marker — and then the second message carries an extra parenthetical naming the cast-less ids separately, because "none is reel-eligible" is not the reason those were dropped and adding a marker to them would change nothing. Only the standalone `build.sh assemble <id...>` reaches this: the `reel` pipeline's `select` half drops cast-less dirs before `assemble` ever sees them, so its skips always have a single cause.
+
 The second message names the ids because that is what makes it actionable, and because the older generic wording pointed at the wrong gate: a reader who saw "no e2e tests changed" on a branch that *had* changed e2e tests would go debugging the git-diff selection, which was working correctly. The inverse hazard is worth naming too — a message claiming nothing changed invites someone to reach for a ` [reel]` marker to make a reel appear, when the absent marker was the deliberate, correct answer.
 
 ## Environment overrides
@@ -181,7 +179,8 @@ A **re-runnable, pure-shell** test (no `agg`/`ffmpeg`, no git, no network — so
 2. given an empty list — and likewise an L1-only list — it **clean-skips** with
    the `no e2e tests changed` message, while an **unmarked-cast-only** list
    clean-skips with the **eligibility** message naming `delta`, so the two
-   wordings cannot drift back into one;
+   wordings cannot drift back into one — and a **mixed** `gamma delta` list names
+   **both** reasons rather than attributing the whole skip to the marker;
 3. on the **`reel`** path, a branch that changed only the *unmarked* test's
    source skips with that eligibility message (never `no e2e tests changed` —
    the issue #735 defect) and still writes no manifest and invokes no engine,

--- a/.claude/skills/demo-reel-adapter/build.sh
+++ b/.claude/skills/demo-reel-adapter/build.sh
@@ -89,17 +89,53 @@ die() { echo "demo-reel-adapter: $*" >&2; exit 1; }
 #     wording sent readers to debug the diff gate, which was working fine.
 # Composed in ONE place, called from both paths, so the two messages cannot drift
 # back into saying the same wrong thing.
-#   usage: skip_message <scope-phrase> [ineligible-id...]
+#
+# Exclusions arrive as TWO buckets separated by a literal `--`, because a list can
+# lose ids to either gate and the composed reason has to survive BOTH firing at
+# once (PR #778 review). An id is never `--` itself — ids are single recording-dir
+# names, and `assemble` rejects `/` and `..` before this is ever called.
+#   usage: skip_message <scope-phrase> [cast-less-id...] -- [unmarked-id...]
 skip_message() {
   local scope="$1"; shift
-  if [[ $# -eq 0 ]]; then
+  # Declared one per line: macOS ships /bin/bash 3.2.57 and this file already
+  # carries one bash-3.2 scar (issue #593's `mapfile`), so array declarations
+  # stay in the single-target form the rest of the script uses.
+  local cast_less=()
+  local unmarked=()
+  local past_sep="" arg
+  for arg in "$@"; do
+    if [[ -z "$past_sep" && "$arg" == "--" ]]; then past_sep=1; continue; fi
+    if [[ -n "$past_sep" ]]; then unmarked+=("$arg"); else cast_less+=("$arg"); fi
+  done
+
+  # Nothing was dropped for a missing marker, so the scope gate really is the
+  # whole story. A cast-less-ONLY list lands here deliberately: "no e2e tests
+  # changed" is literally true of a list that contains no e2e test (a dir with no
+  # cast is an L1 render test, not a clip candidate), and each such id has already
+  # had its own naming diagnostic on stderr mid-loop.
+  if [[ ${#unmarked[@]} -eq 0 ]]; then
     printf '%s\n' "$SKIP_MSG"
     return 0
   fi
-  local list="" id
-  for id in "$@"; do list="${list:+$list, }$id"; done
-  printf '%s\n' "skipped: $# e2e test(s) $scope, but none is reel-eligible — no [reel] marker in $CATALOG_FILE for: $list"
+
+  printf '%s\n' "skipped: ${#unmarked[@]} e2e test(s) $scope, but none is reel-eligible — no [reel] marker in $CATALOG_FILE for: $(join_ids "${unmarked[@]}")"
+  # The marker is not the whole reason when the same list ALSO lost ids before
+  # they ever reached the marker gate: saying only "none is reel-eligible" would
+  # scope that verdict over the cast-less ones too and send a reader to add a
+  # marker that would change nothing. This PR exists because a skip named the
+  # wrong reason — so name both when both apply.
+  if [[ ${#cast_less[@]} -gt 0 ]]; then
+    printf '%s\n' "  (a further ${#cast_less[@]} id(s) in the same list were dropped EARLIER, for an unrelated reason — no full-stream.cast, so not an e2e clip at all and no [reel] marker would help: $(join_ids "${cast_less[@]}"))"
+  fi
   printf '%s\n' "  ([reel] is OPT-IN and its absence is usually the right answer: a clip exists so a human can watch REAL behavior, so only a test that genuinely spins up a real agent is marked — a stand-in (cat, scripted echo, recorder stubs, synthesized hook events) stays unmarked and never becomes a clip. See CLAUDE.md rule 4.)"
+}
+
+# Render an id list for a human: "a, b, c". Used for both of skip_message's
+# buckets, so the two read identically.
+join_ids() {
+  local out="" id
+  for id in "$@"; do out="${out:+$out, }$id"; done
+  printf '%s' "$out"
 }
 
 usage() {
@@ -124,7 +160,9 @@ Usage:
       network). Excludes any ID without a full-stream.cast, or whose catalog id
       lacks the trailing [reel] eligibility marker; orders by catalog id.
       Clean-skips when no ID resolves to a reel-eligible e2e clip, naming any ID
-      dropped for a missing [reel] marker.
+      dropped for a missing [reel] marker — and, when the list also lost IDs for
+      having no cast, naming those separately rather than blaming the marker for
+      the whole skip.
 
 Environment overrides:
   REEL_ADAPTER_RECORDINGS_DIR  (default: .dot-agent-deck/recordings)
@@ -230,8 +268,15 @@ assemble() {
   local manifest="$1"; shift
   local rows id md cast title catid desc ord obj title_dec desc_dec
   # Ids dropped for a missing ` [reel]` marker, so the clean-skip below can name
-  # the real reason instead of blaming the diff (issue #735).
+  # the real reason instead of blaming the diff (issue #735) — and, separately,
+  # the ids dropped for having no cast at all. BOTH buckets are tracked because a
+  # hand-written id list can populate both at once, and a skip that named only
+  # the marker bucket would scope "none is reel-eligible" over cast-less ids too
+  # (PR #778 review). `reel` never mixes them — `select_ids` filters cast-less
+  # dirs out before `assemble` is called — but the standalone
+  # `build.sh assemble <id...>` subcommand takes raw ids with no such filtering.
   local ineligible=()
+  local cast_less=()
   rows="$(mktemp)"
   # The rows scratch file is removed on the normal exit paths below, but a
   # validation `die` can abort mid-loop — so also clean it up on any exit
@@ -250,6 +295,7 @@ assemble() {
     md="$RECORDINGS_DIR/$id/test.md"
     if [[ ! -f "$cast" ]]; then
       echo "demo-reel-adapter: excluding '$id' (no full-stream.cast — not an e2e clip)" >&2
+      cast_less+=("$id")
       continue
     fi
     [[ -f "$md" ]] || die "missing test.md for '$id': $md"
@@ -277,7 +323,8 @@ assemble() {
 
   if [[ ! -s "$rows" ]]; then
     rm -f "$rows"
-    skip_message "in the given list" ${ineligible[@]+"${ineligible[@]}"}
+    skip_message "in the given list" \
+      ${cast_less[@]+"${cast_less[@]}"} -- ${ineligible[@]+"${ineligible[@]}"}
     return 0
   fi
 
@@ -456,7 +503,10 @@ case "$cmd" in
       # Still a CLEAN skip — no manifest, no engine, exit 0. Only the wording
       # changes: an empty `ineligible` means nothing was in scope at all, a
       # non-empty one means tests changed but are deliberately not reel-eligible.
-      skip_message "changed on this branch" ${ineligible[@]+"${ineligible[@]}"}
+      # The cast-less bucket is EMPTY here and always will be: `select_ids`'s gate
+      # (1) drops cast-less dirs itself, so this path never sees one. The `--`
+      # still leads, so both call sites pass the same two-bucket shape.
+      skip_message "changed on this branch" -- ${ineligible[@]+"${ineligible[@]}"}
       exit 0
     fi
     rm -f "$manifest"

--- a/.claude/skills/demo-reel-adapter/build.sh
+++ b/.claude/skills/demo-reel-adapter/build.sh
@@ -19,7 +19,9 @@
 #       `build.sh assemble [ID...] [--manifest PATH]`
 #
 #   reel (default) — run (a), then (b), then invoke the engine forwarding
-#       --out/--publish. Clean-skips when nothing is in scope.
+#       --out/--publish. Clean-skips when nothing is in scope, naming WHICH of
+#       the two causes it hit: nothing changed, or things changed but carry no
+#       ` [reel]` marker (issue #735 — the two call for opposite responses).
 #
 # Selection rule (file-level granularity, robustness over cleverness):
 #   A recording dir `<RECORDINGS_DIR>/<id>/` is IN SCOPE iff
@@ -66,14 +68,48 @@ ENGINE="${REEL_ADAPTER_ENGINE:-$SCRIPT_DIR/../demo-reel/reel.sh}"
 
 SKIP_MSG="skipped: no e2e tests changed on this branch"
 
+# Where `select_ids` records the ids it dropped for a MISSING ` [reel]` marker —
+# the near-misses that cleared every other gate (they have a cast, and their
+# source changed on this branch), so they are exactly what a reader would
+# otherwise go hunting for. A FILE rather than a variable because `reel` reads
+# `select_ids` through a process substitution, which runs it in a subshell whose
+# variables never make it back. Empty (the default, and what `build.sh select`
+# uses) means "record nothing".
+INELIGIBLE_LOG=""
+
 die() { echo "demo-reel-adapter: $*" >&2; exit 1; }
+
+# The clean-skip line. BOTH skip paths write no manifest, invoke no engine and
+# exit 0 — only the WORDING differs, and it must, because the two causes call for
+# opposite responses (issue #735):
+#   * nothing in scope at all      -> a reel was never possible; nothing to do.
+#   * in scope but not [reel]-marked -> a deliberate opt-out is in force, and the
+#     reader may want to know WHICH tests and whether the marker is rightly
+#     absent. Naming the ids is what makes that case actionable; the old generic
+#     wording sent readers to debug the diff gate, which was working fine.
+# Composed in ONE place, called from both paths, so the two messages cannot drift
+# back into saying the same wrong thing.
+#   usage: skip_message <scope-phrase> [ineligible-id...]
+skip_message() {
+  local scope="$1"; shift
+  if [[ $# -eq 0 ]]; then
+    printf '%s\n' "$SKIP_MSG"
+    return 0
+  fi
+  local list="" id
+  for id in "$@"; do list="${list:+$list, }$id"; done
+  printf '%s\n' "skipped: $# e2e test(s) $scope, but none is reel-eligible — no [reel] marker in $CATALOG_FILE for: $list"
+  printf '%s\n' "  ([reel] is OPT-IN and its absence is usually the right answer: a clip exists so a human can watch REAL behavior, so only a test that genuinely spins up a real agent is marked — a stand-in (cat, scripted echo, recorder stubs, synthesized hook events) stays unmarked and never becomes a clip. See CLAUDE.md rule 4.)"
+}
 
 usage() {
   cat <<EOF
 Usage:
   build.sh [reel] [--out OUT.mp4] [--publish] [--manifest PATH] [--title TITLE]
       Select in-scope e2e tests, build a manifest, and invoke the engine.
-      Clean-skips (no manifest, no engine, exit 0) when no e2e tests changed.
+      Clean-skips (no manifest, no engine, exit 0) when no e2e tests changed —
+      or, when e2e tests DID change but none carries the [reel] marker, skips
+      just as cleanly while naming those tests instead.
       Composes a descriptive video title ('<repo> · PRD #<prd> · PR #<pr> —
       <desc>') and forwards it to the engine; --title TITLE overrides that
       composition verbatim (for manual/dogfood runs).
@@ -87,7 +123,8 @@ Usage:
       Build manifest.json from the given recording-dir IDs (pure: no git, no
       network). Excludes any ID without a full-stream.cast, or whose catalog id
       lacks the trailing [reel] eligibility marker; orders by catalog id.
-      Clean-skips when no ID resolves to a reel-eligible e2e clip.
+      Clean-skips when no ID resolves to a reel-eligible e2e clip, naming any ID
+      dropped for a missing [reel] marker.
 
 Environment overrides:
   REEL_ADAPTER_RECORDINGS_DIR  (default: .dot-agent-deck/recordings)
@@ -192,6 +229,9 @@ catalog_reel_eligible() {
 assemble() {
   local manifest="$1"; shift
   local rows id md cast title catid desc ord obj title_dec desc_dec
+  # Ids dropped for a missing ` [reel]` marker, so the clean-skip below can name
+  # the real reason instead of blaming the diff (issue #735).
+  local ineligible=()
   rows="$(mktemp)"
   # The rows scratch file is removed on the normal exit paths below, but a
   # validation `die` can abort mid-loop — so also clean it up on any exit
@@ -223,6 +263,7 @@ assemble() {
     # id list can't smuggle an unmarked test past selection's own marker check.
     if ! catalog_reel_eligible "$catid"; then
       echo "demo-reel-adapter: excluding '$id' (catalog id '$catid' has no [reel] marker — not reel-eligible)" >&2
+      ineligible+=("$id")
       continue
     fi
     desc="$(extract_description "$md")"
@@ -236,7 +277,7 @@ assemble() {
 
   if [[ ! -s "$rows" ]]; then
     rm -f "$rows"
-    echo "$SKIP_MSG"
+    skip_message "in the given list" ${ineligible[@]+"${ineligible[@]}"}
     return 0
   fi
 
@@ -255,7 +296,7 @@ assemble() {
 # Concern (a): print the in-scope recording-dir IDs (one per line).
 # --------------------------------------------------------------------------
 select_ids() {
-  local changed base md id src
+  local changed base md id src catid
   # The default ref is `origin/main`, so refresh the remote-tracking ref first —
   # a local `main` can lag the true remote tip and over-select tests already
   # merged upstream. Best-effort: offline / no remote just falls back to whatever
@@ -273,17 +314,32 @@ select_ids() {
   base="$(git merge-base "$MAIN_REF" HEAD 2>/dev/null || true)"
   changed="$(git diff --name-only "$base" -- '*.rs' 2>/dev/null | sed -E 's#.*/##' | sort -u || true)"
   [[ -d "$RECORDINGS_DIR" ]] || return 0
+  # The three gates are ANDed, so evaluation ORDER cannot change WHICH ids are
+  # selected — but it does change which ones the marker gate gets to talk about,
+  # so the marker is checked LAST (issue #735). Checked first, it fires for every
+  # unmarked recording dir on disk (dozens), which is noise; checked last it
+  # fires only for a test that WOULD have been selected — cast on disk, source
+  # changed on this branch, marker absent. Those are the near-misses worth
+  # naming, and the ones `INELIGIBLE_LOG` hands to the caller so a clean skip can
+  # state its real reason instead of blaming the diff.
   for md in "$RECORDINGS_DIR"/*/test.md; do
     [[ -f "$md" ]] || continue
     id="$(basename "$(dirname "$md")")"
     [[ -f "$RECORDINGS_DIR/$id/full-stream.cast" ]] || continue   # (1) e2e proxy
-    catalog_reel_eligible "$(extract_catalog_id "$(extract_title "$md")")" \
-      || continue                                                 # (2) [reel] marker
     src="$(extract_source_basename "$md")"
     [[ -n "$src" ]] || continue
-    if printf '%s\n' "$changed" | grep -Fxq "$src"; then          # (3) changed vs main
-      printf '%s\n' "$id"
+    printf '%s\n' "$changed" | grep -Fxq "$src" || continue       # (3) changed vs main
+    catid="$(extract_catalog_id "$(extract_title "$md")")"
+    if ! catalog_reel_eligible "$catid"; then                     # (2) [reel] marker
+      # Same diagnostic assemble() emits, so the marker gate explains itself
+      # wherever it fires rather than only at assembly.
+      echo "demo-reel-adapter: excluding '$id' (catalog id '$catid' has no [reel] marker — not reel-eligible)" >&2
+      if [[ -n "$INELIGIBLE_LOG" ]]; then
+        printf '%s\n' "$id" >> "$INELIGIBLE_LOG"
+      fi
+      continue
     fi
+    printf '%s\n' "$id"
   done
 }
 
@@ -374,6 +430,13 @@ case "$cmd" in
     ;;
 
   reel)
+    # Give select_ids somewhere to record the ids it drops for a missing [reel]
+    # marker, so an empty selection can say WHICH of the two causes it hit
+    # (issue #735). Read and removed immediately below rather than left to the
+    # trap: this path ends in `exec`, which replaces the process without running
+    # EXIT traps, so the trap only covers a `die`/interrupt before that point.
+    INELIGIBLE_LOG="$(mktemp)"
+    trap 'rm -f "${INELIGIBLE_LOG:-}"' EXIT INT TERM
     # A read loop rather than `mapfile -t scope`, which is bash 4: macOS ships
     # /bin/bash 3.2.57, where `mapfile` is not a builtin at all and this died
     # with `mapfile: command not found` (exit 127) before selecting anything
@@ -384,8 +447,16 @@ case "$cmd" in
     while IFS= read -r id; do
       scope+=("$id")
     done < <(select_ids)
+    ineligible=()
+    while IFS= read -r id; do
+      ineligible+=("$id")
+    done < "$INELIGIBLE_LOG"
+    rm -f "$INELIGIBLE_LOG"
     if [[ ${#scope[@]} -eq 0 ]]; then
-      echo "$SKIP_MSG"
+      # Still a CLEAN skip — no manifest, no engine, exit 0. Only the wording
+      # changes: an empty `ineligible` means nothing was in scope at all, a
+      # non-empty one means tests changed but are deliberately not reel-eligible.
+      skip_message "changed on this branch" ${ineligible[@]+"${ineligible[@]}"}
       exit 0
     fi
     rm -f "$manifest"

--- a/.claude/skills/demo-reel-adapter/tests/adapter_test.sh
+++ b/.claude/skills/demo-reel-adapter/tests/adapter_test.sh
@@ -2,17 +2,33 @@
 #
 # adapter_test.sh — re-runnable acceptance for the demo-reel ADAPTER (PRD #180 M2.1).
 #
-# PURE shell: NO git, NO agg/ffmpeg, NO network — so this MAY run in CI (unlike
-# the engine smoke and the reel step itself, which are local-only). It drives the
-# adapter's deterministic concern (b) — `build.sh assemble` — against a tiny
-# fixture and asserts:
+# NO agg/ffmpeg, NO network — so this MAY run in CI (unlike the engine smoke and
+# the reel step itself, which are local-only). Sections (i)–(ii) are PURE shell
+# and drive the adapter's deterministic concern (b), `build.sh assemble`, against
+# a tiny fixture; sections (iii)–(iv) drive the `reel` path, which needs concern
+# (a) and therefore git. They assert:
 #
 #   (i)   given a list of IDs, the emitted manifest has the right
 #         titles/descriptions/clip paths IN CATALOG ORDER, EXCLUDES the cast-less
 #         L1 entry, and EXCLUDES a cast-bearing entry that is NOT reel-marked;
 #   (ii)  given an empty in-scope list, it CLEAN-SKIPS — no manifest, exit 0, and
-#         the skip message;
-#   (ii-b/c) an L1-only list AND an unmarked-cast-only list each CLEAN-SKIP too.
+#         the "nothing changed" skip message;
+#   (ii-b) an L1-only list CLEAN-SKIPS with that same message;
+#   (ii-c) an unmarked-cast-only list CLEAN-SKIPS just as cleanly but with the
+#         DIFFERENT, reel-eligibility message that NAMES the excluded id;
+#   (iii) the `reel` path on a branch that DID change an e2e test whose catalog
+#         entry is unmarked skips with that eligibility message too — never the
+#         "no e2e tests changed" one, which is the issue #735 defect;
+#   (iv)  the `reel` path on a branch that changed a MARKED test still selects,
+#         assembles and invokes the engine (a stub), and reports no near-miss.
+#
+# WHY (iii)/(iv) shell out to git: the defect in #735 lives in the SELECTION half,
+# which exists to run `git diff`, so covering it anywhere else covers something
+# else. They follow the same discipline CLAUDE.md rule 5 sets for the `xtask`
+# real-git tests — every repository is built inside the test's own `mktemp -d`
+# with the ambient git configuration switched off, so nothing can read or write
+# the checkout this runs in, and there is no network and no sleep. They SKIP
+# (without failing) where git is unavailable.
 #
 # The fixture under tests/fixtures/recordings/ has FOUR dirs:
 #   * alpha, beta — e2e dirs WITH a cast whose catalog entry carries ` [reel]`;
@@ -21,7 +37,9 @@
 #                   so excluded by the opt-in reel-eligibility marker.
 # The CATALOG.md fixture orders them 001=beta, 002=alpha, 003=gamma, 004=delta, so
 # feeding `alpha beta gamma delta` and getting back exactly `[beta, alpha]` proves
-# ordering, the L1 exclusion, AND the unmarked-cast exclusion at once.
+# ordering, the L1 exclusion, AND the unmarked-cast exclusion at once. alpha and
+# beta share one **Source:** file; delta deliberately names its OWN, so (iii) can
+# change the unmarked test's source WITHOUT changing a marked one's.
 #
 # Run via: task reel-adapter-test
 #   (or directly: .claude/skills/demo-reel-adapter/tests/adapter_test.sh)
@@ -38,6 +56,15 @@ export REEL_ADAPTER_CATALOG="$FIX/CATALOG.md"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 fail() { echo "ADAPTER TEST FAIL: $*" >&2; exit 1; }
+# `says <needle> <haystack>` — a predicate, so assertions read as `if says …` /
+# `says … || fail`, never as `grep … && fail`, whose exit status is a `set -e`
+# trap in its own right.
+says() { printf '%s\n' "$2" | grep -qF -- "$1"; }
+
+# The two skip messages must stay DISTINCT — collapsing them back into one is the
+# issue #735 regression, so every skip assertion below checks both directions.
+NOTHING_CHANGED="skipped: no e2e tests changed on this branch"
+NOT_ELIGIBLE="but none is reel-eligible"
 
 # --- (i) assemble alpha beta gamma delta -> [beta(001), alpha(002)];
 #         gamma excluded (no cast), delta excluded (cast but NOT [reel]-marked) --
@@ -79,26 +106,129 @@ echo "PASS (i): 2 entries in catalog order (beta, alpha); L1 gamma AND unmarked 
 MAN2="$TMP/skip.json"
 out="$("$BUILD" assemble --manifest "$MAN2")"
 [[ ! -e "$MAN2" ]] || fail "(ii) manifest must NOT be written on a clean skip"
-printf '%s\n' "$out" | grep -qF "skipped: no e2e tests changed on this branch" \
-  || fail "(ii) missing skip message; got: '$out'"
-echo "PASS (ii): empty list clean-skips (no manifest, exit 0, skip message)"
+says "$NOTHING_CHANGED" "$out" || fail "(ii) missing skip message; got: '$out'"
+if says "$NOT_ELIGIBLE" "$out"; then
+  fail "(ii) nothing was excluded for a missing marker, so the eligibility message must NOT appear; got: '$out'"
+fi
+echo "PASS (ii): empty list clean-skips (no manifest, exit 0, 'nothing changed' message)"
 
 # --- (ii-b) a list of only L1 (cast-less) ids also clean-skips ------------------
 MAN3="$TMP/skip2.json"
 out3="$("$BUILD" assemble --manifest "$MAN3" gamma)"
 [[ ! -e "$MAN3" ]] || fail "(ii-b) manifest must NOT be written when only L1 ids are given"
-printf '%s\n' "$out3" | grep -qF "skipped: no e2e tests changed on this branch" \
-  || fail "(ii-b) missing skip message for L1-only list; got: '$out3'"
-echo "PASS (ii-b): L1-only list clean-skips"
+says "$NOTHING_CHANGED" "$out3" || fail "(ii-b) missing skip message for L1-only list; got: '$out3'"
+if says "$NOT_ELIGIBLE" "$out3"; then
+  fail "(ii-b) gamma was dropped for having no cast, not for the marker — the eligibility message must NOT appear; got: '$out3'"
+fi
+echo "PASS (ii-b): L1-only list clean-skips with the 'nothing changed' message"
 
-# --- (ii-c) a list of only UNMARKED cast-bearing ids also clean-skips -----------
+# --- (ii-c) only UNMARKED cast-bearing ids -> clean skip, ELIGIBILITY message ---
 # delta has a full-stream.cast but its catalog entry lacks the ` [reel]` marker,
-# so an all-unmarked list resolves to zero reel-eligible clips and clean-skips.
+# so an all-unmarked list resolves to zero reel-eligible clips. It must still
+# clean-skip (no manifest, exit 0) — but say WHY, naming delta, rather than claim
+# nothing changed (issue #735).
 MAN4="$TMP/skip3.json"
-out4="$("$BUILD" assemble --manifest "$MAN4" delta)"
+out4="$("$BUILD" assemble --manifest "$MAN4" delta 2>/dev/null)"
 [[ ! -e "$MAN4" ]] || fail "(ii-c) manifest must NOT be written when only unmarked cast ids are given"
-printf '%s\n' "$out4" | grep -qF "skipped: no e2e tests changed on this branch" \
-  || fail "(ii-c) missing skip message for unmarked-cast-only list; got: '$out4'"
-echo "PASS (ii-c): unmarked-cast-only list clean-skips"
+says "$NOT_ELIGIBLE" "$out4" || fail "(ii-c) skip must state the reel-eligibility reason; got: '$out4'"
+says "no [reel] marker" "$out4" || fail "(ii-c) skip must name the missing [reel] marker; got: '$out4'"
+says "delta" "$out4" || fail "(ii-c) skip must NAME the excluded id, which is what makes it actionable; got: '$out4'"
+if says "$NOTHING_CHANGED" "$out4"; then
+  fail "(ii-c) the two skip messages must not collapse back into one (issue #735); got: '$out4'"
+fi
+echo "PASS (ii-c): unmarked-cast-only list clean-skips with the eligibility message, naming delta"
+
+# --- git-backed sections: the `reel` path (selection + assembly + engine) -------
+if ! command -v git >/dev/null 2>&1; then
+  echo "SKIP (iii)/(iv): git not available"
+  echo "ADAPTER TEST PASS"
+  exit 0
+fi
+
+# A throwaway repo built entirely inside $TMP, with the ambient git configuration
+# switched off so it can neither read nor write the checkout this test runs in
+# (CLAUDE.md rule 5's discipline for the xtask real-git tests). No network: the
+# adapter only fetches when MAIN_REF names an `origin/*` ref, and this passes a
+# local branch. `mainline` stands in for main; each section cuts its own branch
+# off it and changes exactly one source file.
+export GIT_CONFIG_GLOBAL="$TMP/no-such-gitconfig"
+export GIT_CONFIG_SYSTEM="$TMP/no-such-gitconfig"
+export GIT_CONFIG_NOSYSTEM=1
+export HOME="$TMP/home"
+export XDG_CONFIG_HOME="$TMP/home/.config"
+mkdir -p "$HOME"
+
+REPO="$TMP/repo"
+mkdir -p "$REPO/tests"
+git -C "$REPO" init -q >/dev/null 2>&1
+git -C "$REPO" config user.email "adapter-test@example.invalid"
+git -C "$REPO" config user.name "adapter test"
+git -C "$REPO" config commit.gpgsign false
+# The two source files the fixture recordings name in their **Source:** lines.
+echo "// base" > "$REPO/tests/e2e_mouse_button.rs"   # alpha + beta (both [reel]-marked)
+echo "// base" > "$REPO/tests/e2e_mouse_delta.rs"    # delta (cast, but NOT marked)
+git -C "$REPO" add -A
+git -C "$REPO" commit -qm "base"
+git -C "$REPO" branch -q mainline
+export REEL_ADAPTER_MAIN_REF="mainline"
+
+# A stub engine, so (iv) can prove the engine IS invoked without agg/ffmpeg.
+ENGINE_LOG="$TMP/engine.log"
+cat > "$TMP/engine.sh" <<'STUB'
+#!/usr/bin/env bash
+printf 'ENGINE CALLED: %s\n' "$*" >> "$ENGINE_LOG"
+STUB
+chmod +x "$TMP/engine.sh"
+export REEL_ADAPTER_ENGINE="$TMP/engine.sh"
+export ENGINE_LOG
+
+# --- (iii) branch changed ONLY the unmarked test's source -> eligibility skip ---
+# This is issue #735 exactly: e2e tests DID change, all three of the other gates
+# passed, and only the opt-in marker was absent. The skip stays clean (no
+# manifest, no engine, exit 0) but must name the real cause.
+git -C "$REPO" checkout -q -b feature-unmarked mainline
+echo "// changed" >> "$REPO/tests/e2e_mouse_delta.rs"
+git -C "$REPO" commit -qam "touch the unmarked test"
+
+MAN5="$TMP/reel-unmarked.json"
+ERR5="$TMP/reel-unmarked.err"
+rc=0
+out5="$(cd "$REPO" && "$BUILD" reel --manifest "$MAN5" 2>"$ERR5")" || rc=$?
+[[ "$rc" -eq 0 ]] || fail "(iii) the skip must stay CLEAN (exit 0), got exit $rc; stderr: $(cat "$ERR5")"
+[[ ! -e "$MAN5" ]] || fail "(iii) manifest must NOT be written on a clean skip"
+[[ ! -e "$ENGINE_LOG" ]] || fail "(iii) engine must NOT be invoked on a clean skip"
+says "$NOT_ELIGIBLE" "$out5" || fail "(iii) skip must state the reel-eligibility reason; got: '$out5'"
+says "delta" "$out5" || fail "(iii) skip must NAME the changed-but-ineligible test; got: '$out5'"
+if says "$NOTHING_CHANGED" "$out5"; then
+  fail "(iii) e2e tests DID change — claiming otherwise is the issue #735 defect; got: '$out5'"
+fi
+# Selection must also explain itself per id, the way assembly already did — that
+# is the half of #735 where an unmarked id was dropped by a bare `continue`.
+says "has no [reel] marker" "$(cat "$ERR5")" \
+  || fail "(iii) selection must emit the per-id exclusion diagnostic; stderr: $(cat "$ERR5")"
+echo "PASS (iii): reel path names the missing [reel] marker (not 'no e2e tests changed') and still clean-skips"
+
+# --- (iv) branch changed a MARKED test's source -> selects, assembles, engine ---
+# The mirror image, so the near-miss reporting cannot start swallowing real work:
+# alpha/beta are marked and their source changed, so a reel IS built. delta's own
+# source is untouched here, so an unmarked-but-UNCHANGED test is not reported —
+# only near-misses that would otherwise have been selected are.
+git -C "$REPO" checkout -q -b feature-marked mainline
+echo "// changed" >> "$REPO/tests/e2e_mouse_button.rs"
+git -C "$REPO" commit -qam "touch the marked tests"
+
+MAN6="$TMP/reel-marked.json"
+out6="$(cd "$REPO" && "$BUILD" reel --manifest "$MAN6" --title "stub title" 2>/dev/null)"
+# --title is pinned so title composition never runs: it shells out to `gh`, and
+# this test must stay offline.
+[[ -s "$MAN6" ]] || fail "(iv) manifest must be written when a [reel]-marked test changed"
+len6="$(jq 'length' "$MAN6")"
+[[ "$len6" -eq 2 ]] || fail "(iv) expected 2 entries (beta, alpha), got $len6"
+[[ -s "$ENGINE_LOG" ]] || fail "(iv) engine must be invoked when a reel is built"
+grep -qF "ENGINE CALLED" "$ENGINE_LOG" || fail "(iv) engine stub not called: $(cat "$ENGINE_LOG")"
+if says "$NOT_ELIGIBLE" "$out6"; then
+  fail "(iv) delta's source did not change, so it is out of scope — not a near-miss to report; got: '$out6'"
+fi
+echo "PASS (iv): reel path selects the marked tests, writes the manifest, and invokes the engine"
 
 echo "ADAPTER TEST PASS"

--- a/.claude/skills/demo-reel-adapter/tests/adapter_test.sh
+++ b/.claude/skills/demo-reel-adapter/tests/adapter_test.sh
@@ -16,6 +16,9 @@
 #   (ii-b) an L1-only list CLEAN-SKIPS with that same message;
 #   (ii-c) an unmarked-cast-only list CLEAN-SKIPS just as cleanly but with the
 #         DIFFERENT, reel-eligibility message that NAMES the excluded id;
+#   (ii-d) a MIXED list — one id dropped for having no cast, one for having no
+#         marker — names BOTH reasons rather than attributing the whole skip to
+#         the marker (PR #778 review; reachable only via standalone `assemble`);
 #   (iii) the `reel` path on a branch that DID change an e2e test whose catalog
 #         entry is unmarked skips with that eligibility message too — never the
 #         "no e2e tests changed" one, which is the issue #735 defect;
@@ -137,6 +140,30 @@ if says "$NOTHING_CHANGED" "$out4"; then
   fail "(ii-c) the two skip messages must not collapse back into one (issue #735); got: '$out4'"
 fi
 echo "PASS (ii-c): unmarked-cast-only list clean-skips with the eligibility message, naming delta"
+
+# --- (ii-d) MIXED exclusions -> the skip names BOTH reasons, not just one -------
+# `gamma delta` loses one id to EACH gate: gamma has no cast (never reaches the
+# marker check), delta has a cast but no ` [reel]` marker. The composed reason has
+# to account for both. Before the PR #778 review fix it named only the marker
+# bucket, so "none is reel-eligible" silently scoped over gamma as well and a
+# reader chasing it would have added a marker that changes nothing.
+#
+# Unreachable from the automated `reel` pipeline — `select_ids` filters cast-less
+# dirs out before `assemble` sees them — so this covers the standalone
+# `build.sh assemble <id...>` subcommand, which takes raw ids with no filtering.
+MAN5="$TMP/skip4.json"
+out5="$("$BUILD" assemble --manifest "$MAN5" gamma delta 2>/dev/null)"
+[[ ! -e "$MAN5" ]] || fail "(ii-d) manifest must NOT be written when no id resolves to a clip"
+says "no [reel] marker" "$out5" || fail "(ii-d) skip must still name the marker reason; got: '$out5'"
+says "delta" "$out5" || fail "(ii-d) skip must name the marker-rejected id; got: '$out5'"
+says "no full-stream.cast" "$out5" \
+  || fail "(ii-d) skip must ALSO name the cast-less reason, not attribute the whole skip to markers; got: '$out5'"
+says "gamma" "$out5" \
+  || fail "(ii-d) skip must NAME the cast-less id too — omitting it is the defect this case guards; got: '$out5'"
+if says "$NOTHING_CHANGED" "$out5"; then
+  fail "(ii-d) a marker-rejected id is present, so this must not fall back to the generic message; got: '$out5'"
+fi
+echo "PASS (ii-d): mixed cast-less + unmarked list names BOTH reasons (gamma and delta)"
 
 # --- git-backed sections: the `reel` path (selection + assembly + engine) -------
 if ! command -v git >/dev/null 2>&1; then

--- a/.claude/skills/demo-reel-adapter/tests/fixtures/recordings/delta/test.md
+++ b/.claude/skills/demo-reel-adapter/tests/fixtures/recordings/delta/test.md
@@ -1,6 +1,6 @@
 # mouse/button/004 — Delta renders its label.
 
-**Source:** `tests/e2e_mouse_button.rs::delta`
+**Source:** `tests/e2e_mouse_delta.rs::delta`
 **Catalog:** tests/CATALOG.md
 **Cast:** `full-stream.cast`
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -105,7 +105,7 @@ tasks:
       - .claude/skills/demo-reel/tests/smoke.sh
 
   reel-adapter-test:
-    desc: Assert the demo-reel adapter builds manifest.json in catalog order, excludes L1 (cast-less) tests, and clean-skips an empty list (pure shell; no agg/ffmpeg/git/network; CI-safe)
+    desc: Assert the demo-reel adapter builds manifest.json in catalog order, excludes L1 (cast-less) and unmarked tests, and clean-skips with the right reason for each cause (no agg/ffmpeg, no network; the reel-path cases use git in a throwaway repo; CI-safe)
     cmds:
       - .claude/skills/demo-reel-adapter/tests/adapter_test.sh
 

--- a/changelog.d/735.misc.md
+++ b/changelog.d/735.misc.md
@@ -1,0 +1,7 @@
+## Demo-Reel Adapter Names the Real Reason It Skipped
+
+The pre-merge demo-reel step (`.claude/skills/demo-reel-adapter/build.sh`) enforces the opt-in ` [reel]` marker in two stages, but only the later one explained itself — so a branch whose e2e tests changed and were dropped for carrying no marker was told `skipped: no e2e tests changed on this branch`. That statement was false, and it pointed at the wrong gate: a reader would go debugging the git-diff selection, which was working correctly.
+
+The two causes now print different messages. Nothing in scope still prints the original wording. Tests that changed, have casts, and were dropped by the marker gate alone print `skipped: N e2e test(s) changed on this branch, but none is reel-eligible — no [reel] marker in tests/CATALOG.md for: <ids>`, naming them, plus a line explaining that the marker is opt-in and its absence is usually correct — a clip must show a real agent, so a stand-in test stays unmarked. Selection also emits the same per-id exclusion diagnostic assembly already did, so the marker gate explains itself wherever it fires.
+
+Both skips stay clean — no manifest, no engine, exit 0 — so an ordinary branch still passes the reel step. The adapter's acceptance test (`task reel-adapter-test`) now asserts each message against its own cause, including on the `reel` path, so the two cannot drift back into one.

--- a/docs/develop/demo-reel.md
+++ b/docs/develop/demo-reel.md
@@ -156,7 +156,7 @@ Two re-runnable checks guard the tooling locally:
 
 ```sh
 task reel-smoke           # engine: stitch a tiny fixture and assert the MP4 with ffprobe (needs agg+ffmpeg; no network)
-task reel-adapter-test    # adapter: assert manifest order + L1 exclusion + clean-skip (pure shell; CI-safe)
+task reel-adapter-test    # adapter: assert manifest order + L1/unmarked exclusion + both clean-skip messages (no agg/ffmpeg, no network; CI-safe)
 ```
 
 The live YouTube upload cannot be a routine automated test; it is verified by code review of `upload.sh` plus a one-time manual `--publish` run (see the engine SKILL.md).
@@ -170,7 +170,7 @@ The demo reel is **not** built during the pre-PR gate. The casts are *recorded* 
 3. **Build + upload (pre-merge).** Once the PR is green, the adapter (`build.sh --out reel.mp4 --publish`) composes a descriptive title (`<repo> · PRD #<prd> · PR #<pr> — <short desc>`, e.g. `dot-agent-deck · PRD #180 · PR #182 — PRD demo reel`), selects the branch's new/changed e2e tests, builds the manifest, and the engine stitches the reel and uploads it unlisted, returning the watch URL.
 4. **Post the link in three places.** So the reel rides along with both the PR and the release notes, the URL is posted to **(a)** a PR comment, **(b)** the PR description/body, and **(c)** the changelog fragment `changelog.d/<prd>.feature.md` (appended, so it flows into the release notes). Committing the changelog/PR-body change triggers one final quick CI + Greptile pass, which the orchestrator waits on before the merge gate.
 5. **Surface to the human pre-merge.** The orchestrator presents the link at the merge gate: `Demo reel for PRD #NNN: <unlisted YouTube link>. Watch before merging.`
-6. **Clean skip.** If the branch changed **no** e2e tests, the adapter writes no manifest, builds no reel, uploads nothing, and prints `skipped: no e2e tests changed on this branch`. The orchestrator records that there is no reel and why — no URL, no comment, no PR-body edit, no changelog link.
+6. **Clean skip, and which one.** When there is nothing to build the adapter writes no manifest, builds no reel, uploads nothing, and exits 0 — but it says *which* of the two reasons applies, because they call for opposite responses. If the branch changed **no** e2e tests it prints `skipped: no e2e tests changed on this branch` and there is genuinely nothing to do. If e2e tests **did** change and have casts but none carries the opt-in ` [reel]` marker, it instead prints `skipped: N e2e test(s) changed on this branch, but none is reel-eligible — no [reel] marker in tests/CATALOG.md for: <ids>` and names them; that is normally the correct outcome (a stand-in test is deliberately unmarked — see [CLAUDE.md](../../CLAUDE.md) rule 4), and the ids are there so you can confirm the marker is rightly absent rather than go debugging the diff gate. Either way the orchestrator records that there is no reel and why — no URL, no comment, no PR-body edit, no changelog link.
 
 > **The unlisted link is public-by-reach in the release notes.** An unlisted YouTube video is not listed or searchable, but anyone who has the link can watch it — and putting it in the changelog fragment publishes the link into the release notes, so anyone reading those notes can reach the reel. This is intended: the release notes are exactly where a reader wants a "show me what this PRD did" link.
 


### PR DESCRIPTION
Fixes #735.

## The problem

`.claude/skills/demo-reel-adapter/build.sh` enforces the opt-in ` [reel]` marker in **two** stages, and only the later one explained itself:

- `select_ids()` dropped an unmarked id with a bare `continue` and no diagnostic;
- `assemble()` had the explanatory `excluding '<id>' … has no [reel] marker` line.

So when every candidate was filtered out at *selection*, `assemble()` received an empty list and the run fell through to the single generic `SKIP_MSG`, worded for "nothing in scope at all". A branch that **had** changed e2e tests was told `skipped: no e2e tests changed on this branch`. That is false, and it points at the wrong gate — the reader goes debugging the git-diff selection, which was working correctly. (There is a mild integrity angle too: a message saying "nothing changed" invites someone to reach for a ` [reel]` marker to make a reel appear, when the absent marker was the deliberate, correct answer.)

Reproduced against the pre-fix script, same fixture, on a branch whose only changed e2e test is unmarked:

```
### OLD build.sh
skipped: no e2e tests changed on this branch
exit=0

### NEW build.sh
demo-reel-adapter: excluding 'delta' (catalog id 'mouse/button/004' has no [reel] marker — not reel-eligible)
skipped: 1 e2e test(s) changed on this branch, but none is reel-eligible — no [reel] marker in tests/CATALOG.md for: delta
  ([reel] is OPT-IN and its absence is usually the right answer: a clip exists so a human can watch REAL behavior, so only a test that genuinely spins up a real agent is marked — a stand-in (cat, scripted echo, recorder stubs, synthesized hook events) stays unmarked and never becomes a clip. See CLAUDE.md rule 4.)
exit=0
```

## What changed

- **`select_ids()` explains itself.** It emits the same per-id `has no [reel] marker` diagnostic `assemble()` already had, so the marker gate talks wherever it fires — and records those ids for the caller.
- **One `skip_message()` composes both wordings**, called from both skip paths, so they cannot drift back into saying the same wrong thing. The eligibility wording **names the excluded ids** (what makes it actionable) and states that the marker is opt-in and its absence is usually correct — a clip must show a **real agent**, so a stand-in stays unmarked (CLAUDE.md rule 4).
- **The marker gate is evaluated last** in `select_ids()`. The three gates are ANDed, so order cannot change *which* ids are selected; checked last, the diagnostic fires only for a genuine near-miss (cast on disk, source changed, marker absent) instead of for every unmarked recording dir on disk.
- The ids travel from `select_ids` to the `reel` path through a temp file, because `reel` reads selection via a process substitution — a subshell whose variables never come back. It is read and removed immediately (this path ends in `exec`, which never runs EXIT traps).

**The clean-skip contract is unchanged and asserted**: no manifest, no engine, **exit 0** on both paths, so the pre-merge reel step still passes an ordinary branch.

## Tests

`task reel-adapter-test` — all pass:

- **(ii-c)** now asserts the *eligibility* wording instead of the generic one, and **every** skip assertion checks both directions, so the two messages cannot re-collapse.
- **(iii)/(iv)** are new and drive the **`reel` path** — where the defect actually lived — against a throwaway git repo built inside the test's own `mktemp -d` with the ambient git configuration switched off, no network and no sleep (CLAUDE.md rule 5's discipline for the `xtask` real-git tests). They skip without failing where `git` is absent. (iii) is the #735 scenario; (iv) is its mirror — a marked test changed still selects, assembles and invokes the engine (a stub), reporting no near-miss.
- Verified as a real regression guard in both directions: the new tests **fail** against the old `build.sh` (`(ii-c) skip must state the reel-eligibility reason; got: 'skipped: no e2e tests changed on this branch'`), and the old test fails against the new one.
- Fixture: `delta` now names its **own** `**Source:**` file so (iii) can change the unmarked test's source without touching a marked one's.

## Gates

- `cargo fmt --check` — clean.
- `cargo clippy --workspace --all-targets --features e2e -- -D warnings` — clean.
- `cargo test-fast` — hit issue #771 (`libgdk-3.so.0` missing for `dot-agent-deck-desktop`; devbox lacks Tauri's GTK/WebKit deps), not this change. Re-run as `cargo nextest run --workspace --exclude dot-agent-deck-desktop`: **3437 passed, 0 skipped**. (A first run under heavy load flaked three process/timing tests — `agent_lifetime_bound`, `spawn_time_role_prompt_submit_after_session_start`, `shell_activity_001`; all three pass in isolation and in the clean full re-run.)
- **Rule 12 does not apply** — no daemon, TUI↔daemon protocol, orchestration or hook change, so no `PROTOCOL_VERSION` bump, no `.breaking.md` fragment, and no cross-version manual test. This is a shell script plus its docs.
- Changelog fragment: `changelog.d/735.misc.md` (`misc` — project tooling; users of the deck do not see it).
- Docs updated: the adapter `SKILL.md` gains a **Which clean skip you got** table, and `docs/develop/demo-reel.md` step 6 now describes both skips.
- CLAUDE.md rule 13: `demo-reel-adapter` is a project-local skill with no `dot-ai-` prefix, so it is safe to edit; no `dot-ai-*` skill was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)