### PR TITLE
fix(deps): make Renovate wait three days before proposing an npm package (#813)

### DIFF
--- a/changelog.d/813.misc.md
+++ b/changelog.d/813.misc.md
@@ -1,0 +1,5 @@
+## Renovate waits three days before proposing an npm package
+
+pnpm 11 enforces a supply-chain policy that rejects lockfile entries for packages published within the last 24 hours. Renovate was opening npm dependency PRs within hours of publication, so `desktop-web` failed at `pnpm install --frozen-lockfile` on arrival — and when such a PR merged, `main` stayed red until the package aged out. Measured twice in two days: `lucide-react@1.38.0` merged and held `main` red for about sixteen hours, and an unrelated PR opened in that window inherited the failure at 23h31m, twenty-nine minutes short of the cutoff.
+
+Renovate now holds an npm update until it is three days old, so no pull request is created for CI to reject. Three days rather than twenty-four hours because pnpm evaluates the cutoff at install time, leaving no margin for a PR opened at the boundary; for the packages this affects — an icon set, test tooling, the docs site — the delay costs nothing. Cargo, devbox and GitHub Actions updates are untouched: pnpm's policy governs npm packages only, and delaying every lane would change three cadences to fix a problem in one.

--- a/renovate.json
+++ b/renovate.json
@@ -116,6 +116,11 @@
     },
     {
       "matchManagers": ["npm"],
+      "minimumReleaseAge": "3 days",
+      "description": "Do not propose an npm package until it is three days old. pnpm 11 (arrived via #776) enforces a supply-chain policy that REJECTS lockfile entries for packages published within the last 24 hours — its own default, not configured here — so a PR opened hours after publication fails `desktop-web` at `pnpm install --frozen-lockfile` with ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION, and one that MERGES leaves `main` red until the package ages out (issue #813). Measured twice in two days: lucide-react 1.38.0 merged via #790 and held `main` red ~16h, and 1.39.0 arrived on #809 at 1h28m old. The failure is time-based and self-healing, which is what makes it corrosive rather than merely annoying — a recurring red check that means nothing trains everyone to ignore red checks, and an unrelated PR opened in that window inherits it (#805 failed at 23h31m, 29 minutes short). Renovate's internalChecksFilter holds the update rather than opening a PR, so nothing is created for CI to reject. THREE days rather than 24 hours on purpose: pnpm evaluates the cutoff at install time, so matching the figure exactly leaves no margin for a PR opened at the boundary, and for the packages this actually affects — an icon set, test tooling, a docs site — three days costs nothing. SCOPED TO npm DELIBERATELY: pnpm's policy governs npm packages only, so cargo, devbox and github-actions lanes keep their current cadence; a global delay would change three lanes to fix a problem in one. NOTE the 24-hour figure is pnpm's default, not a value pinned in this repository — if it changes, or is later configured explicitly, this number has to track it, which is a two-halves-of-one-number problem of the same shape as #648 in a lane scripts/check-pin-lockstep.sh does not cover."
+    },
+    {
+      "matchManagers": ["npm"],
       "matchFileNames": ["site/**"],
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "Docs site (site/)",


### PR DESCRIPTION
Closes #813.

## The problem

pnpm 11 — which arrived via #776 — rejects lockfile entries for packages published within the last **24 hours**. That is pnpm's own default, not something this repository configures. Renovate opens npm PRs within **hours** of publication. The two policies contradict each other, so every fast-moving npm dependency reproduces the failure by construction:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] 1 lockfile entries failed verification:
  lucide-react@1.39.0 was published at 2026-09-01T13:36:08.000Z,
  within the minimumReleaseAge cutoff (2026-08-31T15:03:55.417Z)
```

**Measured twice in two days:**

| | published | CI ran | age at CI | outcome |
| --- | --- | --- | --- | --- |
| `lucide-react@1.38.0` (#790, **merged**) | 2026-08-31T07:19Z | 2026-08-31T15:21Z | 8h02m | `main` red ~16h |
| `lucide-react@1.39.0` (#809, open) | 2026-09-01T13:36Z | 2026-09-01T15:03Z | 1h28m | red on arrival |

The merged case is the damaging one: the failure landed on `main` and stayed until the package aged out, so **#805 — unrelated work — inherited a red `desktop-web` at 23h31m, twenty-nine minutes short of the cutoff.**

It is time-based and self-healing, which is precisely what makes it corrosive rather than merely annoying. A recurring red check that means nothing trains everyone to ignore red checks.

## The change

Five lines: a `packageRules` entry setting `minimumReleaseAge: "3 days"` on the npm manager. Renovate's `internalChecksFilter` holds the update rather than opening a PR, so nothing is created for CI to reject.

**Three days rather than 24 hours** because pnpm evaluates its cutoff at *install* time, not at PR-creation time — matching the figure exactly leaves no margin for a PR opened at the boundary. For the packages this actually affects (an icon set, test tooling, the docs site) three days costs nothing.

**Scoped to `npm` deliberately.** pnpm's policy governs npm packages only. Cargo, devbox and github-actions keep their current cadence; a global delay would change three lanes to fix a problem in one.

## Verification

`renovate-config-validator` (Renovate's own): **"Config validated successfully against 1 file(s)"**. `cargo fmt --check` clean. `cargo clippy --workspace --all-targets --features e2e,e2e-live -- -D warnings` clean — including `dot-agent-deck-desktop`, which #780 made possible.

**`cargo test-fast` could not be completed locally, and that is worth reporting rather than hiding.** It fails before running any test:

```
dot_agent_deck_desktop-…: error while loading shared libraries:
libgdk-3.so.0: cannot open shared object file: No such file or directory
```

This is **not** caused by this change — the diff is `renovate.json` plus a changelog fragment, and `build` is green on `main`. It is the runtime half of #771 persisting after #780, and I traced the mechanism: `devbox.json` sets `env: { "PKG_CONFIG_PATH": "$PWD/.devbox/nix/profile/default/lib/pkgconfig" }`, but inside `devbox run --` that variable is **empty**, so `pkg-config` silently resolves against the system instead (`--variable=libdir gtk+-3.0` returns `/usr/lib/x86_64-linux-gnu`). The link therefore produces a binary with **no gtk3 path in its RUNPATH**, and per #780's own changelog a Nix-glibc shell has no loader cache, so `/usr/lib` is invisible to the dynamic linker at runtime. Cleaning the crate and rebuilding inside devbox did not change it. Filed separately; CI runs the real gate here.

## Not fixed here, worth knowing

The 24-hour figure is pnpm's **default**, not a value this repository pins. If pnpm changes it, or someone later configures it explicitly, this number has to track it — a two-halves-of-one-number problem of the same shape as #648's toolchain pins, in a lane `scripts/check-pin-lockstep.sh` does not cover.

Rule 12 does not apply: no daemon, protocol, orchestration or hook change.