### PR TITLE
fix(prompt): a start that announces no conversation cannot lose one (#684, #1003)

### DIFF
--- a/changelog.d/684.bugfix.md
+++ b/changelog.d/684.bugfix.md
@@ -1,0 +1,9 @@
+## A Spawn-Time Prompt Is No Longer Discarded When the Agent Announces Itself
+
+Creating an agent with an opening prompt — a `[[modes]]` `seed_prompt`, the new-pane form's prompt, or an orchestration role's opening prompt — could report `Seed prompt not delivered (the agent's conversation changed); abandoned` and drop the prompt, leaving the pane healthy, idle and empty. The agent worked; it just never received what it was created to do.
+
+Nothing about the pane's conversation had actually changed. Two events exist purely to draw a pane's CARD before any conversation exists: the daemon's card-surfacing `SessionStart`, which it broadcasts to attached decks so a spawned pane appears immediately instead of at its first real hook, and the wrapper's boot-provenance `SessionStart` for a launcher-wrapped agent. Neither is a producer speaking for the pane — the card-surfacing one uses the pane id as its session id and carries no agent identity at all — but both established the pane's hook generation, so a prompt written before the agent announced itself bound one of them as the conversation it was entering. The agent's genuine `SessionStart` moments later was then a different conversation replacing that one, which reads as both a rollover and a closed conversation, and the delivery was abandoned on the safe side of a race it should never have been in.
+
+Such a start now draws its card without establishing a generation, so the pane simply has no conversation until a producer announces one, and the prompt is delivered into that genuine conversation when it arrives. This matches what the daemon-owned delivery paths — `dispatch`, the scheduler and issue-dispatch — already did, which is why they were never affected.
+
+Whether the bug fired was a race between the agent's startup and the deck's readiness buffer, so it grew more likely as agent startup got slower: a prompt lost this way had simply been written before the agent got around to announcing itself.

--- a/src/event.rs
+++ b/src/event.rs
@@ -509,6 +509,32 @@ pub const SESSION_START_ORIGIN_METADATA_KEY: &str = "session_start_origin";
 /// later.
 pub const WRAPPER_FORK_SESSION_START_ORIGIN: &str = "wrapper_fork";
 
+/// The [`SESSION_START_ORIGIN_METADATA_KEY`] value meaning "the DAEMON authored
+/// this `SessionStart` to draw a spawned pane's card, and no producer has spoken
+/// for this pane yet" (issue #684).
+///
+/// [`crate::spawn`]'s `surface_spawned_pane` broadcasts such an event straight
+/// onto the client fan-out so a spawned pane gets a card immediately instead of
+/// at its first real hook. It never passes through `daemon::ingest_event`, so the
+/// daemon's own `AppState` never applies it — only attached TUIs do. That is why
+/// the defect below appears in no daemon log.
+///
+/// It is a statement ABOUT a pane, not a producer speaking FOR one: its
+/// `session_id` IS the pane id and it carries no `agent_id`. Without this marker
+/// [`crate::state::AppState::apply_event`] read it as a conversation announcing
+/// itself, so a TUI-owned prompt bound the pane id as its generation and the
+/// agent's genuine `SessionStart` then read as a rollover — abandoning the prompt
+/// with "the agent's conversation changed" (`prompt/pane-input/033`).
+///
+/// MARKED rather than inferred from its shape. `session_id == pane_id` with no
+/// `agent_id` also describes a legacy untagged hook, and the permissive
+/// both-absent branch of `apply_event`'s reuse guard exists precisely to keep
+/// serving those — so inferring provenance from the shape would have taken the
+/// generation away from real conversations too. Producer-writable like every
+/// value on this key, and safe in the only direction it can be abused: a forged
+/// marker makes an event LOSE generation standing, never gain any.
+pub const CARD_SURFACE_SESSION_START_ORIGIN: &str = "daemon_card_surface";
+
 /// The [`SESSION_START_ORIGIN_METADATA_KEY`] value meaning "`dot-agent-deck wrap`
 /// watched the wrapped child take the inner PTY OUT OF COOKED MODE" (issue #243).
 ///
@@ -800,6 +826,19 @@ impl AgentEvent {
             .is_some_and(|origin| origin == WRAPPER_FORK_SESSION_START_ORIGIN)
     }
 
+    /// Issue #684: was this `SessionStart` authored by the DAEMON to draw a
+    /// spawned pane's card (see [`CARD_SURFACE_SESSION_START_ORIGIN`])?
+    ///
+    /// `false` for every event without the marker, which includes every event an
+    /// OLDER daemon relays — an old daemon's unmarked surface event therefore
+    /// behaves exactly as it does today rather than being silently reclassified,
+    /// and the fix this predicate gates needs both sides updated to take effect.
+    pub fn is_card_surface_session_start(&self) -> bool {
+        self.metadata
+            .get(SESSION_START_ORIGIN_METADATA_KEY)
+            .is_some_and(|origin| origin == CARD_SURFACE_SESSION_START_ORIGIN)
+    }
+
     /// Issue #770: does this event carry the daemon's ORPHANED-ROLE marker (see
     /// [`ORCHESTRATION_ORPHANED_METADATA_KEY`])? `false` for every event
     /// without it, which is every event an older daemon relays and every event
@@ -880,12 +919,17 @@ impl AgentEvent {
     /// Issue #424 D4: was this event SYNTHESIZED BY THE DAEMON rather than
     /// produced by the pane's agent?
     ///
-    /// The daemon emits identified events of its own through the same pipeline
-    /// real hook events take — [`EventType::ShellBusy`]/[`EventType::ShellIdle`]
-    /// from the shell-activity monitor (PRD #370/#386), and the delivery-notice
-    /// [`EventType::Error`] (issue #424). They carry the pane's registry
-    /// `agent_id` because that is how they land on the right card, and that is
-    /// exactly what made them indistinguishable from producer evidence to
+    /// The daemon emits events of its own through the same pipeline real hook
+    /// events take: [`EventType::ShellBusy`]/[`EventType::ShellIdle`] from the
+    /// shell-activity monitor (PRD #370/#386), the delivery-notice
+    /// [`EventType::Error`] (issue #424), and the card-surfacing `SessionStart`
+    /// (issue #684, [`CARD_SURFACE_SESSION_START_ORIGIN`]).
+    ///
+    /// The first two carry the pane's registry `agent_id` because that is how
+    /// they land on the right card — the card-surfacing start is the exception and
+    /// carries none, since it RUNS BEFORE any producer has identified itself, so
+    /// it is recognized by its origin marker instead. Carrying that identity is
+    /// exactly what made the first two indistinguishable from producer evidence to
     /// `crate::ui::evidence_channel_is_unidentified`: one of them arriving was
     /// enough to conclude the pane has a tagged reporting channel, when it proves
     /// only that the DAEMON can tag its own events. A pane behind a legacy
@@ -901,6 +945,7 @@ impl AgentEvent {
     pub fn is_daemon_synthetic(&self) -> bool {
         matches!(self.event_type, EventType::ShellBusy | EventType::ShellIdle)
             || self.metadata.contains_key(DELIVERY_NOTICE_METADATA_KEY)
+            || self.is_card_surface_session_start()
     }
 }
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -2371,6 +2371,18 @@ fn surface_spawned_pane(
 ) {
     let mut metadata = HashMap::new();
     metadata.insert(DISPLAY_NAME_METADATA_KEY.to_string(), task_name.to_string());
+    // Issue #684: declare that the DAEMON authored this start to draw a card,
+    // rather than a producer announcing a conversation. `session_id` below is the
+    // PANE ID and there is no `agent_id`, so without the marker an attached TUI's
+    // `AppState` established the pane id as the pane's hook GENERATION — a
+    // TUI-owned seed or role prompt bound it, and the agent's genuine
+    // `SessionStart` then read as a rollover and abandoned the prompt with "the
+    // agent's conversation changed". See `CARD_SURFACE_SESSION_START_ORIGIN` and
+    // `prompt/pane-input/033`.
+    metadata.insert(
+        crate::event::SESSION_START_ORIGIN_METADATA_KEY.to_string(),
+        crate::event::CARD_SURFACE_SESSION_START_ORIGIN.to_string(),
+    );
     let event = AgentEvent {
         session_id: pane_id.to_string(),
         agent_type: agent_type
@@ -6087,6 +6099,25 @@ mod tests {
                 .map(String::as_str),
             Some("morning-digest"),
             "the friendly name must ride on the event so the live card titles itself with it"
+        );
+        // Issue #684: and it declares itself DAEMON-AUTHORED, so an attached
+        // TUI's `AppState` does not read it as a conversation announcing itself
+        // over this pane. Without the marker it established the pane's hook
+        // generation — the pane id, since that is this event's `session_id` — a
+        // TUI-owned seed or role prompt bound that as its delivery target, and
+        // the agent's genuine `SessionStart` moments later read as a rollover and
+        // discarded the prompt. Asserted on the PRODUCER because the behavioural
+        // test (`prompt/pane-input/033`) replays this event rather than calling
+        // this function, so nothing else would notice the marker going missing.
+        assert!(
+            e.is_card_surface_session_start(),
+            "the card-surfacing start must carry its origin marker; metadata={:?}",
+            e.metadata
+        );
+        assert!(
+            e.is_daemon_synthetic(),
+            "and must therefore fall in the daemon-authored class, which is what \
+             `AppState::apply_event` and the delivery paths discriminate on"
         );
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1156,6 +1156,14 @@ pub struct AppState {
     /// out-of-order / older-generation event is IGNORED so a delayed prior-event
     /// can neither restore a stale id nor clear a newer one, and a delayed
     /// prior-generation `SessionEnd` cannot wipe the current generation.
+    ///
+    /// Issue #684: an entry only ever exists because a producer ANNOUNCED a
+    /// conversation, or because an ordinary frame carrying a pane id arrived. A
+    /// `SessionStart` that announces nothing — the wrapper's boot provenance, the
+    /// daemon's card-surfacing start — draws its card without establishing one,
+    /// so "this pane has an entry" is not merely "something happened on this
+    /// pane". Consumers that bind this value as a delivery target depend on that:
+    /// see `provisional_start` in [`Self::apply_event`].
     pane_hook_session: HashMap<String, (String, DateTime<Utc>)>,
     /// Issue #424 F2 / H4 (auditor HIGH): how many times each pane's established
     /// hook generation has been CLOSED — ended, or superseded by a different one.
@@ -7482,9 +7490,16 @@ impl AppState {
         // that same value, so both then authorized a retry into a conversation
         // that is over while the agent is really in the successor. Boot
         // provenance is a statement that the real agent has not started yet: it
-        // may ESTABLISH a generation where the pane has none, and refresh the one
-        // it already names, but it is never authority to move a pane that already
-        // has a conversation — in either direction. That also strictly improves
+        // may refresh the generation it already names, but it is never authority
+        // to move a pane that already has a conversation — in either direction.
+        //
+        // Issue #684 removed the third permission this paragraph used to grant.
+        // Boot provenance may no longer ESTABLISH a generation on a pane that has
+        // none either: a TUI-owned delivery binds `pane_hook_session_id` before it
+        // writes, so a generation established by something that announced no
+        // conversation became the target the prompt claimed, and the real agent's
+        // announcement then read as that target being lost. See `provisional_start`
+        // below. That also strictly improves
         // #532: the wrapper's fork-time start can no longer take the generation
         // off the wrapped agent's native session.
         if let Some(ref pane_id) = event.pane_id {
@@ -7492,21 +7507,53 @@ impl AppState {
             // Issue #243: widened to EITHER wrapper origin. The reasoning above is
             // about wrapper provenance, not about the fork moment specifically —
             // an interface-ready event is still the wrapper talking about its own
-            // session id, so it may establish a generation where the pane has none
-            // and refresh the one it already names, but never move a pane that
-            // already has a conversation.
-            let launcher_origin_start =
-                event.event_type == EventType::SessionStart && event.is_wrapper_session_start();
+            // session id, so it may refresh the generation it already names, but
+            // never establish one (issue #684) and never move a pane that already
+            // has a conversation.
+            // Issue #684: a `SessionStart` that announces nothing is
+            // PROVISIONAL. Two producers emit one — the wrapper's boot-provenance
+            // start (PRD #225 M3) and the daemon's own card-surfacing start
+            // (`CARD_SURFACE_SESSION_START_ORIGIN`) — and both exist to draw a
+            // CARD before any conversation exists, not to speak for the pane.
+            //
+            // Widened from `launcher_origin_start`, which named only the wrapper
+            // half. The card-surfacing start carries no origin marker at all
+            // until this issue added one, so it fell through every exclusion here
+            // and was read as a conversation announcing itself; `is_daemon_synthetic`
+            // keeps any future daemon-authored start in the same class by default
+            // rather than needing to be listed here again.
+            let provisional_start = event.event_type == EventType::SessionStart
+                && (event.is_wrapper_session_start() || event.is_daemon_synthetic());
             let announces_generation =
-                event.event_type == EventType::SessionStart && !launcher_origin_start;
+                event.event_type == EventType::SessionStart && !provisional_start;
             let advance = match self.pane_hook_session.get(pane_id) {
-                None => true,
+                // Issue #684: a provisional start may not ESTABLISH a generation
+                // either, which is the half that was missing. Letting it do so
+                // was not merely cosmetic: a TUI-owned delivery binds
+                // `pane_hook_session_id` as its target before it writes, so the
+                // pane id (or the wrapper's own session) became the conversation
+                // the prompt claimed to be entering — and the agent's genuine
+                // announcement moments later was then a DIFFERENT generation
+                // replacing it, i.e. both a `note_generation_closed` below and a
+                // changed target in `crate::ui::delivery_target_changed`. The
+                // prompt was discarded with the pane healthy and idle
+                // (`prompt/pane-input/033`, which pins both provisional
+                // establishing events as cases of the one mechanism).
+                //
+                // Leaving the pane with NO generation until a producer announces
+                // one is what the daemon-side latch already does
+                // (`latch_generation` refuses to bind either wrapper origin), so
+                // this makes the map agree with the latch instead of introducing
+                // a second policy. Non-start frames are untouched and still
+                // establish on any pane id, so a producer whose native hooks emit
+                // no `SessionStart` at all is unaffected.
+                None => !provisional_start,
                 Some((current_id, current_ts)) => {
                     if *current_id == incoming_session_id {
                         // Same generation: keep the id, bump the established
                         // timestamp so subsequent older events stay rejected.
                         incoming_ts > *current_ts
-                    } else if launcher_origin_start {
+                    } else if provisional_start {
                         // Boot provenance never replaces a live conversation.
                         false
                     } else {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4643,6 +4643,7 @@ fn pane_announced_generation(snapshot: &AppState, pane_id: &str) -> Option<Strin
         // Issue #243: EITHER wrapper origin is excluded. Both carry the wrapper's
         // own session id rather than the agent's, so neither is a conversation
         // announcing itself over this pane.
+        //
         .filter(|event| {
             event.event_type == EventType::SessionStart && !event.is_wrapper_session_start()
         })
@@ -36754,6 +36755,149 @@ mod tests {
             lost_seed_records.len() == 1 && lost_role_records.len() == 1,
             "a physically applied write whose response was lost must retain its pre-RPC closure baseline on both TUI paths and never write the old task into a successor; seed_writes={lost_seed_records:?}, orchestrator_writes={lost_role_records:?}"
         );
+    }
+
+    /// Scenario: Spawn a pane whose card is drawn by a start that announces no
+    /// conversation — the daemon's own card-surfacing `SessionStart`, and a
+    /// wrapper's boot-provenance start — then deliver a TUI-owned seed into it
+    /// before the real agent has announced itself. When the agent's genuine
+    /// `SessionStart` arrives, the seed must still be delivered into that
+    /// generation rather than abandoned as "the agent's conversation changed".
+    #[spec("prompt/pane-input/033")]
+    #[test]
+    fn pane_input_033_a_provisional_start_is_not_a_conversation_to_lose() {
+        const PROMPT: &str = "Read the dispatch seed and begin";
+
+        // Both establishing events, replayed as their producers emit them. They
+        // differ only in provenance: `session_id` is the PANE ID for the daemon's
+        // card surface and the WRAPPER'S OWN session for the launcher, and
+        // neither carries an `agent_id`, because both run before any producer has
+        // identified itself.
+        //
+        // The card-surfacing case is the one measured in the field (issue #684's
+        // follow-up): `spawn::surface_spawned_pane` broadcasts it straight to
+        // attached clients and never applies it to the daemon's own `AppState`,
+        // which is why the abandoned deliveries it caused appear in no daemon log.
+        // The wrapper case is the trigger #684 was filed for. One mechanism, two
+        // inputs, so they are cases of one test rather than two tests.
+        let cases: [(&str, &str, &str); 2] = [
+            (
+                "daemon card surface",
+                "surfaced-card-pane",
+                crate::event::CARD_SURFACE_SESSION_START_ORIGIN,
+            ),
+            (
+                "wrapper boot provenance",
+                "wrapper-fork-pane",
+                crate::event::WRAPPER_FORK_SESSION_START_ORIGIN,
+            ),
+        ];
+
+        for (case, pane_id, origin) in cases {
+            let agent_id = format!("{pane_id}-agent");
+            let controller = Arc::new(RecordingPaneController::default());
+            let writes = controller.writes.clone();
+            let pane: Arc<dyn PaneController> = controller;
+            let mut ui = default_ui();
+            ui.pending_seed_prompts
+                .push(ready_seed_prompt(pane_id, PROMPT));
+            let mut snapshot = ready_prompt_snapshot(pane_id, &agent_id);
+
+            let mut metadata = std::collections::HashMap::new();
+            metadata.insert(
+                crate::event::DISPLAY_NAME_METADATA_KEY.to_string(),
+                "dispatcher".to_string(),
+            );
+            metadata.insert(
+                crate::event::SESSION_START_ORIGIN_METADATA_KEY.to_string(),
+                origin.to_string(),
+            );
+            // The card-surfacing start uses the pane id as its session id; the
+            // wrapper uses its own. Neither is a conversation.
+            let provisional_session_id =
+                if origin == crate::event::CARD_SURFACE_SESSION_START_ORIGIN {
+                    pane_id.to_string()
+                } else {
+                    format!("{pane_id}-wrapper-session")
+                };
+            snapshot.apply_event(AgentEvent {
+                session_id: provisional_session_id,
+                agent_type: AgentType::ClaudeCode,
+                event_type: EventType::SessionStart,
+                tool_name: None,
+                tool_detail: None,
+                cwd: None,
+                timestamp: Utc::now(),
+                user_prompt: None,
+                metadata,
+                pane_id: Some(pane_id.into()),
+                agent_id: None,
+                agent_version: None,
+                schema_version: None,
+                live_target: None,
+            });
+            assert_eq!(
+                snapshot.pane_hook_session_id(pane_id),
+                None,
+                "{case}: a start that announces nothing must not establish the \
+                 pane's generation — binding it is what a TUI delivery then loses"
+            );
+
+            // The seed is written while that card is all there is. This is the
+            // ordinary case whenever the agent takes longer to announce itself
+            // than the readiness buffer takes to elapse, which is exactly what a
+            // launcher (`devbox run claude …`) and a slow-booting Claude Code do.
+            process_pending_seed_prompts(&mut ui, &pane, &snapshot);
+            assert_eq!(
+                writes.lock().unwrap().len(),
+                1,
+                "{case}: precondition — the seed reaches the pane before the agent \
+                 announces itself"
+            );
+
+            // The real agent finally announces itself.
+            let genuine = format!("{pane_id}-genuine-generation");
+            apply_generation_event(
+                &mut snapshot,
+                pane_id,
+                &agent_id,
+                &genuine,
+                EventType::SessionStart,
+            );
+
+            ui.send_retry_backoff
+                .get_mut(pane_id)
+                .expect("an unconfirmed write arms retry")
+                .next_attempt_at = std::time::Instant::now();
+            process_pending_seed_prompts(&mut ui, &pane, &snapshot);
+
+            let records = writes.lock().unwrap().clone();
+            assert!(
+                ui.prompt_delivery.contains_key(pane_id),
+                "{case}: the delivery must survive the agent announcing itself — a \
+                 card drawn before any conversation existed is not a conversation \
+                 this prompt could have been lost from. status={:?}",
+                ui.status_message
+            );
+            assert_eq!(
+                records.len(),
+                2,
+                "{case}: the seed must be delivered into the genuine generation; \
+                 writes={records:?}"
+            );
+            assert_eq!(
+                records[1].1.as_deref(),
+                Some(genuine.as_str()),
+                "{case}: the retry must declare the conversation it is entering"
+            );
+            assert_eq!(
+                snapshot.pane_generation_closures(pane_id),
+                0,
+                "{case}: no conversation ended on this pane, so nothing may be \
+                 counted as closed — the closure counter is the other half of the \
+                 target check and abandons the delivery on its own"
+            );
+        }
     }
 
     /// Scenario: Write a seed to a target with no usable prompt-reporting channel, then supply daemon-synthetic evidence beside an untagged legacy hook. Those events must not arm a second physical write into a target that cannot actually confirm submission.

--- a/tests/CATALOG.md
+++ b/tests/CATALOG.md
@@ -1168,6 +1168,13 @@ Demo-reel eligibility marker: a trailing ` [reel]` on an entry's `##### <id> —
 - **Does not assert:** the fix's internal clock-comparison location or the detached spawn watcher (covered by `scheduler/dispatch/018`).
 - **Platform coverage:** mac+linux.
 
+##### prompt/pane-input/033 — A start that announces no conversation does not become one a TUI-owned prompt can be lost from.
+- **Layer:** L1 (in-process seed consumer driving `AppState::apply_event` and the production `process_pending_seed_prompts`, over a recording pane controller).
+- **Agent:** none (synthetic ClaudeCode generations).
+- **Asserts:** for BOTH provisional establishing events — the daemon's card-surfacing `SessionStart` (`CARD_SURFACE_SESSION_START_ORIGIN`, whose `session_id` is the pane id) and a wrapper's boot-provenance `SessionStart` — the pane's hook generation stays unestablished; a seed written while that card is all there is survives the agent's genuine `SessionStart`; the retry is delivered naming that genuine generation; and the pane's generation-closure count stays 0, since the closure counter abandons the delivery on its own even when the bound id happens to match.
+- **Does not assert:** that `spawn::surface_spawned_pane` stamps the marker (this test replays the event rather than calling it — pinned by `surface_spawned_pane_emits_session_start_for_attached_tuis` in `src/spawn.rs`); the #532 residual, where a second producer's NON-announcing frames move the generation; or the daemon-owned delivery paths, which route through `latch_generation` and were never affected.
+- **Platform coverage:** mac+linux.
+
 #### prompt/quit
 
 ##### prompt/quit/001 — `Ctrl+c` from command mode opens the quit confirmation dialog with three options: **Detach** (default), **Stop**, **Cancel**.


### PR DESCRIPTION
## The report

> I'm getting "Seed prompt not delivered..." when I try to create dispatcher agent … I'm getting the same when I try to spin up an orchestration. That feels like a recent change that might have messed it up.

Creating an agent with an opening prompt discarded that prompt and left the pane healthy, idle and with nothing to do. Both TUI-owned delivery paths: `ui::process_pending_seed_prompts` (a `[[modes]]` `seed_prompt` and the new-pane form's prompt) and `ui::deliver_orchestrator_prompt`.

It was **not** a recent change — the deck binary was built five days before the first failure. It is a **race** that agent startup getting slower flipped from usually-winning to always-losing.

## Cause

Two events exist only to draw a pane's **card** before any conversation exists: the daemon's card-surfacing `SessionStart` (`spawn::surface_spawned_pane`) and the wrapper's boot-provenance start (PRD #225 M3). Both **established** the pane's hook generation.

A TUI-owned delivery binds `pane_hook_session_id` as its target *before* it writes, so the prompt claimed a conversation nothing had announced. The agent's genuine `SessionStart` moments later was a different generation replacing that one — which is simultaneously a `note_generation_closed` and a changed target in `ui::delivery_target_changed`. Either one alone abandons the delivery.

The daemon-owned paths (`dispatch`, scheduler, issue-dispatch) were never affected, because `state::latch_generation` already refuses to bind either wrapper origin and permits exactly one handoff.

## Fix

A `SessionStart` that announces no conversation may draw its card but may not **establish** a generation. The pane then simply has no conversation until a producer announces one, and the prompt is delivered into that genuine conversation when it arrives — the path `prompt/pane-input/030` already pinned. This makes the generation map agree with the daemon-side latch instead of adding a second policy.

Non-start frames are untouched and still establish on any pane id, so a producer whose native hooks emit no `SessionStart` at all is unaffected.

## Why #684's diagnosis would have missed it

#684 attributes the class to the wrapper-fork start alone. Your failures had **no wrapper in the chain** (`devbox run` → plain `claude`). The card-surfacing start is the second establishing event, filed as #1003, and it carried **no origin marker at all**, so every `is_wrapper_session_start()` exclusion in the delivery path missed it. It is now marked (`CARD_SURFACE_SESSION_START_ORIGIN`) and recognized by declared provenance rather than inferred from its shape — `session_id == pane_id` with no `agent_id` also describes a legacy untagged hook, and inferring would have taken the generation away from real conversations.

It is also invisible in `deck.log`: that event is broadcast straight to attached clients and never passes through `daemon::ingest_event`, so the daemon never logs it. Pane 10 below received **exactly one** event before the abandon.

## Evidence

Five consecutive failures, each abandoned 530–540 ms after the genuine `SessionStart` — one render pass later:

```
12:55:41.372  SessionStart pane_id=8   1cbf38a0-…
12:55:41.902  WARN … path="seed" pane_id="8"  reason="delivery-target-changed"
12:57:06.179  SessionStart pane_id=10  e4d9355d-…
12:57:06.717  WARN … path="seed" pane_id="10" reason="delivery-target-changed"
12:57:57.725  SessionStart pane_id=11  b2244167-…
12:57:58.266  WARN … path="orchestrator" pane_id="11" reason="delivery-target-changed"
```

The same log shows the race both ways 17 seconds apart on 2026-09-08 (`18:09:33` abandoned, `18:09:50` confirmed), then every TUI-owned delivery after `2026-09-09T00:56` failing, with the binary unchanged since 2026-09-05. `path="spawn"` deliveries were confirmed throughout.

## Tests

- **`prompt/pane-input/033`** (new, L1) drives the production seed path through **both** provisional establishing events and pins that the delivery survives the agent announcing itself, that the retry is delivered naming the genuine generation, and that the pane's generation-closure count stays 0 — the closure counter abandons the delivery on its own, so asserting only the bound id would have half-tested it. One mechanism, two inputs, so they are cases of one test rather than two near-duplicate tests.
- **`surface_spawned_pane_emits_session_start_for_attached_tuis`** (extended) pins the marker on the **producer**, because the behavioural test replays that event rather than calling the function — nothing else would have noticed the marker going missing.
- Reproduction came first and failed with the reporter's verbatim message. Both halves of the fix were then verified **load-bearing** by reverting each in turn (the core `None => !provisional_start`, and widening the predicate past the wrapper-only case). A third candidate change — excluding daemon-authored starts in `ui::pane_announced_generation` — left the test green, so it was **reverted rather than kept as dead defence**; the map-side fix subsumes it, and the residual it would have guarded is #532's non-announcing-frame shape.

## Gates

- `cargo test-fast`: 2558/2558.
- `cargo clippy --workspace --all-targets --features e2e,e2e-live -- -D warnings`: clean. `cargo fmt --check`: clean.
- Covering lane-1 e2e: `e2e_scheduler_spawn`, `e2e_scheduler_live_surface`, `e2e_orchestrator_setup` — 17/17. Includes `live_004_real_hook_supersession_keeps_friendly_title`, which is exactly the card-surface→real-hook handover this changes, so the card title still survives it.
- Cross-version contract check (rule 12) and a real-agent lane-2 run are reported in a comment below.

## Contract

No `PROTOCOL_VERSION` bump and no `.breaking.md`. This adds a fourth value to the existing `session_start_origin` metadata key, documented as additive in both directions; an old consumer matches none of the wrapper values and behaves exactly as it does today. Old and new builds interoperate unchanged — the fix simply requires both sides updated to take effect, which is stated on the predicate.

Closes #684
Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)
