### PR TITLE
test(e2e): wait for [Submit] in the three lane-2 shell-activity tests (#873)

### DIFF
--- a/changelog.d/873.misc.md
+++ b/changelog.d/873.misc.md
@@ -1,0 +1,5 @@
+## The lane-2 real-agent e2e tests stop racing the repaint too
+
+[#807](https://github.com/vfarcic/dot-agent-deck/issues/807) migrated 39 single-shot `find_in_grid` lookups to `TuiDeck::wait_for_in_grid`, but left three behind in `tests/e2e_shell_activity_real_agent.rs` — not because they were a different shape, but because another branch was editing that file at the time. They are the same shape, and in one respect a worse instance of it: each waits for the new-agent form's *title* and then locates `[Submit]`, a different string that the form paints in a second pass, and each sends several more keystrokes between that wait and the lookup — so nothing at all has been proved about the frame the single-shot read lands on.
+
+All three now use `wait_for_in_grid`, which re-reads the grid until the button appears and dumps the final frame on timeout. No harness change was needed. The file is lane 2 (`e2e-live`), so nothing in CI runs it and the fix was verified by running `cargo test-e2e-live shell_activity` against a real Claude credential.

--- a/tests/e2e_shell_activity_real_agent.rs
+++ b/tests/e2e_shell_activity_real_agent.rs
@@ -157,9 +157,7 @@ fn shell_activity_005_real_claude_bash_child_trips_the_descendant_scan() {
     deck.send_keys(PANE_NAME_SUFFIX.as_bytes());
     deck.send_keys(b"\t");
     deck.send_keys(format!("claude --model {HAIKU_MODEL} --allowedTools Bash").as_bytes());
-    let (submit_col, submit_row) = deck
-        .find_in_grid("[Submit]")
-        .expect("new-pane form should render [Submit]");
+    let (submit_col, submit_row) = deck.wait_for_in_grid("[Submit]");
     deck.click(submit_col, submit_row);
 
     assert!(
@@ -321,9 +319,7 @@ fn shell_activity_006_real_claude_bash_call_crossing_the_cap_keeps_the_badge_wor
     deck.send_keys(PANE_NAME_SUFFIX_006.as_bytes());
     deck.send_keys(b"\t");
     deck.send_keys(format!("claude --model {HAIKU_MODEL} --allowedTools Bash").as_bytes());
-    let (submit_col, submit_row) = deck
-        .find_in_grid("[Submit]")
-        .expect("new-pane form should render [Submit]");
+    let (submit_col, submit_row) = deck.wait_for_in_grid("[Submit]");
     deck.click(submit_col, submit_row);
 
     assert!(
@@ -557,9 +553,7 @@ fn shell_activity_007_real_claude_idle_with_live_mcp_servers_stays_idle() {
     deck.send_keys(PANE_NAME_SUFFIX_007.as_bytes());
     deck.send_keys(b"\t");
     deck.send_keys(format!("claude --model {HAIKU_MODEL} --allowedTools Bash").as_bytes());
-    let (submit_col, submit_row) = deck
-        .find_in_grid("[Submit]")
-        .expect("new-pane form should render [Submit]");
+    let (submit_col, submit_row) = deck.wait_for_in_grid("[Submit]");
     deck.click(submit_col, submit_row);
 
     assert!(


### PR DESCRIPTION
Closes #873. Follow-up to #807 / #395, which PR #872 closed.

## What

PR #872 classified all 52 panic-on-miss `find_in_grid` sites across 21 `tests/e2e_*.rs` files and migrated the 39 racy ones to `TuiDeck::wait_for_in_grid`. Three were left out **only because of an edit collision** — the `issue-862` agent was editing `tests/e2e_shell_activity_real_agent.rs` at the time and had no PR to merge against — not because they are a different shape.

This migrates those three. One line each:

```rust
let (submit_col, submit_row) = deck.wait_for_in_grid("[Submit]");
```

replacing the three-line `find_in_grid("[Submit]").expect(..)`.

## Why they are racy

Each waits on the new-agent form's **title** (`wait_for_string("New Agent")`) and then locates `[Submit]` — a *different* string, which the form paints in a second pass, so the title can be on screen while the button is not. That is exactly the discriminator recorded on `wait_for_in_grid`'s doc comment.

They are a worse instance than the lane-1 cases already migrated: each also sends four more keystrokes (Tab, pane name, Tab, the `claude --model …` command) *after* the last wait and before the lookup, so nothing at all has been proved about the frame the single-shot read lands on.

## Scope

**No harness change.** #872 already landed the helper, the split-out `grid_find` / `poll_grid_for`, and their unit tests. `tests/common/mod.rs` is untouched. The three tests' `#[spec]` ids, Scenario comments and assertions are unchanged — this alters only *when* the coordinates are read, never what is asserted.

No panic-on-miss `find_in_grid` site remains anywhere under `tests/` after this.

## Verification

This file is lane 2 (`#![cfg(all(feature = "e2e", feature = "e2e-live", unix))]`), so **nothing in CI runs it** — rule 2's clippy gate type-checks it and that is all. Run locally against a real Claude credential:

```
DOT_AGENT_DECK_REQUIRE_REAL_E2E=1 cargo test-e2e-live shell_activity
→ 16 tests run: 16 passed (1 slow), 2998 skipped
```

`DOT_AGENT_DECK_REQUIRE_REAL_E2E=1` is what makes that a real result: without it an unmet preflight prints `SKIP:` and returns normally, which nextest counts as passed. The three migrated tests all genuinely executed:

- `shell_activity_005_real_claude_bash_child_trips_the_descendant_scan` — 28.6s
- `shell_activity_006_real_claude_bash_call_crossing_the_cap_keeps_the_badge_working` — 129.9s
- `shell_activity_007_real_claude_idle_with_live_mcp_servers_stays_idle` — 7.1s

Other gates:

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --features e2e,e2e-live -- -D warnings` — clean
- `cargo test-fast` — 2749 passed, 0 skipped

Lane 1 is left to CI's `e2e-deterministic` job per rule 5; it was not run in full locally.

Changelog fragment: `changelog.d/873.misc.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)