### PR TITLE
fix(xtask): print list-tests' repo-relative paths forward-slashed on every platform (#831)

### DIFF
--- a/changelog.d/831.misc.md
+++ b/changelog.d/831.misc.md
@@ -1,0 +1,11 @@
+## `cargo xtask list-tests` prints repo-relative paths with forward slashes on every platform
+
+`list_tests`' `rel_to_root` built the repo-relative path in `TestEntry.file` / `ModifiedRow.file` by stringifying a path that came out of a directory walk, so it carried the **native** separator. On Windows the synthetic-test inventory tables printed `tests\e2e_foo.rs`, against a field whose own doc comment promises `tests/e2e_hook_delivery.rs` and beside forward-slashed literals — and against the same field filled from `git ls-tree` on the base side, which is always forward-slashed. It was cosmetic rather than a wrong report, because `file` is display-only (`compute_created` and `compute_modified` key on `spec_id` and compare only the Scenario and the body fingerprint), and it stayed invisible because the one test asserting on the field fed a synthetic `"src/tab.rs"` literal that is forward-slashed before it reaches the code.
+
+The path is now normalised where it is built, by the component-walking `slash_path` helper that PRD #743's palette guard already used for the same defect — moved to a shared `xtask/linkage-check/src/paths.rs` now that it has two consumers. It walks `Path::components` rather than replacing `\` with `/`, because on Unix a backslash is a legal character in a file name and rewriting it would report a path that does not exist.
+
+Two regression tests exercise a genuinely walked path — a real fixture tree in a temporary directory, so the separators under assertion are whatever the platform produced — and assert both the forward-slashed spelling and that the recorded string still resolves to the file the walk found. Of the three build jobs only `build-windows` runs native Windows path semantics, so that is the job that proves the forward-slashed half.
+
+Issue #831's survey of the rest of the crate found no other live exposure, and nothing else was touched: every path *comparison* there goes through `Path`/`PathBuf`, which compares components, and the remaining `display()` interpolations carry absolute paths with no forward-slashed literal glued on.
+
+No shipped behaviour changes — the affected code is a contributor command.

--- a/xtask/linkage-check/src/desktop_palette.rs
+++ b/xtask/linkage-check/src/desktop_palette.rs
@@ -68,6 +68,8 @@ use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::paths::slash_path;
+
 /// The marker that exempts the line it appears on.
 const OPT_OUT: &str = "theme-invariant:";
 
@@ -747,42 +749,6 @@ fn sources(root: &Path) -> Result<Vec<PathBuf>, String> {
     Ok(out)
 }
 
