### PR TITLE
test: bot approval probe (DO NOT MERGE — will be closed)

### DIFF
--- a/.github/workflows/bot-approval-probe.yml
+++ b/.github/workflows/bot-approval-probe.yml
@@ -1,0 +1,24 @@
+# THROWAWAY probe using a real GitHub App identity.
+# Needs NO repo-setting change - the App has its own pull_requests:write.
+name: bot-approval-probe
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+permissions: {}
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v2
+        id: app
+        with:
+          app-id: ${{ secrets.REVIEW_APP_ID }}
+          private-key: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}
+      - name: Approve as the App
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr review "$PR" --repo "$REPO" --approve \
+            --body "Probe only: testing whether an App approval satisfies main-protected. Not a review."


### PR DESCRIPTION
Throwaway probe for the agent-reviewer design discussion.

Adds a workflow that exists only on this branch, so it runs only for this PR. It casts an approving review as the review App (App ID 4887378) so we can observe whether `reviewDecision` flips `REVIEW_REQUIRED` -> `APPROVED` — i.e. whether a GitHub App installation's approval satisfies the `main-protected` ruleset's required approval.

Draft deliberately, to avoid CODEOWNERS routing. CI runs will be cancelled; they are not part of the test. This PR will be closed and the branch deleted once the result is recorded.