### PR TITLE
fix(release): give desktop-publish's gh calls a repository to talk to (#852)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -729,11 +729,29 @@ jobs:
       - name: Upload the desktop assets to the release
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
-        run: gh release upload "v$RELEASE_VERSION" dist-desktop/* --clobber
+        # `--repo` is load-bearing on every `gh` call in this job, and its
+        # absence is why every release that has reached this job published no
+        # desktop artifact at all (#852). Unlike every other job in this file,
+        # `desktop-publish` has no `actions/checkout` -- it downloads artifacts
+        # and calls the API, and needs no source tree -- so there is no git
+        # repository for `gh` to infer the target from and it dies with
+        # `failed to run git: fatal: not a git repository`. Naming the
+        # repository is cheaper than cloning a tree the job never reads.
+        #
+        # All THREE calls in this job needed it: the two in the step below were
+        # latent only because the default `bash -e` aborts the job here first,
+        # so fixing this one alone would have relocated the failure rather than
+        # removed it. `release.yml` never runs on a pull request, so nothing in
+        # CI can catch a regression of this -- the static guard that can is
+        # `gh_calls_in_checkoutless_jobs_name_their_repository` in
+        # xtask/linkage-check/src/release_workflow_wiring.rs.
+        run: gh release upload "v$RELEASE_VERSION" dist-desktop/* --clobber --repo "$REPO"
       - name: Note the unsigned alpha in the release body
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
         # Appended here rather than assembled in `prepare` so the note appears
         # only when the assets it describes actually exist -- a release whose
@@ -741,7 +759,9 @@ jobs:
         run: |
           set -eu
           MARKER="<!-- desktop-alpha -->"
-          BODY=$(gh release view "v$RELEASE_VERSION" --json body -q .body)
+          # `--repo`, for the reason given on the step above: no checkout in
+          # this job means no git context for `gh` to fall back on.
+          BODY=$(gh release view "v$RELEASE_VERSION" --repo "$REPO" --json body -q .body)
           case "$BODY" in
             *"$MARKER"*)
               echo "release body already carries the desktop alpha note; nothing to do"
@@ -756,7 +776,7 @@ jobs:
             printf "On macOS, clear the quarantine flag after moving the app to /Applications:\n\n"
             printf "\`\`\`sh\nxattr -dr com.apple.quarantine \"/Applications/Agent Deck.app\"\n\`\`\`\n\n"
             printf "Signing and notarization are tracked in https://github.com/vfarcic/dot-agent-deck/issues/757. Checksums for these assets are in \`checksums-desktop-alpha.txt\`.\n"
-          } | gh release edit "v$RELEASE_VERSION" --notes-file -
+          } | gh release edit "v$RELEASE_VERSION" --repo "$REPO" --notes-file -
 
   docs:
     needs: [prepare, finalize]

--- a/changelog.d/852.bugfix.md
+++ b/changelog.d/852.bugfix.md
@@ -1,0 +1,7 @@
+## Releases now actually carry the desktop GUI alpha bundles
+
+The desktop alpha bundles were introduced in v0.39.1 and no release has ever published one. Both releases that have had the desktop jobs — v0.39.1 and v0.39.2 — built the dmg and the deb correctly, on both platforms, and then attached neither: their assets are the five CLI files and nothing else. Downloading the desktop preview from a release page was simply not possible, and the release notes were quiet about it, because the paragraph that explains these builds are unsigned is appended by the same job that failed before reaching it.
+
+The cause was a missing repository name. The publishing job downloads the bundles from the release run rather than building them, so it checks out no source — and without a checked-out repository the `gh` calls it uses to reach the release had no way to know which repository they meant. All three now name it explicitly.
+
+Nothing about what gets built, or when, has changed. A release whose bundler fails still goes out with its CLI assets complete and its run red, which is what the desktop jobs were wired for; the failure this fixes was in the attaching, after everything had already built. v0.39.2's bundles are still recoverable from its release run and are being attached separately — a fix here cannot repair an already-tagged release, because a release runs the workflow as it stood at its tag.

--- a/xtask/linkage-check/src/release_workflow_wiring.rs
+++ b/xtask/linkage-check/src/release_workflow_wiring.rs
@@ -303,26 +303,79 @@ fn one_platforms_bundler_failure_does_not_cancel_the_other() {
     );
 }
 
-/// Does this job block carry an `actions/checkout` step?
+/// The code portion of `line` -- everything before an unquoted `#` that opens a
+/// trailing shell comment. A whole-line comment reduces to its indentation.
 ///
-/// Comment lines are dropped first: the steps this predicate feeds carry prose
-/// *about* the absence of a checkout, and a match on that prose would report
-/// the property as satisfied by the very comment explaining it is not.
+/// Both predicates below run through this, and neither is safe without it. The
+/// steps in `desktop-publish` now carry prose *about* the absence of a checkout
+/// and about `--repo`, so a comment can satisfy either check by talking about
+/// it -- and for `checks_out` that failure is silent in the worst direction: a
+/// trailing `# no actions/checkout here` would make the guard skip the job.
+///
+/// Quote-aware, because `printf "…#…"` opens no comment, and word-aware,
+/// because a `#` mid-word does not either. Deliberately no more than that: it
+/// does not understand backslash escapes or here-documents, and does not need
+/// to, since its only job is to keep a `#`-commented mention from being read as
+/// code. Erring toward treating text as code is the safe direction, since code
+/// is what gets checked.
+fn code_before_comment(line: &str) -> &str {
+    let bytes = line.as_bytes();
+    let mut in_single = false;
+    let mut in_double = false;
+    for (i, &b) in bytes.iter().enumerate() {
+        match b {
+            b'\'' if !in_double => in_single = !in_single,
+            b'"' if !in_single => in_double = !in_double,
+            b'#' if !in_single && !in_double && (i == 0 || bytes[i - 1].is_ascii_whitespace()) => {
+                return &line[..i];
+            }
+            _ => {}
+        }
+    }
+    line
+}
+
+/// Does this job block carry an `actions/checkout` step?
 fn checks_out(block: &str) -> bool {
     block
         .lines()
-        .filter(|l| !l.trim_start().starts_with('#'))
+        .map(code_before_comment)
         .any(|l| l.contains("uses: actions/checkout"))
 }
 
-/// The lines of a job block that invoke the `gh` CLI.
+/// Does this command name a repository through a well-formed repo flag?
+///
+/// Token-precise rather than a `contains("--repo")`, per Greptile's P2 on
+/// PR #853, which added this. A substring test also accepts `--repository` and a bare
+/// trailing `--repo` with no value -- both of which `gh` itself rejects, as an
+/// unknown flag and a missing argument respectively -- so it would pass
+/// commands that still cannot run, which is the one thing this guard exists to
+/// stop. `-R` is accepted because it is the same flag, and rejecting it would
+/// fail a correct command.
+fn names_a_repository(command: &str) -> bool {
+    let words: Vec<&str> = command.split_whitespace().collect();
+    words.iter().enumerate().any(|(i, word)| {
+        if let Some(value) = word.strip_prefix("--repo=") {
+            return !value.is_empty();
+        }
+        if *word == "--repo" || *word == "-R" {
+            // The value must be there and must not be the next flag.
+            return words.get(i + 1).is_some_and(|v| !v.starts_with('-'));
+        }
+        false
+    })
+}
+
+/// The `gh`-invoking lines of a job block, each already reduced to its code
+/// portion by [`code_before_comment`] -- so a `gh` named only inside a comment
+/// is not an invocation, and the `--repo` checked below is one actually passed.
 ///
 /// Matched on a `gh` *token* -- the two characters preceded by something that
 /// cannot continue an identifier, and followed by whitespace -- and not on the
 /// bare substring, which is everywhere in ordinary English (`through`, `high`,
-/// `right`) and in this file's own `github.token` / `GH_TOKEN` bindings.
-/// Comment lines are dropped for the same reason: a sweep that drowns in noise
-/// gets abandoned, which buys as much as not sweeping.
+/// `right`) and in this file's own `github.token` / `GH_TOKEN` bindings. A
+/// sweep that drowns in noise gets abandoned, which buys as much as not
+/// sweeping.
 ///
 /// `/` and `.` are deliberately NOT in that set, so a path-qualified
 /// `/usr/bin/gh release upload` is matched too. Erring toward over-matching is
@@ -336,7 +389,7 @@ fn checks_out(block: &str) -> bool {
 fn gh_invocations(block: &str) -> Vec<&str> {
     block
         .lines()
-        .filter(|l| !l.trim_start().starts_with('#'))
+        .map(code_before_comment)
         .filter(|l| {
             l.match_indices("gh").any(|(i, _)| {
                 let boundary_before = l[..i]
@@ -386,10 +439,11 @@ fn gh_calls_in_checkoutless_jobs_name_their_repository() {
         }
         for call in gh_invocations(block) {
             assert!(
-                call.contains("--repo"),
+                names_a_repository(call),
                 "`{name}` has no `actions/checkout` step, so its workspace \
                  holds no git repository for `gh` to infer a target from -- and \
-                 this call names none either:\n\n    {}\n\n\
+                 this call names none either (shown as parsed, with any \
+                 trailing comment removed):\n\n    {}\n\n\
                  It will fail with `failed to run git: fatal: not a git \
                  repository`. That is issue #852: from PRD #740 onward every \
                  release built the desktop bundles and then failed to attach \
@@ -397,6 +451,9 @@ fn gh_calls_in_checkoutless_jobs_name_their_repository() {
                  missing this flag. Fix it either way -- add `--repo \"$REPO\"` \
                  with `REPO: ${{{{ github.repository }}}}` in the step's \
                  `env:`, or give the job a SHA-pinned `actions/checkout` -- but \
+                 note the flag must carry a VALUE and be real code: \
+                 `--repository`, a bare `--repo`, and a `--repo` inside a \
+                 comment are all rejected here because `gh` rejects them too -- \
                  fix it here, because `release.yml` fires only on a tag and \
                  nothing in CI will tell you. By the time this is observable a \
                  release has already gone out without its assets.",

--- a/xtask/linkage-check/src/release_workflow_wiring.rs
+++ b/xtask/linkage-check/src/release_workflow_wiring.rs
@@ -408,17 +408,19 @@ fn gh_calls_in_checkoutless_jobs_name_their_repository() {
     // Non-vacuity. A guard that passes because it matched nothing is not a
     // guard, and this one is one `gh`-token predicate away from matching
     // nothing. `desktop-publish` is the only job in the file that reaches the
-    // API through the CLI, and it does so three times; counted regardless of
-    // whether the job checks out, so this stays live under either remedy above.
-    let publish_calls = gh_invocations(job(&all, "desktop-publish")).len();
+    // API through the CLI, and it does so on three separate lines; counted
+    // regardless of whether the job checks out, so this stays live under either
+    // remedy above.
+    let publish_lines = gh_invocations(job(&all, "desktop-publish")).len();
     assert!(
-        publish_calls >= 3,
-        "expected to still see the three `gh` calls in `desktop-publish` that \
-         issue #852 was about, found {publish_calls}. This is a lower bound, \
-         not a pin on the step layout: if a call was deliberately removed, \
-         lower it in the same commit. If all three are still there, the `gh` \
-         token match above has stopped seeing them -- perhaps a call is now \
-         split across a line continuation -- and the loop it feeds has become \
-         a no-op that passes on nothing."
+        publish_lines >= 3,
+        "expected `desktop-publish` to still hold the three `gh` invocation \
+         LINES that issue #852 was about, matched {publish_lines}. Lines, not \
+         calls -- two invocations sharing a line would count once -- and a \
+         lower bound rather than a pin on the step layout: if a call was \
+         deliberately removed, lower it in the same commit. If all three are \
+         still there, the `gh` token match above has stopped seeing them -- \
+         perhaps a call is now split across a line continuation -- and the loop \
+         it feeds has become a no-op that passes on nothing."
     );
 }

--- a/xtask/linkage-check/src/release_workflow_wiring.rs
+++ b/xtask/linkage-check/src/release_workflow_wiring.rs
@@ -302,3 +302,123 @@ fn one_platforms_bundler_failure_does_not_cancel_the_other() {
          timeout on Linux cancels an otherwise-good macOS dmg."
     );
 }
+
+/// Does this job block carry an `actions/checkout` step?
+///
+/// Comment lines are dropped first: the steps this predicate feeds carry prose
+/// *about* the absence of a checkout, and a match on that prose would report
+/// the property as satisfied by the very comment explaining it is not.
+fn checks_out(block: &str) -> bool {
+    block
+        .lines()
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .any(|l| l.contains("uses: actions/checkout"))
+}
+
+/// The lines of a job block that invoke the `gh` CLI.
+///
+/// Matched on a `gh` *token* -- the two characters preceded by something that
+/// cannot continue an identifier, and followed by whitespace -- and not on the
+/// bare substring, which is everywhere in ordinary English (`through`, `high`,
+/// `right`) and in this file's own `github.token` / `GH_TOKEN` bindings.
+/// Comment lines are dropped for the same reason: a sweep that drowns in noise
+/// gets abandoned, which buys as much as not sweeping.
+///
+/// `/` and `.` are deliberately NOT in that set, so a path-qualified
+/// `/usr/bin/gh release upload` is matched too. Erring toward over-matching is
+/// the safe direction here: a false positive asks for a `--repo` that does no
+/// harm, while a miss is the silent broken release this exists to prevent.
+///
+/// Deliberately line-oriented, so it sees `$(gh release view …)` and
+/// `… | gh release edit …` as invocations. It cannot see one split across a
+/// backslash continuation; nothing in `release.yml` writes one, and the
+/// non-vacuity assertion below is what notices if that changes.
+fn gh_invocations(block: &str) -> Vec<&str> {
+    block
+        .lines()
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .filter(|l| {
+            l.match_indices("gh").any(|(i, _)| {
+                let boundary_before = l[..i]
+                    .chars()
+                    .next_back()
+                    .is_none_or(|c| !(c.is_alphanumeric() || "_-".contains(c)));
+                let arguments_after = l[i + 2..].chars().next().is_some_and(char::is_whitespace);
+                boundary_before && arguments_after
+            })
+        })
+        .collect()
+}
+
+/// Issue #852: `desktop-publish` is the one job in this file with no
+/// `actions/checkout` -- it downloads artifacts and calls the API, so it needs
+/// no source tree -- and none of its three `gh` calls passed `--repo`. `gh`
+/// then falls back to inspecting git for its target repository, finds none, and
+/// dies with `failed to run git: fatal: not a git repository`. Every release
+/// that reached the job failed inside it, so on every tag carrying these jobs
+/// the desktop alpha bundles were built correctly and then never attached, and
+/// the release-body note the two later calls append was never appended either.
+///
+/// Asserted over every `gh` call in every checkout-less job rather than over
+/// the three lines that were wrong, and that generality is the point: the
+/// steps run under the default `bash -e`, so the first failure aborts the job
+/// and the other two calls were *latent*. A check pinned to the call named in
+/// the failure log would have been satisfied by a fix that merely relocated the
+/// failure to the next call. Stated as a property it also covers the next job
+/// added without a checkout, which is how this one arrived.
+///
+/// Either remedy satisfies it, matching the two the issue offers: a `--repo` on
+/// each call, or a checkout for the job. This does not pin which.
+///
+/// **Scoped to `release.yml`**, which is this module's file and the workflow
+/// that never runs on a pull request -- so a static assertion is the only thing
+/// that can catch this at all. It is *not* a claim about the other workflows,
+/// and does not generalise to them as written: `ci.yml`'s `changes` job reaches
+/// the API as `gh api repos/$REPO/…`, carrying its repository in the request
+/// path rather than in a flag, and the `*.lock.yml` files are generated.
+#[test]
+fn gh_calls_in_checkoutless_jobs_name_their_repository() {
+    let all = jobs(&workflow());
+
+    for (name, block) in &all {
+        if checks_out(block) {
+            continue;
+        }
+        for call in gh_invocations(block) {
+            assert!(
+                call.contains("--repo"),
+                "`{name}` has no `actions/checkout` step, so its workspace \
+                 holds no git repository for `gh` to infer a target from -- and \
+                 this call names none either:\n\n    {}\n\n\
+                 It will fail with `failed to run git: fatal: not a git \
+                 repository`. That is issue #852: from PRD #740 onward every \
+                 release built the desktop bundles and then failed to attach \
+                 them, because all three `gh` calls in `desktop-publish` were \
+                 missing this flag. Fix it either way -- add `--repo \"$REPO\"` \
+                 with `REPO: ${{{{ github.repository }}}}` in the step's \
+                 `env:`, or give the job a SHA-pinned `actions/checkout` -- but \
+                 fix it here, because `release.yml` fires only on a tag and \
+                 nothing in CI will tell you. By the time this is observable a \
+                 release has already gone out without its assets.",
+                call.trim()
+            );
+        }
+    }
+
+    // Non-vacuity. A guard that passes because it matched nothing is not a
+    // guard, and this one is one `gh`-token predicate away from matching
+    // nothing. `desktop-publish` is the only job in the file that reaches the
+    // API through the CLI, and it does so three times; counted regardless of
+    // whether the job checks out, so this stays live under either remedy above.
+    let publish_calls = gh_invocations(job(&all, "desktop-publish")).len();
+    assert!(
+        publish_calls >= 3,
+        "expected to still see the three `gh` calls in `desktop-publish` that \
+         issue #852 was about, found {publish_calls}. This is a lower bound, \
+         not a pin on the step layout: if a call was deliberately removed, \
+         lower it in the same commit. If all three are still there, the `gh` \
+         token match above has stopped seeing them -- perhaps a call is now \
+         split across a line continuation -- and the loop it feeds has become \
+         a no-op that passes on nothing."
+    );
+}


### PR DESCRIPTION
## What was wrong

`desktop-publish` is the only job in `release.yml` with no `actions/checkout` — it downloads the bundles from the run and calls the API, so it genuinely needs no source tree — and none of its three `gh release` calls passed `--repo`. `gh` then falls back to inspecting git for its target repository, finds none in the workspace, and dies with `failed to run git: fatal: not a git repository`.

Measured, not assumed: both releases that have carried these jobs published **zero** desktop assets.

```
v0.39.2 desktop_assets=0   # has desktop jobs
v0.39.1 desktop_assets=0   # has desktop jobs
v0.39.0 desktop_assets=0   # predates them (c58ac7e, 2026-08-31)
```

The bundles built correctly on both platforms every time and were then discarded. The release-body note explaining they are unsigned has likewise never been appended, because the step that appends it never ran.

## Every `gh` call in the file, and what happened to each

An independent YAML parse (not the indentation parser the guard uses) confirms `release.yml` contains exactly three `gh` invocations, all three in `desktop-publish`, which has no checkout:

| line | call | before | now |
| --- | --- | --- | --- |
| 733→751 | `gh release upload "v$RELEASE_VERSION" dist-desktop/*` | failed on every run | `--repo "$REPO"` |
| 744→764 | `BODY=$(gh release view "v$RELEASE_VERSION" --json body …)` | latent — never reached | `--repo "$REPO"` |
| 759→779 | `… \| gh release edit "v$RELEASE_VERSION" --notes-file -` | latent — never reached | `--repo "$REPO"` |

**All three, not just the one in the log.** The steps run under the default `bash -e`, so the first failure aborted the job and the other two were latent — adding the flag to the upload alone would have relocated the failure to `gh release view` rather than removed it.

No other workflow is touched, and no other job in `release.yml` invokes `gh` at all.

## Which approach, and why

**Option 1 — `--repo` on each call.** No `actions/checkout` was added, so **no action SHA needed resolving**; the diff introduces no new action dependency and #769's pinning is untouched.

Three reasons over adding a checkout:

1. The job's work needs no source tree. Cloning one so that `gh` has a `.git` to read is paying for a repository to be inferred when it can simply be named.
2. It keeps the fix visible at the call site. `release.yml` never runs on a PR, so a reader auditing line 751 in isolation is a realistic reviewer — and with this shape they can tell it is correct without scrolling to the job's step list.
3. It keeps the new guard **binding** on this job. Under a checkout the property is satisfied trivially and nothing would be checking the three calls themselves.

The value is bound through `env:` as `REPO: ${{ github.repository }}` rather than interpolated into the `run:` line, per the convention this file documents at length on `prepare`'s version step (a `${{ }}` expression is substituted as raw text before bash parses the line). `ci.yml`'s `changes` job already uses the same `REPO` binding.

## The guard, which is the substance

`release.yml` fires only on a tag, so **no CI job can exercise this fix** — a change that merely looks right is exactly what produced the bug. `gh_calls_in_checkoutless_jobs_name_their_repository` in `xtask/linkage-check/src/release_workflow_wiring.rs` asserts the general property over that module's existing parsed job graph, reusing its `jobs()` / `job()` helpers:

> every `gh` invocation in a job that lacks `actions/checkout` must name its repository.

Stated generally on purpose. A check pinned to the call in the failure log would have been **satisfied by the partial fix** described above; stated as a property it also covers the next job added without a checkout, which is how this one arrived. Either remedy the issue offers satisfies it — it does not pin which, so adding a checkout later for an unrelated reason will not fight the test. It carries a **non-vacuity assertion**, because a guard that passes on having matched nothing is not a guard.

The `gh` matcher matches a *token* (boundary before, whitespace after), not the substring — which is everywhere in ordinary English (`through`, `high`) and in this job's own `github.token` / `GH_TOKEN` bindings — and drops comment lines, since the steps it inspects now carry prose *about* `gh`. `/` and `.` are deliberately not boundary characters, so a path-qualified `/usr/bin/gh` is matched too; erring toward over-matching is the safe direction, as a false positive asks for a harmless flag while a miss is the silent broken release.

Scoped to `release.yml`, and the test's doc comment says so rather than implying more: the property does **not** generalise to the other workflows as written — `ci.yml`'s `changes` job reaches the API as `gh api repos/$REPO/…`, carrying its repository in the request path rather than in a flag, and the `*.lock.yml` files are generated.

## Evidence the guard fails when the fix is reverted

A guard nobody has seen fail is not a guard. Each case mutates `release.yml`, runs the single test, and restores:

| case | result |
| --- | --- |
| revert all three `--repo` flags | **FAIL** |
| revert only call 1 (`upload`, the one in the log) | **FAIL** |
| revert only call 2 (`view`, latent) | **FAIL** |
| revert only call 3 (`edit`, latent) | **FAIL** |
| path-qualified `/usr/bin/gh` with `--repo` dropped | **FAIL** |
| `gh` matcher blinded (calls no longer matched) | **FAIL** (non-vacuity) |
| the fix as committed | PASS |
| the issue's other remedy: `actions/checkout`, no `--repo` | PASS |

After Greptile's P2 (below), five more cases — each a command `gh` cannot run, each of which the original substring check let through:

| case | result |
| --- | --- |
| `--repository VALUE` (gh: `unknown flag`) | **FAIL** |
| bare `--repo`, no value (gh: `flag needs an argument`) | **FAIL** |
| `--repo` followed by another flag | **FAIL** |
| `--repo` only inside a trailing `#` comment | **FAIL** |
| empty `--repo=` | **FAIL** |
| `-R VALUE` — legitimate, gh accepts | PASS |
| `--repo=VALUE` — legitimate, gh accepts | PASS |

The whole original matrix was re-run against the tightened check and is unchanged.

The failure names the offending line verbatim:

```
`desktop-publish` has no `actions/checkout` step, so its workspace holds no git
repository for `gh` to infer a target from -- and this call names none either:

    run: gh release upload "v$RELEASE_VERSION" dist-desktop/* --clobber

It will fail with `failed to run git: fatal: not a git repository`. That is
issue #852: ...
```

Rows 2–4 are the ones that matter: the guard catches each of the two **latent** calls on its own, so the partial fix this issue warns about cannot pass.

## Runtime evidence too, since the static guard cannot prove `gh` behaves

The guard proves the flag is present. Two things it cannot prove were checked directly with `gh 2.98.0`, run from a **non-git directory** so it reproduces the job's actual condition:

**1. The fix works.** With `--repo`, `gh` resolves the repository without consulting git:

```
$ cd /tmp/scratch && git rev-parse --is-inside-work-tree
fatal: not a git repository (or any parent up to mount point /)

$ gh release view "v0.39.2" --repo vfarcic/dot-agent-deck --json body -q '.body | .[0:40]'
## [0.39.2] - 2026-09-03

$ gh release view "v0.39.2" --json body -q .body          # negative control
failed to run git: fatal: not a git repository (or any parent up to mount point /)
```

That second line is the failure log in the issue, reproduced exactly.

**2. `--repo` placed after the variadic file args actually parses as a flag.** Worth checking rather than assuming: `gh release upload <tag> <files>...` takes variadic positionals, and if cobra interspersion were off, `--repo` and the repo slug would be consumed as *filenames*. This ordering has **never been executed** — the pre-existing `--clobber` sits in the same position, but the job always died at repository resolution before `gh` parsed anything, so there is no precedent to lean on.

```
$ gh release upload "v0.0.0-no-such-tag-probe" probe.txt --clobber --repo vfarcic/dot-agent-deck
release not found
```

`release not found` is the right answer: the flags were parsed, the repository was resolved from `--repo`, and the only thing wrong was the deliberately fake tag. A non-mutating probe — `gh release upload` resolves the release before touching any asset.

## Tests run

- `release_workflow_wiring::gh_calls_in_checkoutless_jobs_name_their_repository` — the new guard; the whole revert matrix above.
- The nine pre-existing tests in the module, all passing, none modified: `finalize_does_not_wait_on_the_desktop_jobs`, `desktop_bundle_runs_beside_the_cli_matrix_not_after_it`, `desktop_publish_waits_for_the_release_to_exist`, `finalize_downloads_only_the_cli_artifacts`, `desktop_artifacts_are_named_outside_the_cli_pattern`, `a_failed_platform_leg_still_publishes_the_other`, `a_partial_desktop_publish_is_not_silent`, `desktop_jobs_do_not_swallow_their_own_failures`, `one_platforms_bundler_failure_does_not_cancel_the_other`.
- `cargo test-fast` — **4016 tests, 4016 passed, 0 skipped**, no `--exclude`. Re-run after the Greptile fix, same result.
- `cargo fmt --check` clean; `cargo clippy --workspace --all-targets --features e2e,e2e-live -- -D warnings` exit 0.

## Review feedback addressed

**Greptile P2 — "repository option check is imprecise" (valid, fixed in 1c8afe7).** `call.contains("--repo")` also accepted `--repository`, a bare `--repo`, and a `--repo` sitting in a trailing comment — all three commands `gh` cannot run, so the guard would have passed a `desktop-publish` that still failed on a tag. Checked against `gh 2.98.0` rather than assumed:

```
$ gh release upload v0.0.0-probe f.txt --repository vfarcic/dot-agent-deck
unknown flag: --repository
$ gh release upload v0.0.0-probe f.txt --repo
flag needs an argument: --repo
```

The comment case was the least hypothetical of the three, since the fix commit *added* prose about `--repo` to these very steps.

`names_a_repository` now matches the flag as a token carrying a value, so the guard's accept/reject set matches `gh`'s exactly on all four forms — `-R VALUE` and `--repo=VALUE` are accepted, because `gh` takes both and failing a correct command is its own defect. `code_before_comment` strips a trailing shell comment, quote-aware (`printf "…#…"` opens no comment) and word-aware. Both predicates run through it, and `checks_out` needed it more than the repo check did: its failure direction is silent, since a trailing `# no actions/checkout here` would have made the guard skip the job entirely.

## Out of scope, deliberately

- **v0.39.2 is not repaired here** and cannot be: a release run uses the workflow as it stood at its tag. Its bundles are still downloadable from its run as `desktop-bundle-*` artifacts and are being attached by hand separately.
- **No change to what `desktop-publish` does, uploads, or waits on.** PRD #740 chose that topology so a desktop failure cannot gate the CLI release, and this module already pins it.
- **No `continue-on-error` added.** #740 rejected it so a silently missing artifact cannot pass for a healthy release — the whole reason this failure was at least red.

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)