-/// A path as the report should print it: `/`-separated on every platform.
-///
-/// [`Path::display`] emits the **native** separator, so on Windows a finding
-/// read `desktop/src/c\Tile.tsx` — the literal prefix forward-slashed and the
-/// walked tail back-slashed, which is not a path anything in this repository
-/// prints. That string is not just a test fixture: it is what a developer reads
-/// in the guard's failure message and what they paste or click. `git`, every CI
-/// log and every other path written here use `/`, so a Windows contributor and
-/// a Linux contributor debugging the same violation have to see the same text.
-///
-/// Hence normalising here, where the path is built, rather than teaching each
-/// assertion to accept either separator — that would leave the tests asserting
-/// something weaker than the property that matters, and would leave the message
-/// platform-variant for no gain.
-///
-/// Walks components rather than replacing `\` blindly, because on Unix a
-/// backslash is a legal character **in a file name** and rewriting it would
-/// report a path that does not exist.
-fn slash_path(path: &Path) -> String {
-    let mut out = String::new();
-    for component in path.components() {
-        if component == std::path::Component::RootDir {
-            // The leading separator itself; `as_os_str` here is the native one.
-            if !out.ends_with('/') {
-                out.push('/');
-            }
-            continue;
-        }
-        if !out.is_empty() && !out.ends_with('/') {
-            out.push('/');
-        }
-        out.push_str(&component.as_os_str().to_string_lossy());
-    }
-    out
-}
-
 /// Scan a `desktop/src` tree. Fails closed on any traversal or read error —
 /// see [`sources`].
 fn scan_tree(src_root: &Path) -> Result<Vec<Finding>, String> {
@@ -1311,42 +1277,6 @@ mod tests {
         assert_eq!(findings.len(), 1, "{findings:#?}");
         assert_eq!(findings[0].file, "desktop/src/themes/styles.css");
         assert_eq!(findings[0].literal, "#5e9c90");
-    }
-
-    /// The Windows failure that `slash_path` exists for, pinned directly rather
-    /// than inferred from two tests that happen to compare whole path strings.
-    ///
-    /// The joins matter: `Path::join` uses the **native** separator, so on
-    /// Windows these inputs really are `themes\styles.css` and
-    /// `c\ui\Tile.tsx`, and `display()` — what this used to call — returns
-    /// them with those backslashes intact. On Unix the assertion is true either
-    /// way; it is a tripwire for the platform where it can fail, which is the
-    /// most a Linux host can offer for a Windows-only path defect.
-    #[test]
-    fn a_reported_path_is_forward_slashed_whatever_the_native_separator_is() {
-        assert_eq!(
-            slash_path(&Path::new("themes").join("styles.css")),
-            "themes/styles.css"
-        );
-        assert_eq!(
-            slash_path(&Path::new("c").join("ui").join("Tile.tsx")),
-            "c/ui/Tile.tsx"
-        );
-        assert_eq!(slash_path(Path::new("styles.css")), "styles.css");
-        assert!(
-            !slash_path(&Path::new("a").join("b")).contains(std::path::MAIN_SEPARATOR)
-                || std::path::MAIN_SEPARATOR == '/'
-        );
-    }
-
-    /// And it is a component walk rather than a blind `\` → `/` replacement,
-    /// which this host *can* prove: on Unix a backslash is a legal character in
-    /// a file name, so rewriting one would report a path that does not exist.
-    #[cfg(unix)]
-    #[test]
-    fn a_backslash_inside_a_unix_file_name_is_not_a_separator() {
-        assert_eq!(slash_path(Path::new(r"a\b.tsx")), r"a\b.tsx");
-        assert_eq!(slash_path(Path::new("/abs/x.tsx")), "/abs/x.tsx");
     }
 
     /// The palette exemption is a **path** comparison, so it survives a root

--- a/xtask/linkage-check/src/list_tests.rs
+++ b/xtask/linkage-check/src/list_tests.rs
@@ -1133,8 +1133,9 @@ mod tests {
     /// so its separators are whatever the platform produced, and `\` on Windows
     /// is what `to_string_lossy` used to leak into the inventory table. The
     /// pre-existing parser tests feed a synthetic `"src/tab.rs"` literal that is
-    /// forward-slashed before it ever reaches this code, so no assertion on one
-    /// of them can fail on any platform, which is why the defect survived.
+    /// forward-slashed before it ever reaches this code and is stored verbatim,
+    /// so an assertion on the field there cannot fail on any platform — which
+    /// is why the defect survived.
     ///
     /// Nested directories on purpose: a two-component path exercises one
     /// separator and a four-component one exercises three. Both walks are

--- a/xtask/linkage-check/src/list_tests.rs
+++ b/xtask/linkage-check/src/list_tests.rs
@@ -18,6 +18,8 @@ use regex::Regex;
 
 use xtask_docs::{CatalogEntry, DocsConfig, parse_catalog};
 
+use crate::paths::slash_path;
+
 /// One synthetic test as observed at a single git ref.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TestEntry {
@@ -686,12 +688,29 @@ fn collect_tests_on_disk(root: &Path) -> Result<BTreeMap<String, TestEntry>, Str
     collect_tests_from_sources(&sources)
 }
 
+/// The repo-relative path of a walked file, spelled the way [`TestEntry::file`]
+/// promises: `/`-separated on every platform.
+///
+/// `abs_path` comes out of [`walk_rs_files`], so its separators are the host's,
+/// and `to_string_lossy` — what this used to end with — keeps them, so on
+/// Windows the inventory tables printed `tests\e2e_foo.rs` (issue #831).
+/// The field is display-only — [`compute_created`] and [`compute_modified`] key
+/// on `spec_id` and compare only `scenario` and `body_fingerprint`, never
+/// `file` — which is why this was cosmetic rather than a wrong report. It is
+/// still worth fixing at the source: the same field is filled from
+/// `git ls-tree` output on the base side ([`collect_tests_at_ref`]), which is
+/// always forward-slashed, so one field had two producers that disagreed by
+/// platform, and one added assertion on it would have gone red on
+/// `build-windows`.
+///
+/// Normalising here, where the string is built, rather than at each print site
+/// keeps the promise in one place. See [`slash_path`] for why it is a component
+/// walk and not a `\` → `/` replacement.
 fn rel_to_root(root: &Path, abs_path: &Path) -> Result<String, String> {
-    Ok(abs_path
+    let rel = abs_path
         .strip_prefix(root)
-        .map_err(|e| format!("strip prefix {}: {e}", abs_path.display()))?
-        .to_string_lossy()
-        .into_owned())
+        .map_err(|e| format!("strip prefix {}: {e}", abs_path.display()))?;
+    Ok(slash_path(rel))
 }
 
 fn walk_rs_files(
@@ -1104,5 +1123,125 @@ mod tests {
         assert!(!layer_token_is_l1("L2 (re-sequenced from L1: ...)"));
         assert!(!layer_token_is_l1("L2 synthetic"));
         assert!(!layer_token_is_l1(""));
+    }
+
+    /// Issue #831: the repo-relative `file` string is `/`-separated even though
+    /// the walk that produced it used the host's separator.
+    ///
+    /// Building a real tree in a tempdir is the whole point: the path under
+    /// assertion is a **walked** one — `walk_rs_files` gets it from `read_dir`,
+    /// so its separators are whatever the platform produced, and `\` on Windows
+    /// is what `to_string_lossy` used to leak into the inventory table. The
+    /// pre-existing parser tests feed a synthetic `"src/tab.rs"` literal that is
+    /// forward-slashed before it ever reaches this code, so no assertion on one
+    /// of them can fail on any platform, which is why the defect survived.
+    ///
+    /// Nested directories on purpose: a two-component path exercises one
+    /// separator and a four-component one exercises three. Both walks are
+    /// covered because `rel_to_root` is called from each.
+    ///
+    /// This host is Linux, so the exact-string assertions cannot *fail* here —
+    /// `build-windows` is the only one of the three build jobs running native
+    /// Windows path semantics, so it is what proves them, and no gate on a
+    /// Linux host can. What this host does prove is the two
+    /// platform-independent halves: the recorded string carries no native
+    /// separator, and it still resolves to the very file the walk found.
+    #[test]
+    fn a_walked_path_is_recorded_with_forward_slashes() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let root = tmp.path();
+
+        let tests_file = root.join("tests").join("nested").join("e2e_walked.rs");
+        std::fs::create_dir_all(tests_file.parent().expect("has a parent")).expect("mkdir tests");
+        std::fs::write(
+            &tests_file,
+            r#"
+                #[spec("walked/tests/001")]
+                #[test]
+                /// Scenario: a test file the tests/ walk has to find.
+                fn walked_001_from_tests() { let _ = 1; }
+            "#,
+        )
+        .expect("write the tests/ fixture");
+
+        let src_file = root.join("src").join("deep").join("nest").join("tab.rs");
+        std::fs::create_dir_all(src_file.parent().expect("has a parent")).expect("mkdir src");
+        std::fs::write(
+            &src_file,
+            r#"
+                #[cfg(test)]
+                mod tests {
+                    #[spec("walked/src/001")]
+                    #[test]
+                    /// Scenario: a src file the src/ walk has to find.
+                    fn walked_001_from_src() { let _ = 2; }
+                }
+            "#,
+        )
+        .expect("write the src/ fixture");
+
+        let map = collect_tests_on_disk(root).expect("the fixture tree must be walkable");
+        assert_eq!(map.len(), 2, "{map:#?}");
+
+        // These two are the assertions that go red on Windows without the fix:
+        // the walk hands `rel_to_root` `tests\nested\e2e_walked.rs` there.
+        assert_eq!(map["walked/tests/001"].file, "tests/nested/e2e_walked.rs");
+        assert_eq!(map["walked/src/001"].file, "src/deep/nest/tab.rs");
+
+        for (spec_id, walked) in [
+            ("walked/tests/001", &tests_file),
+            ("walked/src/001", &src_file),
+        ] {
+            let recorded = &map[spec_id].file;
+            assert!(
+                !recorded.contains(std::path::MAIN_SEPARATOR) || std::path::MAIN_SEPARATOR == '/',
+                "{recorded} still carries the native separator"
+            );
+            // Separator-free is only half of it. The string also has to still
+            // name the file the walk found, which is what makes it a path
+            // rather than a shape — and what a caller who pastes it needs.
+            assert_eq!(
+                std::fs::canonicalize(root.join(recorded)).expect("the recorded path must resolve"),
+                std::fs::canonicalize(walked).expect("the walked path must resolve"),
+                "{recorded} does not round-trip to the file the walk found"
+            );
+        }
+    }
+
+    /// The normalisation is a component walk, not a `\` → `/` replacement —
+    /// proven here against a real directory entry rather than the synthetic
+    /// `Path` the `paths` module's own unit test uses.
+    ///
+    /// On Unix a backslash is a legal character **in a file name**, so this
+    /// fixture is one file called `we\ird.rs` inside `tests/`, not a `we`
+    /// directory. A `replace` would record `tests/we/ird.rs`, which resolves to
+    /// nothing — so the round-trip is the assertion that catches it. Unix-only
+    /// because on Windows those same bytes really are two components.
+    #[cfg(unix)]
+    #[test]
+    fn a_backslash_in_a_walked_file_name_survives_as_itself() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let root = tmp.path();
+
+        let odd = root.join("tests").join(r"we\ird.rs");
+        std::fs::create_dir_all(odd.parent().expect("has a parent")).expect("mkdir tests");
+        std::fs::write(
+            &odd,
+            r#"
+                #[spec("walked/odd/001")]
+                #[test]
+                /// Scenario: a file whose name contains a backslash.
+                fn odd_001_backslash_name() { let _ = 3; }
+            "#,
+        )
+        .expect("write the odd-name fixture");
+
+        let map = collect_tests_on_disk(root).expect("the fixture tree must be walkable");
+        let recorded = &map["walked/odd/001"].file;
+        assert_eq!(recorded, r"tests/we\ird.rs");
+        assert_eq!(
+            std::fs::canonicalize(root.join(recorded)).expect("the recorded path must resolve"),
+            std::fs::canonicalize(&odd).expect("the walked path must resolve"),
+        );
     }
 }

--- a/xtask/linkage-check/src/main.rs
+++ b/xtask/linkage-check/src/main.rs
@@ -117,6 +117,11 @@ mod issue_labeler_policy;
 #[cfg(test)]
 mod junit_strip;
 mod list_tests;
+/// Issue #831: printing a walked path the way this repository writes
+/// paths. Shared by `desktop_palette` and `list_tests`, which both build a
+/// repo-relative string out of a directory walk and print it next to
+/// forward-slashed literals.
+mod paths;
 /// Issue #648: the toolchain pins duplicated between `devbox.json` and
 /// `.github/workflows/`. Tests only, and Unix only — the rule itself lives in
 /// `scripts/check-pin-lockstep.sh`, which CI's `devbox` job also runs directly.

--- a/xtask/linkage-check/src/paths.rs
+++ b/xtask/linkage-check/src/paths.rs
@@ -1,0 +1,98 @@
+//! Printing a path the way this repository writes paths.
+//!
+//! One helper, used by the two modules that build a **repo-relative** string
+//! out of a directory walk and then print it beside forward-slashed literals:
+//! `desktop_palette`'s findings and `list_tests`' inventory tables.
+//!
+//! The rule it encodes: *a walked path is safe to compare, and unsafe to
+//! stringify* (issue #831). Issue #831's survey found the crate's path
+//! *comparisons* already immune — they go through `Path`/`PathBuf`, which
+//! compares components — and found the crate's other `display()` sites
+//! unaffected, because they print **absolute** paths with no forward-slashed
+//! literal glued on, so their output is self-consistently native. What is left
+//! is the case here: the moment a walked path becomes a repo-relative `String`
+//! it carries the native separator into text that promises `/`.
+//!
+//! It arrived in `desktop_palette` (`25b39b5`), which is where the failure was
+//! first observed, and moved here when `list_tests` needed the same thing.
+
+use std::path::Path;
+
+/// A path as a report should print it: `/`-separated on every platform.
+///
+/// [`Path::display`] and [`std::ffi::OsStr::to_string_lossy`] emit the
+/// **native** separator, so on Windows a palette finding read
+/// `desktop/src/c\Tile.tsx` — the literal prefix forward-slashed and the walked
+/// tail back-slashed, which is not a path anything in this repository prints.
+/// That string is not just a test fixture: it is what a developer reads in a
+/// guard's failure message or in `cargo xtask list-tests`' inventory table, and
+/// what they paste or click. `git`, every CI log and every other path written
+/// here use `/`, so a Windows contributor and a Linux contributor debugging the
+/// same output have to see the same text.
+///
+/// Hence normalising here, where the path is built, rather than teaching each
+/// assertion to accept either separator — that would leave the tests asserting
+/// something weaker than the property that matters, and would leave the output
+/// platform-variant for no gain.
+///
+/// Walks components rather than replacing `\` blindly, because on Unix a
+/// backslash is a legal character **in a file name** and rewriting it would
+/// report a path that does not exist.
+pub(crate) fn slash_path(path: &Path) -> String {
+    let mut out = String::new();
+    for component in path.components() {
+        if component == std::path::Component::RootDir {
+            // The leading separator itself; `as_os_str` here is the native one.
+            if !out.ends_with('/') {
+                out.push('/');
+            }
+            continue;
+        }
+        if !out.is_empty() && !out.ends_with('/') {
+            out.push('/');
+        }
+        out.push_str(&component.as_os_str().to_string_lossy());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The Windows failure this helper exists for, pinned directly rather than
+    /// inferred from callers that happen to compare whole path strings.
+    ///
+    /// The joins matter: `Path::join` uses the **native** separator, so on
+    /// Windows these inputs really are `themes\styles.css` and `c\ui\Tile.tsx`,
+    /// and `display()` — what the palette guard used to call — returns them
+    /// with those backslashes intact. On Unix the assertion is true either way;
+    /// it is a tripwire for the platform where it can fail, which is the most a
+    /// Linux host can offer for a Windows-only path defect.
+    #[test]
+    fn a_printed_path_is_forward_slashed_whatever_the_native_separator_is() {
+        assert_eq!(
+            slash_path(&Path::new("themes").join("styles.css")),
+            "themes/styles.css"
+        );
+        assert_eq!(
+            slash_path(&Path::new("c").join("ui").join("Tile.tsx")),
+            "c/ui/Tile.tsx"
+        );
+        assert_eq!(slash_path(Path::new("styles.css")), "styles.css");
+        assert!(
+            !slash_path(&Path::new("a").join("b")).contains(std::path::MAIN_SEPARATOR)
+                || std::path::MAIN_SEPARATOR == '/'
+        );
+    }
+
+    /// And it is a component walk rather than a blind `\` → `/` replacement,
+    /// which this host *can* prove: on Unix a backslash is a legal character in
+    /// a file name, so rewriting one would report a path that does not exist.
+    #[cfg(unix)]
+    #[test]
+    fn a_backslash_inside_a_unix_file_name_is_not_a_separator() {
+        assert_eq!(slash_path(Path::new(r"a\b.tsx")), r"a\b.tsx");
+        assert_eq!(slash_path(Path::new("/abs/x.tsx")), "/abs/x.tsx");
+    }
+}


### PR DESCRIPTION
Closes #831.

## The instance

`list_tests.rs`' `rel_to_root` built the repo-relative path in `TestEntry.file` / `ModifiedRow.file` as `abs_path.strip_prefix(root)…to_string_lossy()` — a path straight out of `walk_rs_files`, stringified with the **native** separator. On Windows the `cargo xtask list-tests` inventory tables printed `tests\e2e_foo.rs`, against a field whose own doc comment promises `tests/e2e_hook_delivery.rs`, beside forward-slashed literals in the same table, and against the same field filled from `git ls-tree` on the base side — which is always forward-slashed. It is the identical construction that failed `build-windows` on #830.

It was cosmetic, and #831 explains exactly why: `file` is display-only (`compute_created` and `compute_modified` key on `spec_id` and compare only `scenario` and `body_fingerprint`, never `file`), and the one test asserting on the field feeds a synthetic `"src/tab.rs"` literal that is forward-slashed before it ever reaches the code — so no assertion on it can fail on any platform.

## The fix

`slash_path` — added for the palette guard in 25b39b5 — moves to a shared `xtask/linkage-check/src/paths.rs`, and `rel_to_root` normalises through it.

**Shared rather than duplicated.** No sibling module in this crate referenced another sibling before this — `main.rs` does reach into modules (`clean_tmp::MAX_PINNED_ORPHAN_CAP_SECS`, `list_tests::run`, `repo_state::run`), but module-to-module was new, so `paths` is the crate's first shared-helper module. That seemed the natural place for it; the alternative was two copies of a subtle function whose whole value is an 18-line rationale for *why* it is written the way it is. `desktop_palette` is `#[cfg(test)]`-only while `list_tests` is not, so `paths` is declared unconditionally and `slash_path` is `pub(crate)` — live in both configurations, no `dead_code` allow needed. The helper's two unit tests travel with it; the palette module's higher-level tests that assert on its *output* (`desktop/src/themes/styles.css`) stay put, so palette coverage is unchanged.

It walks `Path::components` and does **not** `replace('\\', "/")`, because on Unix a backslash is a legal character in a file name and rewriting it would report a path that does not exist.

## The test is the actual defect being closed

Both new tests build a real fixture tree in a `tempfile::tempdir()` and call `collect_tests_on_disk`, so the path under assertion came from `read_dir` and its separators are whatever the platform produced — not a forward-slashed literal handed in from the test.

- **`a_walked_path_is_recorded_with_forward_slashes`** — nested fixtures on both walks (`tests/nested/e2e_walked.rs`, `src/deep/nest/tab.rs`, so one separator and three). Asserts the exact forward-slashed spelling, that the string carries no `MAIN_SEPARATOR`, and that it still `canonicalize`s to the same file the walk found. The round-trip is the half that makes it a path rather than a shape.
- **`a_backslash_in_a_walked_file_name_survives_as_itself`** (Unix only) — pins the component walk against a **real directory entry** named `we\ird.rs`, which is stronger than the synthetic `Path` the `paths` unit test uses.

**What this Linux host actually proved, and what it cannot.** I substituted the `.replace('\\', "/")` shortcut into `slash_path` and both backslash tests went red — `tests/we/ird.rs` against `tests/we\ird.rs` for the walked one, `a/b.tsx` against `a\b.tsx` for the synthetic one. So the guard against that shortcut is demonstrated here, not asserted.

The forward-slashed half cannot be proved here, and #831 says why: the local gates are Linux-only and structurally cannot catch a Windows-only path regression in `xtask` code — on #830 the bug survived five clean local gate runs, `build`, and `build-macos`. **`build-windows` is the job that proves this PR**, being the only one of the three build jobs running native Windows path semantics. Worth noting it runs *bare* `cargo clippy -- -D warnings` (CLAUDE.md rule 2), so a Windows-only lint would not have shown up in my local four-flag run either.

I did run the repo's own `scripts/windows-cross-check.sh` locally (exit 0, only the pre-existing `clean_tmp` and unrelated-crate warnings), so the new code and its tests do *compile* for `x86_64-pc-windows-msvc` with `--all-targets` — which confirms the walked-path test is compiled rather than cfg'd out there, and that the Unix-only one is correctly excluded. But `cargo check` does not run anything, so it cannot execute a single assertion; the separator value only differs at run time. Two notes for anyone reproducing it: the script needs the `stable` rustup toolchain (the pinned devbox one ships no Windows std), and there is no wine on this box, so actually *running* the tests off-Windows was not available.

## Scope

Nothing else in the crate is normalised. #831's survey found no other live exposure — every path *comparison* there goes through `Path`/`PathBuf`, which compares components, and the remaining `display()` interpolations in `main.rs`, `clean_tmp.rs`, `repo_state.rs`, `junit_strip.rs`, `release_workflow_wiring.rs` and `issue_labeler_memory.rs` carry **absolute** paths with no forward-slashed literal glued on, so their output is self-consistently native. I read the survey and did not re-derive it; I have no evidence against it, so those sites are left alone rather than churned.

## Changelog fragment

`changelog.d/831.misc.md`, type **misc** ("Internal improvements, CI/CD, tooling, refactoring — users don't directly see it"). This changes the output of a contributor command, not anything a user runs, so it is not a `bugfix`; and the repo's own convention is that xtask fixes get a `misc` fragment rather than none — #834, #679, #568, #521 and #474 all did, including #834, which like this one was a test-only `xtask` correctness fix.

## Gates

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --features e2e,e2e-live -- -D warnings` — clean
- `cargo test-fast` — **2403 passed, 0 skipped**
- `cargo xtask linkage-check` — ok (626 catalog ids, 556 annotations, 100 allowlisted, 11 rules)
- `cargo xtask list-tests` — runs clean (no `#[spec]` test deltas in this branch; the new tests are crate-internal unit tests, not `#[spec]`-annotated, so rule 7 does not apply)

Named tests run: `list_tests::tests::a_walked_path_is_recorded_with_forward_slashes`, `list_tests::tests::a_backslash_in_a_walked_file_name_survives_as_itself`, `paths::tests::a_printed_path_is_forward_slashed_whatever_the_native_separator_is`, `paths::tests::a_backslash_inside_a_unix_file_name_is_not_a_separator`, plus the whole `list_tests::tests` module (12) and the whole `desktop_palette::tests` module (26, to confirm the move broke nothing).

I did not run the e2e tier: nothing here touches the daemon, protocol, orchestration, hooks or the TUI, and `xtask/linkage-check`'s tests are in the fast tier via `--workspace`. Note `e2e-deterministic` is red on `main` independently of this branch (#818 — the `orchestration_remit_*` family, PR #837, and repaint flakes, PR #872); it is not a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
